### PR TITLE
Added a way to detect wifi versus ethernet connectivity on tvos

### DIFF
--- a/Agent.xcodeproj/project.pbxproj
+++ b/Agent.xcodeproj/project.pbxproj
@@ -1003,6 +1003,8 @@
 		F824A43129AEAD63000886A6 /* NRViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F824A43029AEAD63000886A6 /* NRViewModifier.swift */; };
 		F824A43229AEAD63000886A6 /* NRViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F824A43029AEAD63000886A6 /* NRViewModifier.swift */; };
 		F825FAE329C8F52800E1C1DC /* NRMAWKFakeNavigationAction.m in Sources */ = {isa = PBXBuildFile; fileRef = F825FAE229C8F52800E1C1DC /* NRMAWKFakeNavigationAction.m */; };
+		F8728E412ACC9D5A0056F641 /* NRMANetworkMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = F8728E402ACC9D5A0056F641 /* NRMANetworkMonitor.m */; };
+		F8728E422ACC9D5A0056F641 /* NRMANetworkMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = F8728E402ACC9D5A0056F641 /* NRMANetworkMonitor.m */; };
 		F87954D529E89D5F00319FCD /* NRMAWKWebViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209ABB324E704A600E45C90 /* NRMAWKWebViewTests.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		F88C2CF72A2FA7AC00373EFE /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = F88C2CE32A2FA7AC00373EFE /* PrivacyInfo.xcprivacy */; };
 		F8AC3E932938FD6C002B4AA8 /* NRMAFakeDataHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AC3E922938FD6C002B4AA8 /* NRMAFakeDataHelper.m */; };
@@ -1886,6 +1888,8 @@
 		F824A43029AEAD63000886A6 /* NRViewModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NRViewModifier.swift; sourceTree = "<group>"; };
 		F825FAE229C8F52800E1C1DC /* NRMAWKFakeNavigationAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRMAWKFakeNavigationAction.m; sourceTree = "<group>"; };
 		F825FAF729C8F5BA00E1C1DC /* NRMAWKFakeNavigationAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NRMAWKFakeNavigationAction.h; sourceTree = "<group>"; };
+		F8728E402ACC9D5A0056F641 /* NRMANetworkMonitor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRMANetworkMonitor.m; sourceTree = "<group>"; };
+		F8728E562ACC9F840056F641 /* NRMANetworkMonitor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NRMANetworkMonitor.h; sourceTree = "<group>"; };
 		F88C2CE32A2FA7AC00373EFE /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		F8AC3E922938FD6C002B4AA8 /* NRMAFakeDataHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRMAFakeDataHelper.m; sourceTree = "<group>"; };
 		F8AC3EA72938FDDB002B4AA8 /* NRMAFakeDataHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NRMAFakeDataHelper.h; sourceTree = "<group>"; };
@@ -3018,6 +3022,8 @@
 				02FF4A8D24DC652D00115469 /* NRMAUDIDManager.m */,
 				02FF4A8B24DC652D00115469 /* NRMAUUIDStore.h */,
 				02FF4A8824DC652C00115469 /* NRMAUUIDStore.m */,
+				F8728E562ACC9F840056F641 /* NRMANetworkMonitor.h */,
+				F8728E402ACC9D5A0056F641 /* NRMANetworkMonitor.m */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -4337,6 +4343,7 @@
 				02FF4AB124DC652E00115469 /* NRMAJSON.m in Sources */,
 				02FF49F124DC645B00115469 /* NRMAAppUpgradeMetricGenerator.m in Sources */,
 				02FF48DA24DC622700115469 /* NRMATimestampContainer.m in Sources */,
+				F8728E412ACC9D5A0056F641 /* NRMANetworkMonitor.m in Sources */,
 				02FF49AE24DC62B800115469 /* NRMAHarvestableMethodMetric.m in Sources */,
 				02FF489C24DC61D200115469 /* NRMAURLSessionOverride.m in Sources */,
 				02FF49CB24DC62B800115469 /* NRMAHarvestableMetric.m in Sources */,
@@ -4673,6 +4680,7 @@
 				02FF4C8124E3201400115469 /* NRMAInteractionHistoryObjCInterface.m in Sources */,
 				02FF4C8224E3201400115469 /* NRMAActivityTraceMeasurementProducer.m in Sources */,
 				02FF4C8324E3201400115469 /* NRMAExceptionMetaDataStore.m in Sources */,
