### PR TITLE
Moved the apiKey and collectorAddress plist getters to another file

### DIFF
--- a/Test Harness/NRTestApp/NRTestApp/AppDelegate.swift
+++ b/Test Harness/NRTestApp/NRTestApp/AppDelegate.swift
@@ -14,7 +14,6 @@ import NewRelic
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
 #if DEBUG
         // The New Relic agent is set to log at NRLogLevelInfo by default, verbose logging should only be used for debugging.
         NRLogger.setLogLevels(NRLogLevelVerbose.rawValue)
@@ -30,12 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 #if Enable_SWIFT_INTERACTION_TRACING
         NewRelic.enableFeatures(NRMAFeatureFlags.NRFeatureFlag_SwiftInteractionTracing)
 #endif
-        // Generate your own api key to see data get sent to your app's New Relic web services. Also be sure to put your key in the `Run New Relic dSYM Upload Tool` build phase.
-        guard let apiKey = plistHelper.objectFor(key: "NRAPIKey", plist: "NRAPI-Info") as? String else {return true}
-        
-        // Changing the collector and crash collector addresses is not necessary to use New Relic production servers.
-        guard let collectorAddress = plistHelper.objectFor(key: "collectorAddress", plist: "NRAPI-Info") as? String, let crashCollectorAddress = plistHelper.objectFor(key: "crashCollectorAddress", plist: "NRAPI-Info") as? String else { return true }
-       
+               
         // If the entries for collectorAddress or crashCollectorAddress are empty in NRAPI-Info.plist, start the New Relic agent with default production endpoints.
         if collectorAddress.isEmpty || crashCollectorAddress.isEmpty {
             // Start the agent using default endpoints.
@@ -46,10 +40,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                            andCollectorAddress: collectorAddress,
                            andCrashCollectorAddress: crashCollectorAddress)
         }
-
-        // These must be called after NewRelic.start(withApplicationToken:)
-        NewRelic.setMaxEventPoolSize(5000)
-        NewRelic.setMaxEventBufferTime(60)
         
         return true
     }

--- a/Test Harness/NRTestApp/NRTestApp/Helpers/plistHelper.swift
+++ b/Test Harness/NRTestApp/NRTestApp/Helpers/plistHelper.swift
@@ -7,6 +7,26 @@
 
 import Foundation
 
+// Generate your own api key to see data get sent to your app's New Relic web services. Also be sure to put your key in the `Run New Relic dSYM Upload Tool` build phase.
+var apiKey: String! {
+    get {
+        return plistHelper.objectFor(key: "NRAPIKey", plist: "NRAPI-Info") as? String
+    }
+}
+
+// Changing the collector and crash collector addresses is not necessary to use New Relic production servers.
+var collectorAddress: String! {
+    get {
+        return plistHelper.objectFor(key: "collectorAddress", plist: "NRAPI-Info") as? String
+    }
+}
+
+var crashCollectorAddress: String! {
+    get {
+        return plistHelper.objectFor(key: "crashCollectorAddress", plist: "NRAPI-Info") as? String
+    }
+}
+
 class plistHelper {
     
     static func objectFor(key: String, plist: String) -> Any? {


### PR DESCRIPTION
I moved the plist helper info to simplify the apiKey and collector addresses stuff that was cluttering the AppDelegate.