### PR TITLE
NR-220019: bespoke branch build

### DIFF
--- a/.github/workflows/branchBuild.yml
+++ b/.github/workflows/branchBuild.yml
@@ -1,0 +1,87 @@
+name: BespokeBuild
+on:  
+  workflow_dispatch:
+    # The input version number (ex: 7.4.0) and branch are required for the bespoke branch build. Branch is an automatically added selector for all github actions.
+    inputs:
+      version:
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deployS3:
+    name: DeployS3
+    # runs-on: will be set to macos-latest when running on actual GHA. 
+    # *** runs-on: ubuntu-latest is used when running via act on mac os. ***
+    runs-on: macos-13 
+    outputs:
+      version: ${{ steps.setOutput.outputs.version }}
+    steps:
+    - uses: actions/checkout@v3
+      with: 
+        submodules: true
+    
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '14.3'
+
+    - name: Install the Apple certificate and provisioning profile
+      env:
+        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+        # BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      run: |
+        # create variables
+        CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+        PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+        KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+        # import certificate and provisioning profile from secrets
+        echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+        # echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+
+        # create temporary keychain
+        security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+        # import certificate to keychain
+        security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+        security list-keychain -d user -s $KEYCHAIN_PATH
+
+        # # apply provisioning profile
+        # mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+        # cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+
+    - name: Update gem
+      run: bundle update
+
+    - name: Install gems
+      run: bundle install
+
+    - name: Build NewRelic.xcframework (using fastlane)
+      run: bundle exec fastlane buildAndZip
+
+    - name: Get name
+      run: echo "version=$(cat fastlane/build_version)" >> $GITHUB_ENV
+
+    - id: setOutput
+      name: Print name
+      run: echo "version=${{ env.version }}"  >> $GITHUB_OUTPUT
+
+    - name: Deploy to staging S3
+      run: "aws s3 cp NewRelic_XCFramework_Agent_${{ env.version }}.zip s3://nr-downloads-main/ios-v5/"
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        
+    - name: Upload build reports
+      if: failure() && steps.build-step.outcome != 'success'
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-reports
+        path: /Users/runner/Library/Logs/fastlane/xcbuild/


### PR DESCRIPTION
This PR ads a new `branchBuild.yml` github action file that can be used to create "Bespoke Branch Builds". 

These are very similar pre-release builds to a Staging build except this build is intended to be released to specific customers with specific documentation related to the build. 
We need a GHA since we may need to update the build at any time. 

BUIlds are provided to the client as a .zip framework only. Cocoapods and Swift Package Manager enabled builds are not supported for Bespoke Branch Based Builds.