+				F8728E422ACC9D5A0056F641 /* NRMANetworkMonitor.m in Sources */,
 				02FF4C8424E3201400115469 /* NRMASummaryMeasurementConsumer.m in Sources */,
 				02FF4C8524E3201400115469 /* NRMAFlags.m in Sources */,
 				02FF4C8624E3201400115469 /* NRMACrashDataWriter.m in Sources */,
@@ -5144,6 +5152,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ARCHS = "$(ARCHS_STANDARD)";
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -5200,6 +5209,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ARCHS = "$(ARCHS_STANDARD)";
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/Agent/Network/NRMANetworkFacade.mm
+++ b/Agent/Network/NRMANetworkFacade.mm
@@ -107,9 +107,12 @@
     __block NRMAThreadInfo* threadInfo = [NRMAThreadInfo new];
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^() {
 
+#if TARGET_OS_TV
+        NSString* connectionType = [NewRelicInternalUtils connectionType];
+#else
         // getCurrentWanType shouldn't be called on the main thread.
         NSString* connectionType = [NewRelicInternalUtils getCurrentWanType];
-        
+#endif
         NRMAURLTransformer *transformer = [NewRelicAgentInternal getURLTransformer];
         NSURL *replacedURL = [transformer transformURL:request.URL];
         if(!replacedURL) {
@@ -203,7 +206,12 @@
 
     __block NRMAThreadInfo* threadInfo = [NRMAThreadInfo new];
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^() {
+#if TARGET_OS_TV
+        NSString* connectionType = [NewRelicInternalUtils connectionType];
+#else
+        // getCurrentWanType shouldn't be called on the main thread.
         NSString* connectionType = [NewRelicInternalUtils getCurrentWanType];
+#endif
         
         NRMAURLTransformer *transformer = [NewRelicAgentInternal getURLTransformer];
         NSURL *replacedURL = [transformer transformURL:request.URL];

--- a/Agent/Utilities/NRMANetworkMonitor.h
+++ b/Agent/Utilities/NRMANetworkMonitor.h
@@ -1,0 +1,16 @@
+//
+//  NRMANetworkMonitor.h
+//  Agent
+//
+//  Created by Mike Bruin on 10/3/23.
+//  Copyright © 2023 New Relic. All rights reserved.
+//
+
+@interface NRMANetworkMonitor : NSObject
+- (instancetype)init API_AVAILABLE(ios(12.0), tvos(12.0));
+
+- (void) startNetworkMonitoring API_AVAILABLE(ios(12.0), tvos(12.0));
+- (void) stopNetworkMonitoring API_AVAILABLE(ios(12.0), tvos(12.0));
+- (NSString*) getConnectionType;
+
+@end

--- a/Agent/Utilities/NRMANetworkMonitor.m
+++ b/Agent/Utilities/NRMANetworkMonitor.m
@@ -1,0 +1,66 @@
+//
+//  NRMANetworkMonitor.m
+//  Agent
+//
+//  Created by Mike Bruin on 10/3/23.
+//  Copyright © 2023 New Relic. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Network/Network.h>
+
+#import "NRMANetworkMonitor.h"
+
+@interface NRMANetworkMonitor()
+
+@property (nonatomic, strong) nw_path_monitor_t monitor;
+@property (nonatomic, strong) dispatch_queue_t monitorQueue;
+@property (nonatomic, strong) NSString* connectionType;
+
+@end
+
+@implementation NRMANetworkMonitor
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.connectionType = @"unknown";
+        [self startNetworkMonitoring];
+    }
+    return self;
+}
+
+- (void) startNetworkMonitoring {
+    self.monitorQueue = dispatch_queue_create("com.newrelic.network.monitor", dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_UTILITY, DISPATCH_QUEUE_PRIORITY_DEFAULT));
+    self.monitor = nw_path_monitor_create();
+    nw_path_monitor_set_queue(self.monitor, self.monitorQueue);
+    
+    nw_path_monitor_set_update_handler(self.monitor, ^(nw_path_t _Nonnull path) {
+        @synchronized(self.connectionType){
+            if(nw_path_get_status(path) == nw_path_status_satisfied) {
+                if(nw_path_uses_interface_type(path, nw_interface_type_cellular)) {
+                    self.connectionType = @"cellular";
+                } else if (nw_path_uses_interface_type(path, nw_interface_type_wifi)) {
+                    self.connectionType = @"wifi";
+                } else if (nw_path_uses_interface_type(path, nw_interface_type_wired)) {
+                    self.connectionType = @"ethernet";
+                } else {
+                    self.connectionType = @"unknown";
+                }
+            }
+        }
+    });
+    nw_path_monitor_start(self.monitor);
+}
+
+- (void) stopNetworkMonitoring {
+    nw_path_monitor_cancel(self.monitor);
+}
+
+- (NSString*) getConnectionType {
+    @synchronized(self.connectionType){
+        return _connectionType;
+    }
+}
+
+@end

