### PR TITLE
fix lcov installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,9 @@ jobs:
         xcode-version: '14.3'
 
     - name: Install lcov
-      run: brew install lcov
+      run: |
+        curl https://raw.githubusercontent.com/Homebrew/homebrew-core/e92d2ae54954ebf485b484d8522104700b144fee/Formula/lcov.rb > lcov.rb
+        brew install ./lcov.rb
 
     - name: Update gem
       run: bundle update


### PR DESCRIPTION
This pR fixes our testIOS action to properly install lcov@1.16 where we are required.