### PR TITLE
fix xcode15 urlsession warn

### DIFF
--- a/Agent/Harvester/NRMAHarvesterConnection.m
+++ b/Agent/Harvester/NRMAHarvesterConnection.m
@@ -72,8 +72,12 @@
     NRLOG_VERBOSE(@"NEWRELIC - REQUEST: %@", post);
     NRLOG_VERBOSE(@"NEWRELIC - REQUEST BODY: %@", post.HTTPBody);
 
-    [[self.harvestSession uploadTaskWithRequest:post
-                                       fromData:post.HTTPBody
+    NSData *initialReqBody = [post.HTTPBody copy];
+    NSMutableURLRequest *modifiedRequest = [post mutableCopy];
+    [modifiedRequest setHTTPBody:nil];
+
+    [[self.harvestSession uploadTaskWithRequest:modifiedRequest
+                                       fromData:initialReqBody
                               completionHandler:^(NSData* responseBody, NSURLResponse* bresponse, NSError* berror){
         @autoreleasepool {
             data = responseBody;


### PR DESCRIPTION
Change upload Task in Hex uploader and HarvesterConnection to not pass HTTPBody data directly when creating task. Fixes  following error in Xcode 15.

```
The request of a upload task should not contain a body or a body stream, use `upload(for:fromFile:)`, `upload(for:from:)`, or supply the body stream through the `urlSession(_:needNewBodyStreamForTask:)` delegate method.
```