### PR TITLE
NR-239832 - Fix incorrect NSURLSession cast

### DIFF
--- a/Agent/HandledException/NRMAHexUploader.m
+++ b/Agent/HandledException/NRMAHexUploader.m
@@ -115,14 +115,15 @@ didCompleteWithError:(nullable NSError*)error {
            dataTask:(NSURLSessionDataTask*)dataTask
  didReceiveResponse:(NSURLResponse*)response
   completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler {
-    NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
+//    NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
+//
+//    NSInteger statusCode = httpResponse.statusCode;
 
-    NSInteger statusCode = httpResponse.statusCode;
-
-    NRLOG_VERBOSE(@"NEWRELIC HEX UPLOADER - Hex Upload response: %@", httpResponse);
+    NRLOG_VERBOSE(@"NEWRELIC HEX UPLOADER - Hex Upload response: %@", response);
     
-    if (statusCode >= 400) {
-        NRLOG_ERROR(@"NEWRELIC HEX UPLOADER - failed to upload handled exception report: %@", httpResponse.description);
+    if ([response isKindOfClass:[NSHTTPURLResponse class]] &&
+        ((NSHTTPURLResponse*)response).statusCode >= 400) {
+        NRLOG_ERROR(@"NEWRELIC HEX UPLOADER - failed to upload handled exception report: %@", response.description);
         [self handledErroredRequest:dataTask.originalRequest];
     }
     else {

--- a/Agent/Harvester/NRMAHarvesterConnection.m
+++ b/Agent/Harvester/NRMAHarvesterConnection.m
@@ -120,9 +120,10 @@
         @autoreleasepool {
             data = responseBody;
             error = berror;
+            response = (NSHTTPURLResponse*)bresponse;
             dispatch_semaphore_signal(harvestRequestSemaphore);
             
-            NRLOG_VERBOSE(@"NEWRELIC CONNECT - RESPONSE: %@", [bresponse debugDescription]);
+            NRLOG_VERBOSE(@"NEWRELIC CONNECT - RESPONSE: %@", [response debugDescription]);
             
             // Enqueue Data Usage Supportability Metric for /data or /connect if the harvest request was successful.
             if (!error) {

--- a/Agent/Harvester/NRMAHarvesterConnection.m
+++ b/Agent/Harvester/NRMAHarvesterConnection.m
@@ -120,10 +120,9 @@
         @autoreleasepool {
             data = responseBody;
             error = berror;
-            response = (NSHTTPURLResponse*)bresponse;
             dispatch_semaphore_signal(harvestRequestSemaphore);
             
-            NRLOG_VERBOSE(@"NEWRELIC CONNECT - RESPONSE: %@", [response debugDescription]);
+            NRLOG_VERBOSE(@"NEWRELIC CONNECT - RESPONSE: %@", [bresponse debugDescription]);
             
             // Enqueue Data Usage Supportability Metric for /data or /connect if the harvest request was successful.
             if (!error) {

--- a/Agent/Network/NRMANetworkFacade.mm
+++ b/Agent/Network/NRMANetworkFacade.mm
@@ -128,12 +128,13 @@
         [NRMAHTTPUtilities addTrackedHeaders:request.allHTTPHeaderFields to:networkRequestData];
         
         NSUInteger modifiedBytesReceived = bytesReceived;
-        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
-        NSString* header = httpResponse.allHeaderFields[@"Content-Encoding"];
-        if ([header isEqualToString:@"gzip"]) {
-            modifiedBytesReceived = [[NRMAHarvesterConnection gzipData:responseData] length];
+        if([response isKindOfClass:[NSHTTPURLResponse class]]) {
+            NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
+            NSString* header = httpResponse.allHeaderFields[@"Content-Encoding"];
+            if ([header isEqualToString:@"gzip"]) {
+                modifiedBytesReceived = [[NRMAHarvesterConnection gzipData:responseData] length];
+            }
         }
-
 
         if ([NRMANetworkFacade statusCode:response] >= NRMA_HTTP_STATUS_CODE_ERROR_THRESHOLD) {
             if([NRMAFlags shouldEnableNewEventSystem]){


### PR DESCRIPTION
A crash was found when the allHeaders selector was sent to an instance of NSURLSession that was not also an NSHTTPURLSession, and this cast was not checked.