### PR TITLE
NR-256157: Remove Sample flag from traceState header for dist tracing

### DIFF
--- a/Agent/DistributedTracing/W3CTraceState.h
+++ b/Agent/DistributedTracing/W3CTraceState.h
@@ -23,7 +23,7 @@
 @property (strong) NSString*  appId;
 @property (strong) NSString*  spanId;
 @property (strong) NSString*  transactionId;
-@property          int        sampled;
+//@property          int        sampled;
 @property (strong) NSString*  priority;
 @property          long long  timestamp;
 

--- a/Agent/DistributedTracing/W3CTraceState.mm
+++ b/Agent/DistributedTracing/W3CTraceState.mm
@@ -29,28 +29,30 @@
 + (NSString *) getParentType {
     return @"2";
 }
-+ (NSString *) getSampled {
-    return @"0";
-}
+//+ (NSString *) getSampled {
+//    return @"0";
+//}
 + (NSString *) getPriority {
     return @"";
 }
 + (NSString *) headerFromContext:(NRMATraceContext*) traceContext {
-    NSString *formatStr = @"%@=%@-%@-%@-%@-%@-%@-%@-%@-%lld";
+                          //1  2  3  4  5  6  7   9  10
+    NSString *formatStr = @"%@=%@-%@-%@-%@-%@-%@-%@-%lld";
 
     // Do not base64 encode. traceContext.spanId should equal traceparent->parentId.
     NSString *headerString = [NSString stringWithFormat:formatStr,
-                              [W3CTraceState trustedAccountKeyFor: traceContext],
-                              [W3CTraceState getVersion],
-                              [W3CTraceState getParentType],
-                              traceContext.accountId,
-                              traceContext.appId,
-                              traceContext.spanId,
-                              traceContext.TRACE_FIELD_UNUSED,
-                              [W3CTraceState getSampled],
-                              [W3CTraceState getPriority],
-                              traceContext.timestamp];
-    
+                              [W3CTraceState trustedAccountKeyFor: traceContext], // 1
+                              [W3CTraceState getVersion],                         // 2
+                              [W3CTraceState getParentType],                      // 3
+                              traceContext.accountId,                             // 4
+                              traceContext.appId,                                 // 5
+                              traceContext.spanId,                                // 6
+                              traceContext.TRACE_FIELD_UNUSED,                    // 7
+                              // Note: We used to pass 0 as the sampled flag but the Language agent teams requested this change.
+//                              [W3CTraceState getSampled],                         // 8
+                              [W3CTraceState getPriority],                        // 9
+                              traceContext.timestamp];                            // 10
+
     return headerString;
 }
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/DistributedTesting-Tests/TestW3CTraceState.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/DistributedTesting-Tests/TestW3CTraceState.mm
@@ -45,7 +45,7 @@
     NRMATraceContext *traceContext = [[NRMATraceContext alloc] initWithPayload: payload];
     
     NSString *traceState = [W3CTraceState headerFromContext:traceContext];
-    NSString *desiredHeader = @"1@nr=0-2-10816994-25789457-17172750e6ff8549--0--1609970157093";
+    NSString *desiredHeader = @"1@nr=0-2-10816994-25789457-17172750e6ff8549---1609970157093";
     
     // assert
     XCTAssert([traceState isEqualToString: desiredHeader]);
@@ -63,7 +63,7 @@
     NRMATraceContext *traceContext = [[NRMATraceContext alloc] initWithNRMAPayload: payload];
     
     NSString *traceState = [W3CTraceState headerFromContext:traceContext];
-    NSString *desiredHeader = @"1@nr=0-2-10816994-25789457-17172750e6ff8549--0--1609970157093";
+    NSString *desiredHeader = @"1@nr=0-2-10816994-25789457-17172750e6ff8549---1609970157093";
     
     // assert
     XCTAssert([traceState isEqualToString: desiredHeader]);
@@ -86,7 +86,7 @@
     NRMATraceContext *traceContext = [[NRMATraceContext alloc] initWithPayload: payload];
     
     NSString *traceState = [W3CTraceState headerFromContext:traceContext];
-    NSString *desiredHeader = @"@nr=0-2-10816994-25789457-17172750e6ff8549--0--1609970157093";
+    NSString *desiredHeader = @"@nr=0-2-10816994-25789457-17172750e6ff8549---1609970157093";
 
     // assert
     XCTAssert([traceState isEqualToString: desiredHeader]);
@@ -106,7 +106,7 @@
     NRMATraceContext *traceContext = [[NRMATraceContext alloc] initWithNRMAPayload: payload];
     
     NSString *traceState = [W3CTraceState headerFromContext:traceContext];
-    NSString *desiredHeader = @"@nr=0-2-10816994-25789457-17172750e6ff8549--0--1609970157093";
+    NSString *desiredHeader = @"@nr=0-2-10816994-25789457-17172750e6ff8549---1609970157093";
 
     // assert
     XCTAssert([traceState isEqualToString: desiredHeader]);


### PR DESCRIPTION
The New Relic iOS agent used to send traceState header of the form:

`1@nr=0-2-10816994-25789457-17172750e6ff8549--0--1609970157093`

Where we have the following format:
```
                              [W3CTraceState trustedAccountKeyFor: traceContext], // 1
                              [W3CTraceState getVersion],                         // 2
                              [W3CTraceState getParentType],                      // 3
                              traceContext.accountId,                             // 4
                              traceContext.appId,                                 // 5
                              traceContext.spanId,                                // 6
                              traceContext.TRACE_FIELD_UNUSED,                    // 7
                              // Note: We used to pass 0 as the sampled flag but the Language agent teams requested this change.
//                              [W3CTraceState getSampled],                         // 8
                              [W3CTraceState getPriority],                        // 9
                              traceContext.timestamp];                            // 10
```

This PR changes the New Relic IOS agent to generate the traceState header without the isSampled flag. The output trace state header looks  like this:

`1@nr=0-2-10816994-25789457-17172750e6ff8549---1609970157093`

I validated in the Android agent that they are creating the trace state header the same way.

https://github.com/newrelic/newrelic-android-agent/blob/develop/agent-core/src/main/java/com/newrelic/agent/android/distributedtracing/TraceState.java#L29