### PR TITLE
NR-231192: run-symbol-tool updates for DEM

### DIFF
--- a/dsym-upload-tools/README_RUN_SYMBOL_TOOL.MD
+++ b/dsym-upload-tools/README_RUN_SYMBOL_TOOL.MD
@@ -15,7 +15,7 @@
 Optional:
 
 Note: A few environment variables can be set to modify the behavior of the map or dSYM uploader.
-- DSYM_UPLOAD_URL: Host URL to use when uploading to New Relic.
+- DSYM_UPLOAD_URL: Host URL to use when uploading to New Relic. default: "https://mobile-symbol-upload.newrelic.com"
 - NEWRELIC_SYMBOL_ENDPOINT: Symbol endpoint. default: "map"
 - NEWRELIC_DSYM_ENDPOINT: Dsym endpoint. default: "symbol"
 - NEWRELIC_SYMBOL_POST_KEY: Symbol Post Key used in Curl. default: "upload"
@@ -29,6 +29,18 @@ Add "--debug" after last line of script to enable debug logs in the output `uplo
 ```
 
 DSYM_UPLOAD_URL - define this environment variable above run script to override the New Relic server hostname
+
+
+```
+export DSYM_UPLOAD_URL="https://staging-mobile-symbol-upload.newrelic.com"
+```
+
+Repeat this line for each Env Var you'd like to set.
+
+```
+export NEWRELIC_SYMBOL_ENDPOINT="map2"
+```
+
 
 - Due to limitations with Swift scripting run-symbol-tool.swift is one file.
    Main script contents are in start() func. Helper functions are categorized at the end.

--- a/dsym-upload-tools/README_RUN_SYMBOL_TOOL.MD
+++ b/dsym-upload-tools/README_RUN_SYMBOL_TOOL.MD
@@ -1,0 +1,37 @@
+## Swift script used to upload a builds symbols to New Relic.
+### Intended to be run from a Xcode build phase.
+
+ 1. In Xcode, select your project in the navigator, then click on the application target.
+ 2. Select the Build Phases tab in the settings editor.
+ 3. Click the + icon above Target Dependencies and choose New Run Script Build Phase.
+ 4. Add the following lines of code to the new phase, pasting in the
+     application token as "APP_TOKEN" from your New Relic dashboard for the app in question.
+ 
+```
+    SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+    /bin/sh "${SCRIPT}" "APP_TOKEN"
+```
+
+Optional:
+
+Note: A few environment variables can be set to modify the behavior of the map or dSYM uploader.
+- DSYM_UPLOAD_URL: Host URL to use when uploading to New Relic.
+- NEWRELIC_SYMBOL_ENDPOINT: Symbol endpoint. default: "map"
+- NEWRELIC_DSYM_ENDPOINT: Dsym endpoint. default: "symbol"
+- NEWRELIC_SYMBOL_POST_KEY: Symbol Post Key used in Curl. default: "upload"
+- NEWRELIC_DSYM_POST_KEY: Dsym Post Key used in Curl. default: "dsym"
+
+Add "--debug" after last line of script to enable debug logs in the output `upload_dsym_results.log` file.
+
+```
+    SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+    /bin/sh "${SCRIPT}" "APP_TOKEN" --debug
+```
+
+DSYM_UPLOAD_URL - define this environment variable above run script to override the New Relic server hostname
+
+- Due to limitations with Swift scripting run-symbol-tool.swift is one file.
+   Main script contents are in start() func. Helper functions are categorized at the end.
+- Script will first attempt to convert each dSYM into NR map files, 
+   then it will combine map files into zip file and upload to New Relic.
+   If conversion isn't possible or zipped map files upload fails the dSYMs are uploaded to New Relic.