--- a/Agent/Utilities/NewRelicInternalUtils.h
+++ b/Agent/Utilities/NewRelicInternalUtils.h
@@ -8,6 +8,7 @@
 
 #import "NRMAReachability.h"
 #import "NRConstants.h"
+#import "NRMANetworkMonitor.h"
 
 #if __LP64__
 #define NRMA_NSI "ld"
@@ -48,6 +49,9 @@ NSTimeInterval NRMAMillisecondTimestamp(void);
 // Returns the carrier name, or 'wifi' if the device is on a wifi network.
 + (NSString*) carrierName;
 
+// Returns the connection type, wifi, ethernet, or cellular.
++ (NSString*) connectionType;
+
 // Returns the NRMANetworkStatus
 + (NRMANetworkStatus) networkStatus;
 
@@ -86,6 +90,8 @@ NSTimeInterval NRMAMillisecondTimestamp(void);
 + (BOOL)isDebuggerAttached;
 
 + (BOOL)isSimulator;
+
++ (NRMANetworkMonitor*) networkMonitor;
 
 @end
 

--- a/Agent/Utilities/NewRelicInternalUtils.m
+++ b/Agent/Utilities/NewRelicInternalUtils.m
@@ -174,10 +174,17 @@ static NSString* _osVersion;
     }
 }
 
++ (NSString*) connectionType {
+    NRMANetworkMonitor* nm = [self networkMonitor];
+    @synchronized(nm) {
+        return [nm getConnectionType];
+    }
+}
+
 // Returns the carrier name, or 'wifi' if the device is on a wifi network.
 + (NSString*) carrierName {
 #if TARGET_OS_TV
-    return @"wifi";
+    return [self connectionType];
 #else
 #ifdef NRMA_REACHABILITY_DEBUG
     static NRMADEBUG_Reachability* debugLog;
@@ -429,6 +436,17 @@ static NSString* _osVersion;
         r = [NRMAReachability reachability];
     });
     return r;
+}
+
++ (NRMANetworkMonitor*) networkMonitor {
+    static NRMANetworkMonitor* nm = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        if (@available(tvOS 12.0, *)) {
+            nm = [[NRMANetworkMonitor alloc] init];
+        }
+    });
+    return nm;
 }
 
 // Returns the device model.  Ex.  iPhone4,1

--- a/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/Harvestable-Data-Tests/NRMAHarvestableHTTPReqeustTests.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/Harvestable-Data-Tests/NRMAHarvestableHTTPReqeustTests.m
@@ -77,7 +77,11 @@
     XCTAssertTrue(measurement.statusCode == 200,@"statusCode %d doesn't match sent status code",measurement.statusCode);
     XCTAssertTrue(measurement.bytesSent == 1024,@"bytesSent %lld doesn't max sent bytesSent",measurement.bytesSent);
     XCTAssertTrue(measurement.bytesReceived == 1023,@"bytesReceived %lld doesn't match bytesReceived",measurement.bytesReceived);
+#if TARGET_OS_TV
+    XCTAssertTrue([measurement.wanType isEqualToString:@"ethernet"] || [measurement.wanType isEqualToString:@"wifi"],@"measurement.wanType %@ doesn't match expected connection type",measurement.wanType);
+#else
     XCTAssertTrue([measurement.wanType isEqualToString:@"CDMA"],@"measurement.wanType %@ doesn't match expected connection type",measurement.wanType);
+#endif
 }
 
 - (void) testWanTypeInHarvestController5G
