### PR TITLE
productionDeploy: workflow_dispatch trigger.

### DIFF
--- a/.github/workflows/productionDeploy.yml
+++ b/.github/workflows/productionDeploy.yml
@@ -31,12 +31,13 @@ jobs:
       name: Print name
       run: echo "version=${{ env.version }}"  >> $GITHUB_OUTPUT
     
-    - name: Deploy to production S3
-      run: "aws s3 cp s3://nr-downloads-main/ios-v5/NewRelic_XCFramework_Agent_${{ env.version }}.zip s3://nr-downloads-main/ios_agent/"
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+    ## COMMENTED FOR THE DRY RUN 
+    # - name: Deploy to production S3
+    #   run: "aws s3 cp s3://nr-downloads-main/ios-v5/NewRelic_XCFramework_Agent_${{ env.version }}.zip s3://nr-downloads-main/ios_agent/"
+    #   env:
+    #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
   
   # The deployProductionSpecs job creates the prod Podspec and Prod Package.swift from template and pushes to cp trunk.
   deployProductionSpecs:
@@ -66,7 +67,10 @@ jobs:
         rm NewRelicAgent.podspec-e
         rm NewRelicAgent.podspecbak
         
+        # added for dry run
         cat NewRelicAgent.podspec
+        # added for dry run
+        pod trunk me
 
         # COMMENTED FOR DRY RUN
         # pod trunk push --allow-warnings NewRelicAgent.podspec
@@ -92,13 +96,16 @@ jobs:
 
         rm $XCFRAMEWORK_NAME
 
+        # added for dry run
         cat Package.swift
 
         # COMMENTED FOR DRY RUN
         # # The following git cmd adds remote https://github.com/newrelic/newrelic-ios-agent-spm.
         # # The subsequent git commands push the Package.swift up to that repo. URL is prepended with GHA PAT.
-        # git remote add origin ${{ secrets.PROD_SPM_URL }}
-        # git remote -v
+
+        git remote add origin ${{ secrets.PROD_SPM_URL }}
+        git remote -v
+
         # git add Package.swift
         # git commit -m "Added build ${{ env.version }}"
         # git tag ${{ env.version }}


### PR DESCRIPTION
We'll need to do a develop -> main merge soon. 

This productionDeployment manually invoked workflow will show up once its merged to the main branch.
This prod deploy job will only be invoked manually and shouldn't be invoked until we have an RC we are happy with in the staging downloads folder.  There should be no version suffix. ex: ( https://download.newrelic.com/ios-v5/NewRelic_XCFramework_Agent_7.4.0.zip  becomes https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.4.0.zip)