### PR TITLE
Feature/NR-189606: Retrieve Static HTTP Headers

### DIFF
--- a/Agent/Public/NewRelic.h
+++ b/Agent/Public/NewRelic.h
@@ -624,8 +624,14 @@ extern "C" {
 /*******************************************************************************
  * Add a NSArray of NSStrings of the header
  * fields you want added to network events
- *******************************************************************************/
+ *******************************************************************************/ 
 +  (void)addHTTPHeaderTrackingFor:(NSArray<NSString*>*_Nonnull)headers;
+
+/*******************************************************************************
+ * Returns the NSArray of NSStrings of the header
+ * fields that were added to network events
+ *******************************************************************************/
++ (NSArray<NSString*>* _Nonnull)httpHeadersAddedForTracking;
 
 #pragma mark - Recording custom events
 

--- a/Agent/Public/NewRelic.m
+++ b/Agent/Public/NewRelic.m
@@ -337,6 +337,10 @@
     [NRMAHTTPUtilities addHTTPHeaderTrackingFor:headers];
 }
 
++ (NSArray<NSString*>* _Nonnull)httpHeadersAddedForTracking {
+    return [NRMAHTTPUtilities trackedHeaderFields];
+}
+
 
 #pragma mark - Interactions
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/API-Tests/NewRelicTests.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/API-Tests/NewRelicTests.m
@@ -376,26 +376,27 @@
 
 -(void) testAddHTTPHeaderTrackingDefault {
     XCTAssertNil([NewRelicAgentInternal sharedInstance]);
-    XCTAssertNotNil([NRMAHTTPUtilities trackedHeaderFields]);
-    XCTAssertTrue([[NRMAHTTPUtilities trackedHeaderFields] containsObject:@"X-APOLLO-OPERATION-NAME"]);
-    XCTAssertTrue([[NRMAHTTPUtilities trackedHeaderFields] containsObject:@"X-APOLLO-OPERATION-TYPE"]);
-    XCTAssertTrue([[NRMAHTTPUtilities trackedHeaderFields] containsObject:@"X-APOLLO-OPERATION-ID"]);
+//    [NewRelic httpHeadersAddedForTracking]
+    XCTAssertNotNil([NewRelic httpHeadersAddedForTracking]);
+    XCTAssertTrue([[NewRelic httpHeadersAddedForTracking] containsObject:@"X-APOLLO-OPERATION-NAME"]);
+    XCTAssertTrue([[NewRelic httpHeadersAddedForTracking] containsObject:@"X-APOLLO-OPERATION-TYPE"]);
+    XCTAssertTrue([[NewRelic httpHeadersAddedForTracking] containsObject:@"X-APOLLO-OPERATION-ID"]);
 }
 
 -(void) testAddHTTPHeaderTracking {
     XCTAssertNil([NewRelicAgentInternal sharedInstance]);
-
+    
     // Add a new header value to track
     [NewRelic addHTTPHeaderTrackingFor:@[@"Test"]];
 
-    XCTAssertNotNil([NRMAHTTPUtilities trackedHeaderFields]);
-    XCTAssertTrue([[NRMAHTTPUtilities trackedHeaderFields] containsObject:@"Test"]);
-    XCTAssertFalse([[NRMAHTTPUtilities trackedHeaderFields] containsObject:@"Fake"]);
+    XCTAssertNotNil([NewRelic httpHeadersAddedForTracking]);
+    XCTAssertTrue([[NewRelic httpHeadersAddedForTracking] containsObject:@"Test"]);
+    XCTAssertFalse([[NewRelic httpHeadersAddedForTracking] containsObject:@"Fake"]);
     
     // Make sure you can't add duplicates
-    NSUInteger count = [NRMAHTTPUtilities trackedHeaderFields].count;
+    NSUInteger count = [NewRelic httpHeadersAddedForTracking].count;
     [NewRelic addHTTPHeaderTrackingFor:@[@"Test", @"X-APOLLO-OPERATION-TYPE"]];
-    XCTAssertTrue([NRMAHTTPUtilities trackedHeaderFields].count == count);
+    XCTAssertTrue([NewRelic httpHeadersAddedForTracking].count == count);
 }
 
 -(void) testSetShutdown {


### PR DESCRIPTION
For use in hybrid agents, added an additional static method to retrieve additional tracked headers added to requests.