@@ -123,7 +127,11 @@
     XCTAssertTrue(measurement.statusCode == 200,@"statusCode %d doesn't match sent status code",measurement.statusCode);
     XCTAssertTrue(measurement.bytesSent == 1024,@"bytesSent %lld doesn't max sent bytesSent",measurement.bytesSent);
     XCTAssertTrue(measurement.bytesReceived == 1023,@"bytesReceived %lld doesn't match bytesReceived",measurement.bytesReceived);
+#if TARGET_OS_TV
+    XCTAssertTrue([measurement.wanType isEqualToString:@"ethernet"] || [measurement.wanType isEqualToString:@"wifi"],@"measurement.wanType %@ doesn't match expected connection type",measurement.wanType);
+#else
     XCTAssertTrue([measurement.wanType isEqualToString:@"5G"],@"measurement.wanType %@ doesn't match expected connection type",measurement.wanType);
+#endif
 }
 
 // TODO: Rewrite this test without HTTPError

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRReachabilityTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRReachabilityTest.m
@@ -42,7 +42,9 @@ NRMANetworkStatus NotReachableMethod(void) {
     sleep(1);
 
     NSString* carrier = [NewRelicInternalUtils carrierName];
+#if !TARGET_OS_TV
     XCTAssertTrue([carrier isEqualToString:@"wifi"], @"Carrier :%@", carrier);
+#endif
 }
 
 -(void)testCarrierNameReachableViaWWAN
@@ -54,9 +56,7 @@ NRMANetworkStatus NotReachableMethod(void) {
     void* origMethod = NRMAReplaceInstanceMethod([NRMAReachability class], @selector(currentReachabilityStatus), (IMP)ReachableViaWWANMethod);
     @try {
         NSString* carrier = [NewRelicInternalUtils carrierName];
-#if TARGET_OS_TV
-        XCTAssertTrue([carrier isEqualToString:@"wifi"], @"Carrier should still be 'unknown', but is actually '%@'", carrier);
-#else
+#if !TARGET_OS_TV
         XCTAssertTrue([carrier isEqualToString:@"unknown"], @"Carrier should be 'unknown', but is actually '%@'", carrier);
 #endif
     } @finally {
@@ -75,9 +75,7 @@ NRMANetworkStatus NotReachableMethod(void) {
     void* origMethod = NRMAReplaceInstanceMethod([NRMAReachability class], @selector(currentReachabilityStatus), (IMP)ReachableViaWWANMethod);
     @try {
         carrier = [NewRelicInternalUtils carrierName];
-#if TARGET_OS_TV
-        XCTAssertTrue([carrier isEqualToString:@"wifi"], @"Carrier should still be 'unknown', but is actually '%@'", carrier);
-#else
+#if !TARGET_OS_TV
         XCTAssertTrue([carrier isEqualToString:@"unknown"], @"Carrier should be 'unknown', but is actually '%@'", carrier);
 #endif
     } @finally {
@@ -86,15 +84,15 @@ NRMANetworkStatus NotReachableMethod(void) {
 
     // calling immediately should return 'other' as it's still cached
     carrier = [NewRelicInternalUtils carrierName];
-#if TARGET_OS_TV
-    XCTAssertTrue([carrier isEqualToString:@"wifi"], @"Carrier should still be 'unknown', but is actually '%@'", carrier);
-#else
+#if !TARGET_OS_TV
     XCTAssertTrue([carrier isEqualToString:@"unknown"], @"Carrier should still be 'unknown', but is actually '%@'", carrier);
 #endif
     // after a second our cache should have expired and we should get 'wifi' this time
     sleep(1);
     carrier = [NewRelicInternalUtils carrierName];
+#if !TARGET_OS_TV
     XCTAssertTrue([carrier isEqualToString:@"wifi"], @"Carrier should have reverted to 'wifi', but is actually '%@'", carrier);
+#endif
 }
 
 @end


### PR DESCRIPTION
I added the class NRMANetworkMonitor that uses nw_path_monitor to detect updates in networking. The nw_path_monitor gives a way to determine wifi, ethernet, or cellular that the reachability class doesn't. I changed it so tvOS looks to this class for connection type information.
Also there is a small tvOS unit tests Build Settings change, that matches what we already do for the iOS tests.