### PR TITLE
NR-234826 - Missing DT Headers

### DIFF
--- a/Agent/Instrumentation/NSURLSession/NRMAURLSessionOverride.m
+++ b/Agent/Instrumentation/NSURLSession/NRMAURLSessionOverride.m
@@ -38,6 +38,14 @@ IMP NRMAOriginal__uploadTaskWithStreamedRequest;
 
 void NRMA__instanceSwizzleIfNotSwizzled(Class clazz, SEL selector, IMP newImplementation);
 
+@interface PayloadHolder : NSObject
+@property (nonatomic, retain) NRMAPayload *objcPayload;
+@property (nonatomic, retain) NRMAPayloadContainer *cppPayload;
+@end
+
+@implementation PayloadHolder
+@end
+
 @interface NRMAIMPContainer : NSObject
 @property(readonly) IMP imp;
 - (instancetype) initWithImp:(IMP)imp;
@@ -248,17 +256,21 @@ NSURLSessionTask* NRMAOverride__dataTaskWithRequest_completionHandler(id self, S
 
     NSMutableURLRequest* mutableRequest = [NRMAHTTPUtilities addCrossProcessIdentifier:request];
     __block NSURLSessionTask* task = nil;
+    
+    PayloadHolder *payloadHolder = [[PayloadHolder alloc] init];
+    if([NRMAFlags shouldEnableNewEventSystem]) {
+        payloadHolder.objcPayload = ([NRMAHTTPUtilities addConnectivityHeaderNRMAPayload:mutableRequest]);
+    } else {
+        payloadHolder.cppPayload = ([NRMAHTTPUtilities addConnectivityHeader:mutableRequest]);
+    }
+    
     if (completionHandler == nil) {
         task  = ((id(*)(id,SEL,NSURLRequest*,void(^)(NSData*,NSURLResponse*,NSError*)))originalImp)(self,_cmd,mutableRequest,completionHandler);
 
-        if([NRMAFlags shouldEnableNewEventSystem]){
-            NRMAPayload* payload = [NRMAHTTPUtilities addConnectivityHeaderNRMAPayload:mutableRequest];
-            [NRMAHTTPUtilities attachNRMAPayload:payload
-                                          to:task.originalRequest];
+        if([NRMAFlags shouldEnableNewEventSystem]) {
+            [NRMAHTTPUtilities attachNRMAPayload:payloadHolder.objcPayload to:task.originalRequest];
         } else {
-            NRMAPayloadContainer* payload = [NRMAHTTPUtilities addConnectivityHeader:mutableRequest];
-            [NRMAHTTPUtilities attachPayload:payload
-                                          to:task.originalRequest];
+            [NRMAHTTPUtilities attachPayload:payloadHolder.cppPayload to:task.originalRequest];
         }
         
         [NRMAURLSessionTaskOverride instrumentConcreteClass:[task class]];
@@ -267,14 +279,10 @@ NSURLSessionTask* NRMAOverride__dataTaskWithRequest_completionHandler(id self, S
     
     task =  ((id(*)(id,SEL,NSURLRequest*,void(^)(NSData*,NSURLResponse*,NSError*)))originalImp)(self,_cmd,mutableRequest,^(NSData* data, NSURLResponse* response, NSError* error){
 
-        if([NRMAFlags shouldEnableNewEventSystem]){
-            NRMAPayload* payload = [NRMAHTTPUtilities addConnectivityHeaderNRMAPayload:mutableRequest];
-            [NRMAHTTPUtilities attachNRMAPayload:payload
-                                          to:task.originalRequest];
+        if([NRMAFlags shouldEnableNewEventSystem]) {
+            [NRMAHTTPUtilities attachNRMAPayload:payloadHolder.objcPayload to:task.originalRequest];
         } else {
-            NRMAPayloadContainer* payload = [NRMAHTTPUtilities addConnectivityHeader:mutableRequest];
-            [NRMAHTTPUtilities attachPayload:payload
-                                          to:task.originalRequest];
+            [NRMAHTTPUtilities attachPayload:payloadHolder.cppPayload to:task.originalRequest];
         }
 
         NRMA__recordTask(task,data,response,error);
@@ -392,17 +400,20 @@ NSURLSessionUploadTask* NRMAOverride__uploadTaskWithRequest_fromFile_completionH
 
     NSMutableURLRequest* mutableRequest = [NRMAHTTPUtilities addCrossProcessIdentifier:request];
     __block NSURLSessionUploadTask* task = nil;
+    PayloadHolder *payloadHolder = [[PayloadHolder alloc] init];
+    if([NRMAFlags shouldEnableNewEventSystem]) {
+        payloadHolder.objcPayload = ([NRMAHTTPUtilities addConnectivityHeaderNRMAPayload:mutableRequest]);
+    } else {
+        payloadHolder.cppPayload = ([NRMAHTTPUtilities addConnectivityHeader:mutableRequest]);
+    }
+    
     if (completionHandler == nil) {
         task = ((NSURLSessionUploadTask*(*)(id,SEL,NSURLRequest*,NSURL*,void(^)(NSData*,NSURLResponse*,NSError*)))originalIMP)(self,_cmd,mutableRequest,fileURL,completionHandler);
         
-        if([NRMAFlags shouldEnableNewEventSystem]){
-            NRMAPayload* payload = [NRMAHTTPUtilities addConnectivityHeaderNRMAPayload:mutableRequest];
-            [NRMAHTTPUtilities attachNRMAPayload:payload
-                                          to:task.originalRequest];
+        if([NRMAFlags shouldEnableNewEventSystem]) {
+            [NRMAHTTPUtilities attachNRMAPayload:payloadHolder.objcPayload to:task.originalRequest];
         } else {
-            NRMAPayloadContainer* payload = [NRMAHTTPUtilities addConnectivityHeader:mutableRequest];
-            [NRMAHTTPUtilities attachPayload:payload
-                                          to:task.originalRequest];
+            [NRMAHTTPUtilities attachPayload:payloadHolder.cppPayload to:task.originalRequest];
         }
     
         [NRMAURLSessionTaskOverride instrumentConcreteClass:[task class]];
@@ -412,15 +423,12 @@ NSURLSessionUploadTask* NRMAOverride__uploadTaskWithRequest_fromFile_completionH
     task =  ((NSURLSessionUploadTask*(*)(id,SEL,NSURLRequest*,NSURL*,void(^)(NSData*,NSURLResponse*,NSError*)))originalIMP)(self,_cmd,mutableRequest,fileURL,^(NSData* data,
                                                                                                                                                         NSURLResponse* response,
                                                                                                                                                         NSError* error){
-        if([NRMAFlags shouldEnableNewEventSystem]){
-            NRMAPayload* payload = [NRMAHTTPUtilities addConnectivityHeaderNRMAPayload:mutableRequest];
-            [NRMAHTTPUtilities attachNRMAPayload:payload
-                                              to:task.originalRequest];
+        if([NRMAFlags shouldEnableNewEventSystem]) {
+            [NRMAHTTPUtilities attachNRMAPayload:payloadHolder.objcPayload to:task.originalRequest];
         } else {
-            NRMAPayloadContainer* payload = [NRMAHTTPUtilities addConnectivityHeader:mutableRequest];
-            [NRMAHTTPUtilities attachPayload:payload
-                                          to:task.originalRequest];
+            [NRMAHTTPUtilities attachPayload:payloadHolder.cppPayload to:task.originalRequest];
         }
+        
         NRMA__recordTask(task,data,response,error);
 
         completionHandler(data,response,error);
@@ -444,17 +452,21 @@ NSURLSessionUploadTask* NRMAOverride__uploadTaskWithRequest_fromData_completionH
 
     NSMutableURLRequest* mutableRequest = [NRMAHTTPUtilities addCrossProcessIdentifier:request];
     __block NSURLSessionUploadTask* task = nil;
+    
+    PayloadHolder *payloadHolder = [[PayloadHolder alloc] init];
+    if([NRMAFlags shouldEnableNewEventSystem]) {
+        payloadHolder.objcPayload = ([NRMAHTTPUtilities addConnectivityHeaderNRMAPayload:mutableRequest]);
+    } else {
+        payloadHolder.cppPayload = ([NRMAHTTPUtilities addConnectivityHeader:mutableRequest]);
+    }
+    
     if (completionHandler == nil) {
         task = ((NSURLSessionUploadTask*(*)(id,SEL,NSURLRequest*,NSData*,void(^)(NSData*,NSURLResponse*,NSError*)))originalIMP)(self,_cmd,mutableRequest,bodyData,completionHandler);
 
-        if([NRMAFlags shouldEnableNewEventSystem]){
-            NRMAPayload* payload = [NRMAHTTPUtilities addConnectivityHeaderNRMAPayload:mutableRequest];
-            [NRMAHTTPUtilities attachNRMAPayload:payload
-                                          to:task.originalRequest];
+        if([NRMAFlags shouldEnableNewEventSystem]) {
+            [NRMAHTTPUtilities attachNRMAPayload:payloadHolder.objcPayload to:task.originalRequest];
         } else {
-            NRMAPayloadContainer* payload = [NRMAHTTPUtilities addConnectivityHeader:mutableRequest];
-            [NRMAHTTPUtilities attachPayload:payload
-                                          to:task.originalRequest];
+            [NRMAHTTPUtilities attachPayload:payloadHolder.cppPayload to:task.originalRequest];
         }
 
         [NRMAURLSessionTaskOverride instrumentConcreteClass:[task class]];
@@ -463,15 +475,12 @@ NSURLSessionUploadTask* NRMAOverride__uploadTaskWithRequest_fromData_completionH
     
     task =  ((NSURLSessionUploadTask*(*)(id,SEL,NSURLRequest*,NSData*,void(^)(NSData*,NSURLResponse*,NSError*)))originalIMP)(self,_cmd,mutableRequest,bodyData,^(NSData* data, NSURLResponse* response, NSError* error){
 
-        if([NRMAFlags shouldEnableNewEventSystem]){
-            NRMAPayload* payload = [NRMAHTTPUtilities addConnectivityHeaderNRMAPayload:mutableRequest];
-            [NRMAHTTPUtilities attachNRMAPayload:payload
-                                          to:task.originalRequest];
+        if([NRMAFlags shouldEnableNewEventSystem]) {
+            [NRMAHTTPUtilities attachNRMAPayload:payloadHolder.objcPayload to:task.originalRequest];
         } else {
-            NRMAPayloadContainer* payload = [NRMAHTTPUtilities addConnectivityHeader:mutableRequest];
-            [NRMAHTTPUtilities attachPayload:payload
-                                          to:task.originalRequest];
+            [NRMAHTTPUtilities attachPayload:payloadHolder.cppPayload to:task.originalRequest];
         }
+        
         NRMA__recordTask(task,data,response,error);
 
         completionHandler(data,response,error);

--- a/Agent/Instrumentation/NSURLSession/NRMAURLSessionTaskOverride.m
+++ b/Agent/Instrumentation/NSURLSession/NRMAURLSessionTaskOverride.m
@@ -126,7 +126,7 @@ void NRMAOverride__urlSessionTask_SetState(NSURLSessionTask* task, SEL _cmd, NSU
                 
                 NSURL *url = [currentRequest URL];
                 if (url != nil &&
-                    newState != NSURLSessionTaskStateRunning && task.state == NSURLSessionTaskStateRunning) {
+                    task.state == NSURLSessionTaskStateRunning) {
 
                     // Added this section to add Distributed Tracing traceId\trace.id, guid,id and payload.
                     //1


### PR DESCRIPTION
In several instances, Distributed Tracing headers were not added to requests before they were sent off. This was due to not calling the proper method which would, simultaneously generate the DT headers, and add them to the request. Later, the Distributed Tracing Payload would be associated with the request, allowing for round trip tracing. In addition, DT headers were not being added to Swift Async requests before they went off, due to the delegate method setState not giving us a proper updated state in the newState parameter. 