### PR TITLE
Added the offline attribute to the old event system

### DIFF
--- a/Agent/Analytics/NRMAAnalytics.h
+++ b/Agent/Analytics/NRMAAnalytics.h
@@ -53,6 +53,7 @@
 + (NSString*) getLastSessionsEvents;
 - (void) clearLastSessionsAnalytics;
 
+- (BOOL) checkOfflineStatus;
 
 //this utilizes setSessionAttribute:value: which validates the user input 'name'.
 - (BOOL) setLastInteraction:(NSString*)name;

--- a/Agent/UserAction/NRMAUserActionFacade.mm
+++ b/Agent/UserAction/NRMAUserActionFacade.mm
@@ -39,7 +39,8 @@
                                                            userAction.interactionCoordinates.UTF8String,
                                                            userAction.actionType.UTF8String,
                                                            userAction.elementFrame.UTF8String,
-                                                           [NewRelicInternalUtils deviceOrientation].UTF8String);
+                                                           [NewRelicInternalUtils deviceOrientation].UTF8String,
+                                                           [analyticsController checkOfflineStatus]);
         } catch (std::exception &error) {
             NRLOG_VERBOSE(@"Failed to add TrackedGesture: %s.", error.what());
         } catch (...) {

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMAAnalyticsTest.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMAAnalyticsTest.mm
@@ -131,6 +131,7 @@
     XCTAssertFalse([decode[0][@"requestUrl"] containsString:@"?"]);
     XCTAssertFalse([decode[0][@"requestUrl"] containsString:@"request"]);
     XCTAssertFalse([decode[0][@"requestUrl"] containsString:@"parameter"]);
+    XCTAssertFalse([json containsString:@"offline"]);
 
     [NRMAFlags disableFeatures:NRFeatureFlag_NetworkRequestEvents];
 }
@@ -217,7 +218,7 @@
 
     XCTAssertNotNil(decode[0][@"responseTime"]);
     XCTAssertNil(decode[0][@"networkErrorCode"]);
-
+    XCTAssertFalse([json containsString:@"offline"]);
 
 }
 
@@ -312,6 +313,7 @@
     XCTAssertTrue([decode[0][@"networkError"] isEqualToString:@"network failure"]);
     XCTAssertNotNil(decode[0][@"responseTime"]);
     XCTAssertNil(decode[0][@"statusCode"]);
+    XCTAssertFalse([json containsString:@"offline"]);
 }
 
 - (void) testRequestEventNetworkErrorOffline {
@@ -363,6 +365,7 @@
     XCTAssertTrue([decode[0][@"eventType"] isEqualToString:@"newEventBlah"]);
     XCTAssertTrue([decode[0][@"blah"] isEqualToString:@"blah"]);
     XCTAssertTrue([decode[0][@"Winner"] isEqual:@1]);
+    XCTAssertFalse([json containsString:@"offline"]);
 }
 
 - (void) testInteractionEvent {
@@ -381,6 +384,7 @@
     XCTAssertTrue([decode[0][@"name"] isEqualToString:@"newEventBlah"]);
     XCTAssertTrue([decode[0][@"category"] isEqualToString:@"Interaction"]);
     XCTAssertTrue([decode[0][@"interactionDuration"] isEqual:@(1.0)]);    
+    XCTAssertFalse([json containsString:@"offline"]);
 }
 
 - (void) testInteractionEventOffline {
@@ -439,6 +443,7 @@
     XCTAssertNotNil(decode[0][@"eventType"]);
     XCTAssertTrue([decode[0][@"eventType"] isEqualToString:@"MobileBreadcrumb"]);
     XCTAssertTrue([decode[0][@"name"] isEqualToString:@"testBreadcrumbs"]);
+    XCTAssertFalse([json containsString:@"offline"]);
 }
 
 - (void) testBreadcrumbOffline {

--- a/libMobileAgent/src/Analytics/include/Analytics/AnalyticsController.hpp
+++ b/libMobileAgent/src/Analytics/include/Analytics/AnalyticsController.hpp
@@ -126,15 +126,18 @@ namespace NewRelic {
 
         bool addRequestEvent(const NewRelic::NetworkRequestData& requestData,
                              const NewRelic::NetworkResponseData& responseData,
-                             std::unique_ptr<const Connectivity::Payload> payload);
+                             std::unique_ptr<const Connectivity::Payload> payload,
+                             bool isOffline);
 
         bool addHTTPErrorEvent(const NewRelic::NetworkRequestData& requestData,
                                const NewRelic::NetworkResponseData& responseData,
-                               std::unique_ptr<const Connectivity::Payload> payload);
+                               std::unique_ptr<const Connectivity::Payload> payload,
+                               bool isOffline);
 
         bool addNetworkErrorEvent(const NewRelic::NetworkRequestData& requestData,
                                   const NewRelic::NetworkResponseData& responseData,
-                                  std::unique_ptr<const Connectivity::Payload> payload);
+                                  std::unique_ptr<const Connectivity::Payload> payload,
+                                  bool isOffline);
 
         bool addUserActionEvent(const char *functionName,
                                 const char *targetObject,
@@ -143,9 +146,10 @@ namespace NewRelic {
                                 const char *tapCoordinates,
                                 const char *actionType,
                                 const char *controlFrame,
-                                const char *orientation);
+                                const char *orientation,
+                                bool isOffline);
 
-        bool addInteractionEvent(const char *name, double duration_sec);
+        bool addInteractionEvent(const char *name, double duration_sec, bool isOffline);
 
         std::shared_ptr <NRJSON::JsonArray> getEventsJSON(bool clearEvents);
 

--- a/libMobileAgent/src/Analytics/include/Analytics/Constants.hpp
+++ b/libMobileAgent/src/Analytics/include/Analytics/Constants.hpp
@@ -75,6 +75,7 @@ extern const char* __kNRMA_Attrib_contentType;
 extern const char* __kNRMA_Attrib_dtGuid;
 extern const char* __kNRMA_Attrib_dtId;
 extern const char* __kNRMA_Attrib_dtTraceId;
+extern const char* __kNRMA_Attrib_offline;
 
 extern const char* __kNRMA_Val_errorType_HTTP;
 extern const char* __kNRMA_Val_errorType_Network;

--- a/libMobileAgent/src/Analytics/src/Constants.cxx
+++ b/libMobileAgent/src/Analytics/src/Constants.cxx
@@ -72,6 +72,7 @@ const char* __kNRMA_Attrib_contentType       = "contentType";
 const char* __kNRMA_Attrib_dtGuid            = "guid";
 const char* __kNRMA_Attrib_dtId              = "id";
 const char* __kNRMA_Attrib_dtTraceId         = "trace.id";
+const char* __kNRMA_Attrib_offline           = "offline";
 
 const char* __kNRMA_Val_errorType_HTTP       = "HTTPError";
 const char* __kNRMA_Val_errorType_Network    = "NetworkFailure";


### PR DESCRIPTION
The offline attribute was only added to the new event system. This pr adds the attribute to the old event system. An event should have the offline attribute when it is created while the device is in an offline state.