### PR TITLE
Nr 221555 GTSE investigation related to dataTaskWithURL without completionHandler

### DIFF
--- a/Test Harness/NRTestApp/NRTestApp/ViewModels/UtilViewModel.swift
+++ b/Test Harness/NRTestApp/NRTestApp/ViewModels/UtilViewModel.swift
@@ -43,6 +43,8 @@ class UtilViewModel {
         options.append(UtilOption(title: "Notice Network Request", handler: { [self] in noticeNWRequest()}))
         options.append(UtilOption(title: "Notice Network Failure", handler: { [self] in noticeFailedNWRequest()}))
         options.append(UtilOption(title: "URLSession dataTask", handler: { [self] in doDataTask()}))
+
+        options.append(UtilOption(title: "URLSession dataTask No Completion", handler: { [self] in doDataTaskNoCompletion()}))
         options.append(UtilOption(title: "Shut down New Relic Agent", handler: { [self] in shutDown()}))
     }
 
@@ -142,6 +144,15 @@ class UtilViewModel {
         var request = URLRequest(url: url)
         request.addValue("Sucsess", forHTTPHeaderField: "Test")
         let dataTask = urlSession.dataTask(with: request)
+
+        dataTask.resume()
+    }
+
+    func doDataTaskNoCompletion() {
+        let urlSession = URLSession(configuration: URLSession.shared.configuration, delegate: nil, delegateQueue: nil)
+        guard let url = URL(string: "https://www.google.com") else { return }
+
+        let dataTask = urlSession.dataTask(with: url)
 
         dataTask.resume()
     }


### PR DESCRIPTION
Draft to demonstrate usage of NSURLSession/URLSession dataTaskWithURL 

Adds a new button to UtilView which allows to send  "URLSession dataTaskWithURL No Completion"  this invokes the following code:

```
    func doDataTaskNoCompletion() {
        let urlSession = URLSession(configuration: URLSession.shared.configuration, delegate: nil, delegateQueue: nil)
        guard let url = URL(string: "https://www.google.com") else { return }

        let dataTask = urlSession.dataTask(with: url)

        dataTask.resume()
    }
```
which successfully is recorded in NRMANetworkFacade and is recorded within New Relic One as a n/w request.

I've also added a unit test to the NRURLSessionTaskOverrideTests.m which verifies that NRMANetworkFacade is called by swizzled form of:

```
    __block NSURLSessionDataTask* task = [self.session dataTaskWithURL:[NSURL URLWithString:@"http://google.com"]];

    XCTAssertTrue([self verifyTaskSwizzled:task],@"task's method 'resume' was not instrumented!");

    [task resume];
```