### PR TITLE
Include Prod Podspec Job by default in productionDeploy

### DIFF
--- a/.github/workflows/productionDeploy.yml
+++ b/.github/workflows/productionDeploy.yml
@@ -66,19 +66,19 @@ jobs:
     - name: Print XCFramework name
       run: echo "${{ env.version }}" 
 
-    # - name: Create Prod Podspec for XCFramework version
-    #   run: |
-    #      cd main
+    - name: Create Prod Podspec for XCFramework version
+      run: |
+         cd main
 
-    #      cp cocoapods/NewRelicAgent.podspec.template NewRelicAgent.podspec
-    #      REPLACE=X.XX
-    #      sed -i bak "s/$REPLACE/${{ env.version }}/g" NewRelicAgent.podspec
+         cp cocoapods/NewRelicAgent.podspec.template NewRelicAgent.podspec
+         REPLACE=X.XX
+         sed -i bak "s/$REPLACE/${{ env.version }}/g" NewRelicAgent.podspec
 
-    #      rm NewRelicAgent.podspecbak
+         rm NewRelicAgent.podspecbak
 
-    #      pod trunk push --allow-warnings NewRelicAgent.podspec
-    #   env:
-    #      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+         pod trunk push --allow-warnings NewRelicAgent.podspec
+      env:
+         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
     - name: Create Prod Package.swift for XCFramework version
       run: |


### PR DESCRIPTION
I forgot to put this back in before creating the main PR. 

This simply makes it so GHA will run both jobs when running the productionDeploy action

1. Create Prod Podspec for XCFramework version
2. Create Prod Package.swift for XCFramework version