### PR TITLE
no merge: ~Payload() fix: add networkfacade retrievedPayload safety when traceHeaders set

### DIFF
--- a/Tests/Unit-Tests/NewRelicAgentTests/API-Tests/APINetworkNoticeTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/API-Tests/APINetworkNoticeTest.m
@@ -13,6 +13,10 @@
 #import "NRMATaskQueue.h"
 #import "NRMANetworkFacade.h"
 #import "NewRelicAgentInternal.h"
+#import "NRMAHarvestController.h"
+#import "NRMAAppToken.h"
+#import "NRTestConstants.h"
+
 @interface NRMATaskQueue ()
 + (NRMATaskQueue*) taskQueue;
 - (void) dequeue;
@@ -29,6 +33,12 @@
 - (void)setUp
 {
     [super setUp];
+
+    NRMAAgentConfiguration *config = [[NRMAAgentConfiguration alloc] initWithAppToken:[[NRMAAppToken alloc] initWithApplicationToken:kNRMA_ENABLED_STAGING_APP_TOKEN]
+                                                  collectorAddress:KNRMA_TEST_COLLECTOR_HOST
+                                                      crashAddress:nil];
+    [NRMAHarvestController initialize:config];
+
     helper = [[NRMAMeasurementConsumerHelper alloc] initWithType:NRMAMT_HTTPTransaction];
     [NRMAMeasurements initializeMeasurements];
     [NRMAMeasurements addMeasurementConsumer:helper];
@@ -138,6 +148,35 @@
     XCTAssertEqual((long long)result.endTime,(long long) 10000,@"Result end time did not match expected end time.");
     XCTAssertEqual(result.totalTime, 4000);
     XCTAssertEqual(result.statusCode, 0, @"Result status code did not match expected status code.");
+}
+
+- (void) testNoticeNetworkRequestWithTraceHeaders
+{
+    double startTime = 6000;
+    double endTime = 10000;
+    NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"google.com"]];
+    NSHTTPURLResponse* response = [[NSHTTPURLResponse alloc] initWithURL:request.URL
+                                                              statusCode:200
+                                                             HTTPVersion:nil
+                                                            headerFields:nil];
+    [NRMANetworkFacade noticeNetworkRequest:request
+                                   response:response
+                                  withTimer:[[NRTimer alloc] initWithStartTime:startTime andEndTime:endTime]
+                                  bytesSent:0
+                              bytesReceived:0
+                               responseData:nil
+                               traceHeaders:@{@"traceparent":@"parent-awesomeid-verycool"}
+                                     params:nil];
+
+    while(CFRunLoopGetCurrent() && !helper.result) {}
+
+    NRMAHTTPTransactionMeasurement* result = (NRMAHTTPTransactionMeasurement*)helper.result;
+
+    XCTAssertEqualObjects(result.url, @"google.com", @"Result url does not match recorded url.");
+    XCTAssertEqual(result.startTime, (double) 6000, @"Result start time did not match expected start time.");
+    XCTAssertEqual((long long)result.endTime,(long long) 10000,@"Result end time did not match expected end time.");
+    XCTAssertEqual(result.totalTime, 4000);
+    XCTAssertEqual(result.statusCode, 200, @"Result status code did not match expected status code.");
 }
 
 @end


### PR DESCRIPTION
This doesn't just set stuff up better, it also fixes a crash when traceParent headers are set but applicationId / contextId aren’t. This can be tested by adding the  testNoticeNetworkRequestWithTraceHeaders test to the tests and you will see the crash.

<img width="1071" alt="Screenshot 2023-03-29 at 12 13 45 PM" src="https://user-images.githubusercontent.com/103527346/228630629-9725e440-bc21-44e4-a38b-fa419b173727.png">