--- a/dsym-upload-tools/run-symbol-tool.swift
+++ b/dsym-upload-tools/run-symbol-tool.swift
@@ -486,7 +486,7 @@ func padHex(_ hexString: String) -> String {
 func uploadFile(_ path: String, _ apiKey: String, _ url: String, _ isDsym: Bool, _ size: UInt64) throws -> String? {
     var resultFromCurl: String? = nil
     do {
-        let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -F \(isDsym ? dsymUploadDataPostKey : symbolUploadDataPostKey)=@\"\(path)\" -H \"x-app-license-key: \(apiKey)\" -H \"Content-Disposition: attachment\" -H \"X-NewRelic-Agent-Version: \(versionNumber)\" -H \"X-NewRelic-OS-Name: \(osName)\" -H \"X-NewRelic-Platform: \(platformName)\" -H \"X-NewRelic-App-Version: \(appVersionNumber)\" -H \"X-File-Size: \(size)\" \(url)/\(isDsym ? dsymEndpointPath : symbolEndpointPath)"
+        let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -F \(isDsym ? dsymUploadDataPostKey : symbolUploadDataPostKey)=@\"\(path)\" -H \"x-app-license-key: \(apiKey)\" -H \"X-NewRelic-Agent-Version: \(versionNumber)\" -H \"X-NewRelic-OS-Name: \(osName)\" -H \"X-NewRelic-Platform: \(platformName)\" -H \"X-NewRelic-App-Version: \(appVersionNumber)\" -H \"X-File-Size: \(size)\" \(url)/\(isDsym ? dsymEndpointPath : symbolEndpointPath)"
 
        // let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -F \(isDsym ? "dsym" : "upload")=@\"\(path)\" -H \"x-app-license-key: \(apiKey)\" -H \"Content-Disposition: attachment\" -H \"X-File-Size: \(size)\" \(url)/\(isDsym ? "symbol" : "map")"
 

--- a/dsym-upload-tools/run-symbol-tool.swift
+++ b/dsym-upload-tools/run-symbol-tool.swift
@@ -8,12 +8,23 @@
 // 1. In Xcode, select your project in the navigator, then click on the application target.
 // 2. Select the Build Phases tab in the settings editor.
 // 3. Click the + icon above Target Dependencies and choose New Run Script Build Phase.
-// 4. Add the following line of code to the new phase, pasting in the
-//     application token from your New Relic dashboard for the app in question.
+// 4. Add the following lines of code to the new phase, pasting in the
+//     application token as "APP_TOKEN" from your New Relic dashboard for the app in question.
 // 
-//  "${BUILD_DIR%/Build/*}/SourcePackages/artifacts/newrelic-ios-agent-spm/NewRelic.xcframework/Resources/run-symbol-tool" "APP_TOKEN"
-// 
+// ```
+//  SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+//  /bin/sh "${SCRIPT}" "APP_TOKEN"
+// ```
+//
 // Optional:
+//
+// Add "--debug" after script invocation to enable debug logs in the output upload_dsym_results.log file.
+//
+// ```
+//  SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+//  /bin/sh "${SCRIPT}" "APP_TOKEN" --debug
+// ```
+//
 // DSYM_UPLOAD_URL - define this environment variable above run script to override the New Relic server hostname
 //
 // - Due to limitations with Swift scripting run-symbol-tool.swift is one file.
@@ -71,8 +82,17 @@ func start() {
         }
     }
 
+// Start Configure Env Vars //
+    /// Grab URLs and Keys from environment variables. 
     // Grab URL from set Env Var "$DSYM_UPLOAD_URL" or use default URL.
     var url = environment["DSYM_UPLOAD_URL"] ?? defaultURL
+    var symbolEndpointPath = environment["NEWRELIC_SYMBOL_ENDPOINT"] ?? "map"
+    var dsymEndpointPath   = environment["NEWRELIC_DSYM_ENDPOINT"] ?? "symbol"
+
+    var symbolUploadDataPostKey = environment["NEWRELIC_SYMBOL_POST_KEY"] ?? "upload"
+    var dsymUploadDataPostKey   = environment["NEWRELIC_DSYM_POST_KEY"] ?? "dsym"
+// End Configure Env Vars //
+
 
     if let regionAwareURL = parseRegionFromApiKey(apiKey) {
         url = regionAwareURL
@@ -170,8 +190,16 @@ func zipAndUploadDsym(_ dsymPath: String, _ apiKey: String, _ url: String) throw
 
                 print("successfully zipped dSYM to \(archiveUrl)")
 
+                // get size @ archiveUrl 
+                guard let size = getSizeAtURL(archiveUrl) else { 
+                    print("Failed to get fileSize. --failing")
+                    return 
+                }
+                if debug {
+                    print("Detected zipped dSYM file size = \(size). Uploading...")
+                }
                 // Now that we have archiveUrl with the dSYM file zipped up, upload the zip file.
-                let dsymUploadResult = try uploadFile(archiveUrl.path, apiKey, url, true)
+                let dsymUploadResult = try uploadFile(archiveUrl.path, apiKey, url, true, size)
                 if dsymUploadResult == "201" {
                     print("Successfully uploaded dSYM: \(archiveUrl.path)")
                 }
@@ -271,8 +299,17 @@ func processDsym(_ path: String, _ apiKey: String, _ url: String) throws {
             archiveUrl = temporaryURL
 
             if let archiveUrl = archiveUrl {
+
+                // get size @ archiveUrl 
+                guard let size = getSizeAtURL(archiveUrl) else { 
+                    print("Failed to get fileSize. --failing")
+                    return 
+                }
+                if debug {
+                    print("Detected zipped map file size = \(size). Uploading...")
+                }
                 // Now that we have archiveUrl with the combined map files zipped up, upload the map file.
-                let mapUploadResult = try uploadFile(archiveUrl.path, apiKey, url, false)
+                let mapUploadResult = try uploadFile(archiveUrl.path, apiKey, url, false, size)
                 if mapUploadResult == "201" {
                     print("Successfully uploaded map: \(archiveUrl.path)")
                 }
@@ -436,10 +473,14 @@ func padHex(_ hexString: String) -> String {
  }
 
 // Networking via curl
-func uploadFile(_ path: String, _ apiKey: String, _ url: String, _ isDsym: Bool) throws -> String? {
+func uploadFile(_ path: String, _ apiKey: String, _ url: String, _ isDsym: Bool, _ size: UInt64) throws -> String? {
     var resultFromCurl: String? = nil
     do {
-        let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -F \(isDsym ? "dsym" : "upload")=@\"\(path)\" -H \"x-app-license-key: \(apiKey)\" \(url)/\(isDsym ? "symbol" : "map")"
+        let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -F \(isDsym ? dsymUploadDataPostKey : symbolUploadDataPostKey)=@\"\(path)\" -H \"x-app-license-key: \(apiKey)\" -H \"Content-Disposition: attachment\" -H \"X-File-Size: \(size)\" \(url)/\(isDsym ? dsymEndpointPath : symbolEndpointPath)"
+
+       // let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -F \(isDsym ? "dsym" : "upload")=@\"\(path)\" -H \"x-app-license-key: \(apiKey)\" -H \"Content-Disposition: attachment\" -H \"X-File-Size: \(size)\" \(url)/\(isDsym ? "symbol" : "map")"
+
+
         if debug { print("Executing $ \(command)") }
         resultFromCurl = try shell(command)
     } catch {
@@ -484,5 +525,20 @@ extension String {
             return self
         }
         return String(self[...index])
+    }
+}
+
+func getSizeAtURL(_ url: URL) -> UInt64? {
+    do {
+        let attrs = try fileManager.attributesOfItem(atPath: url.path)
+        guard let fileSize = attrs[.size] as? UInt64 else { 
+            print("Failed to acquire ")
+            return nil 
+        }
+        return fileSize
+    }
+    catch {
+        print("Error loading file attribute size. --failing")
+        return nil
     }
 }

--- a/dsym-upload-tools/run-symbol-tool.swift
+++ b/dsym-upload-tools/run-symbol-tool.swift
@@ -44,6 +44,16 @@ var debug = false
 // Set to true for dSYM upload feature. (dSYM files are normally only uploaded if map file conversion fails.)
 let uploadDsymsOnly = false
 
+var symbolEndpointPath = "map"
+var dsymEndpointPath   = "symbol"
+var symbolUploadDataPostKey = "upload"
+var dsymUploadDataPostKey   = "dsym"
+
+var versionNumber = "7.4.10"
+var osName = "iOS"
+var platformName = "Native"
+var appVersionNumber = "1.2.3"
+
 enum SymbolToolError: Error {
     case failedToConvert
     case failedToUpload
@@ -86,11 +96,11 @@ func start() {
     /// Grab URLs and Keys from environment variables. 
     // Grab URL from set Env Var "$DSYM_UPLOAD_URL" or use default URL.
     var url = environment["DSYM_UPLOAD_URL"] ?? defaultURL
-    var symbolEndpointPath = environment["NEWRELIC_SYMBOL_ENDPOINT"] ?? "map"
-    var dsymEndpointPath   = environment["NEWRELIC_DSYM_ENDPOINT"] ?? "symbol"
+    symbolEndpointPath = environment["NEWRELIC_SYMBOL_ENDPOINT"] ?? "map"
+    dsymEndpointPath   = environment["NEWRELIC_DSYM_ENDPOINT"] ?? "symbol"
 
-    var symbolUploadDataPostKey = environment["NEWRELIC_SYMBOL_POST_KEY"] ?? "upload"
-    var dsymUploadDataPostKey   = environment["NEWRELIC_DSYM_POST_KEY"] ?? "dsym"
+    symbolUploadDataPostKey = environment["NEWRELIC_SYMBOL_POST_KEY"] ?? "upload"
+    dsymUploadDataPostKey   = environment["NEWRELIC_DSYM_POST_KEY"] ?? "dsym"
 // End Configure Env Vars //
 
 
@@ -476,7 +486,7 @@ func padHex(_ hexString: String) -> String {
 func uploadFile(_ path: String, _ apiKey: String, _ url: String, _ isDsym: Bool, _ size: UInt64) throws -> String? {
     var resultFromCurl: String? = nil
     do {
-        let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -F \(isDsym ? dsymUploadDataPostKey : symbolUploadDataPostKey)=@\"\(path)\" -H \"x-app-license-key: \(apiKey)\" -H \"Content-Disposition: attachment\" -H \"X-File-Size: \(size)\" \(url)/\(isDsym ? dsymEndpointPath : symbolEndpointPath)"
+        let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -F \(isDsym ? dsymUploadDataPostKey : symbolUploadDataPostKey)=@\"\(path)\" -H \"x-app-license-key: \(apiKey)\" -H \"Content-Disposition: attachment\" -H \"X-NewRelic-Agent-Version: \(versionNumber)\" -H \"X-NewRelic-OS-Name: \(osName)\" -H \"X-NewRelic-Platform: \(platformName)\" -H \"X-NewRelic-App-Version: \(appVersionNumber)\" -H \"X-File-Size: \(size)\" \(url)/\(isDsym ? dsymEndpointPath : symbolEndpointPath)"
 
        // let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -F \(isDsym ? "dsym" : "upload")=@\"\(path)\" -H \"x-app-license-key: \(apiKey)\" -H \"Content-Disposition: attachment\" -H \"X-File-Size: \(size)\" \(url)/\(isDsym ? "symbol" : "map")"
 

--- a/examples/manual/FrameworkExample/dsym-upload-tools/README_RUN_SYMBOL_TOOL.MD
+++ b/examples/manual/FrameworkExample/dsym-upload-tools/README_RUN_SYMBOL_TOOL.MD
@@ -1,0 +1,49 @@
+## Swift script used to upload a builds symbols to New Relic.
+### Intended to be run from a Xcode build phase.
+
+ 1. In Xcode, select your project in the navigator, then click on the application target.
+ 2. Select the Build Phases tab in the settings editor.
+ 3. Click the + icon above Target Dependencies and choose New Run Script Build Phase.
+ 4. Add the following lines of code to the new phase, pasting in the
+     application token as "APP_TOKEN" from your New Relic dashboard for the app in question.
+ 
+```
+    SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+    /bin/sh "${SCRIPT}" "APP_TOKEN"
+```
+
+Optional:
+
+Note: A few environment variables can be set to modify the behavior of the map or dSYM uploader.
+- DSYM_UPLOAD_URL: Host URL to use when uploading to New Relic. default: "https://mobile-symbol-upload.newrelic.com"
+- NEWRELIC_SYMBOL_ENDPOINT: Symbol endpoint. default: "map"
+- NEWRELIC_DSYM_ENDPOINT: Dsym endpoint. default: "symbol"
+- NEWRELIC_SYMBOL_POST_KEY: Symbol Post Key used in Curl. default: "upload"
+- NEWRELIC_DSYM_POST_KEY: Dsym Post Key used in Curl. default: "dsym"
+
+Add "--debug" after last line of script to enable debug logs in the output `upload_dsym_results.log` file.
+
+```
+    SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+    /bin/sh "${SCRIPT}" "APP_TOKEN" --debug
+```
+
+DSYM_UPLOAD_URL - define this environment variable above run script to override the New Relic server hostname
+
+
+```
+export DSYM_UPLOAD_URL="https://staging-mobile-symbol-upload.newrelic.com"
+```
+
+Repeat this line for each Env Var you'd like to set.
+
+```
+export NEWRELIC_SYMBOL_ENDPOINT="map2"
+```
+
+
+- Due to limitations with Swift scripting run-symbol-tool.swift is one file.
+   Main script contents are in start() func. Helper functions are categorized at the end.
+- Script will first attempt to convert each dSYM into NR map files, 
+   then it will combine map files into zip file and upload to New Relic.
+   If conversion isn't possible or zipped map files upload fails the dSYMs are uploaded to New Relic.

--- a/examples/spm/SPMExample/SPMExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/spm/SPMExample/SPMExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/newrelic/newrelic-ios-agent-spm.git",
       "state" : {
-        "revision" : "58899678b7afb2f50c6f584344a622376b887c06",
-        "version" : "7.4.8"
+        "revision" : "b86de5b23317262d820858cf7f61720547cced91",
+        "version" : "7.4.9"
       }
     }
   ],


### PR DESCRIPTION
https://new-relic.atlassian.net/browse/NR-231192 

Here is an example of the full curl from changes:

```
Executing $ curl --retry 3 --write-out %{http_code} --silent --output /dev/null -F upload=@"/Users/cdillard/Library/Caches/B785AEAD-D903-49A8-AAF3-4DB773885556/mapArchive.zip" -H "x-app-license-key: APP-TOKEN-NRMA" -H "X-NewRelic-Agent-Version: 7.4.10" -H "X-NewRelic-OS-Name: iOS" -H "X-NewRelic-Platform: Native" -H "X-NewRelic-App-Version: 1.2.3" -H "X-File-Size: 34193" https://mobile-symbol-upload.newrelic.com/map
```

Notice the new curl format we now will support a couple things:

We previously supported changing the host name via setting the env var  prior to the run-symbol-tool line:
eg:
export DSYM_UPLOAD_URL="https://staging-mobile-symbol-upload.newrelic.com"

Now we additionally support configuring:
- DSYM_UPLOAD_URL: Host URL to use when uploading to New Relic. default: “https://mobile-symbol-upload.newrelic.com”
- NEWRELIC_SYMBOL_ENDPOINT: Symbol endpoint. default: “map”
- NEWRELIC_DSYM_ENDPOINT: Dsym endpoint. default: “symbol”
- NEWRELIC_SYMBOL_POST_KEY: Symbol Post Key used in Curl. default: “upload”
- NEWRELIC_DSYM_POST_KEY: Dsym Post Key used in Curl. default: “dsym”


See new README_RUN_SYMBOL_TOOL.MD for all the details.


Curl Header Changes:
we’ve added the following headers:
X-NewRelic-Agent-Version: 7.4.10
X-NewRelic-OS-Name: iOS
X-NewRelic-Platform: Native
X-NewRelic-App-Version: 1.2.3
X-File-Size: 34193