### PR TITLE
Fixed a typo in our offline configuration functions

### DIFF
--- a/Agent/Harvester/DataStore/NRMAAgentConfiguration.h
+++ b/Agent/Harvester/DataStore/NRMAAgentConfiguration.h
@@ -47,6 +47,6 @@
 + (void) setMaxEventBufferSize:(NSUInteger)size;
 + (NSUInteger) getMaxEventBufferSize;
 
-+ (void) setMaxOfflineStorageSize:(NSUInteger)megaBytes;
++ (void) setMaxOfflineStorageSize:(NSUInteger)megabytes;
 + (NSUInteger) getMaxOfflineStorageSize;
 @end

--- a/Agent/Harvester/DataStore/NRMAAgentConfiguration.m
+++ b/Agent/Harvester/DataStore/NRMAAgentConfiguration.m
@@ -58,8 +58,8 @@ static NSUInteger __NRMA__maxOfflineStorageSize = 100000000; // 100 mb
     return __NRMA__maxEventBufferSize;
 }
 
-+ (void) setMaxOfflineStorageSize:(NSUInteger)megaBytes {
-    __NRMA__maxOfflineStorageSize = megaBytes;
++ (void) setMaxOfflineStorageSize:(NSUInteger)megabytes {
+    __NRMA__maxOfflineStorageSize = megabytes;
 }
 
 + (NSUInteger) getMaxOfflineStorageSize {

--- a/Agent/Public/NewRelic.h
+++ b/Agent/Public/NewRelic.h
@@ -696,12 +696,12 @@ extern "C" {
 /*!
  Change the maximum size in megabytes that the agent will store for offline storage.
  
- @param megaBytes the maximum size in mega bytes of offline storage that can be stored in the local file system
+ @param megabytes the maximum size in mega bytes of offline storage that can be stored in the local file system
  
  By default the SDK will store up to 100 MB worth of offline payloads in the local file system.
  */
 
-+ (void) setMaxOfflineStorageSize:(unsigned int)megaBytes;
++ (void) setMaxOfflineStorageSize:(unsigned int)megabytes;
 
 #pragma mark - Tracking global attributes
 

--- a/Agent/Public/NewRelic.m
+++ b/Agent/Public/NewRelic.m
@@ -629,10 +629,10 @@
  * this means: once the maximum size has been met the agent will stop storing offline payloads until
  * more room is made.
  */
-+ (void) setMaxOfflineStorageSize:(unsigned int)megaBytes {
-    [NRMAAgentConfiguration setMaxOfflineStorageSize:megaBytes];
++ (void) setMaxOfflineStorageSize:(unsigned int)megabytes {
+    [NRMAAgentConfiguration setMaxOfflineStorageSize:megabytes];
 
-    [NRMAHarvestController setMaxOfflineStorageSize:megaBytes];
+    [NRMAHarvestController setMaxOfflineStorageSize:megabytes];
 }
 #pragma mark - Hidden APIs
 


### PR DESCRIPTION
There was a typo in offline storage configuration, megaBytes instead of megabytes.