### PR TITLE
WatchOS background exclude

### DIFF
--- a/Agent/Analytics/Events/NRMAMobileEvent.m
+++ b/Agent/Analytics/Events/NRMAMobileEvent.m
@@ -41,12 +41,14 @@ static NSString* const kAttributesKey = @"Attributes";
                 }
             }
         }
+#if !TARGET_OS_WATCH
         // Handle Background attribute addition.
         if([NRMAFlags shouldEnableBackgroundReporting]) {
             if ([NewRelicAgentInternal sharedInstance].currentApplicationState == UIApplicationStateBackground) {
                 [self addAttribute:kNRMA_Attrib_background value:@YES];
             }
         }
+#endif
     }
     
     return self;

--- a/Agent/Analytics/NRMAAnalytics.mm
+++ b/Agent/Analytics/NRMAAnalytics.mm
@@ -917,9 +917,11 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
 }
 
 - (BOOL) checkBackgroundStatus {
+#if !TARGET_OS_WATCH
     if([NRMAFlags shouldEnableBackgroundReporting]) {
         return ([NewRelicAgentInternal sharedInstance].currentApplicationState == UIApplicationStateBackground);
     }
+#endif
     return false;
 }
 

--- a/Agent/General/NewRelicAgentInternal.h
+++ b/Agent/General/NewRelicAgentInternal.h
@@ -13,8 +13,9 @@
 #import "NRMAUserActionFacade.h"
 #import "NRMAURLTransformer.h"
 
+#if !TARGET_OS_WATCH
 #import <BackgroundTasks/BackgroundTasks.h>
-
+#endif
 // Keys used for harvester data request.
 #define NEW_RELIC_APP_VERSION_HEADER_KEY        @"X-NewRelic-App-Version"
 #define NEW_RELIC_OS_NAME_HEADER_KEY            @"X-NewRelic-OS-Name"
@@ -46,8 +47,9 @@
 
 @property (nonatomic, assign) BOOL isShutdown;
 
+#if !TARGET_OS_WATCH
 @property (nonatomic, readonly, assign) UIApplicationState currentApplicationState;
-
+#endif
 + (void)shutdown;
 
 + (void)startWithApplicationToken:(NSString*)appToken

--- a/Agent/General/NewRelicAgentInternal.m
+++ b/Agent/General/NewRelicAgentInternal.m
@@ -159,6 +159,7 @@ static NewRelicAgentInternal* _sharedInstance;
     if (self) {
 
         // NOTE: BackgroundReporting is only enabled for iOS 13+.
+#if !TARGET_OS_WATCH
         if ([NRMAFlags shouldEnableBackgroundReporting]) {
             if (@available(iOS 13.0, *)) {
                 [[BGTaskScheduler sharedScheduler] registerForTaskWithIdentifier:[[NSBundle mainBundle] bundleIdentifier] usingQueue:nil launchHandler:^(__kindof BGTask * _Nonnull task) {
@@ -166,7 +167,7 @@ static NewRelicAgentInternal* _sharedInstance;
                 }];
             }
         }
-
+#endif
         self.appWillTerminate = NO;
         [NRMACPUVitals setAppStartCPUTime];
 #if TARGET_OS_WATCH
@@ -212,10 +213,11 @@ static NewRelicAgentInternal* _sharedInstance;
                                                        object:[UIApplication sharedApplication]];
 #endif
 
+#if !TARGET_OS_WATCH
             if ([NRMAFlags shouldEnableBackgroundReporting]) {
                 [[UIApplication sharedApplication] setMinimumBackgroundFetchInterval:UIApplicationBackgroundFetchIntervalMinimum];
             }
-
+#endif
             NRLOG_INFO(@"Agent enabled");
 
             // Store Data For Crash Reporter
@@ -570,8 +572,9 @@ static const NSString* kNRMA_APPLICATION_WILL_TERMINATE = @"com.newrelic.appWill
         return;
     }
 
+#if !TARGET_OS_WATCH
     _currentApplicationState = UIApplicationStateActive;
-
+#endif
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT,
                                              0),
                    ^{
@@ -676,8 +679,9 @@ static UIBackgroundTaskIdentifier background_task;
     // We are leaving the background.
     didFireEnterForeground = NO;
     
+#if !TARGET_OS_WATCH
     _currentApplicationState = UIApplicationStateBackground;
-
+#endif
     [[NRMAHarvestController harvestController].harvestTimer stop];
 
     // Disable observers.
@@ -889,6 +893,7 @@ void applicationDidEnterBackgroundCF(void) {
     return;
 }
 
+#if !TARGET_OS_WATCH
 // We only support background fetch in iOS 13+
 - (void) scheduleHeartbeatTask {
     if (@available(iOS 13.0, *)) {
@@ -935,7 +940,7 @@ void applicationDidEnterBackgroundCF(void) {
     }
 
 }
-
+#endif
 + (BOOL) harvestNow {
     return [NRMAHarvestController harvestNow];
 }

--- a/Agent/Harvester/NRMAHarvester.mm
+++ b/Agent/Harvester/NRMAHarvester.mm
@@ -365,12 +365,16 @@
     @try {
 #endif
         NSString *name;
+#if TARGET_OS_WATCH
+        name = kNRSupportabilityPrefix@"/Collector/Harvest";
+#else
         if ([NewRelicAgentInternal sharedInstance].currentApplicationState == UIApplicationStateBackground) {
             name = kNRSupportabilityPrefix@"/Collector/Harvest/Background";
         }
         else {
             name = kNRSupportabilityPrefix@"/Collector/Harvest";
         }
+#endif
         [NRMATaskQueue queue:[[NRMAMetric alloc] initWithName:name
                                                         value:[NSNumber numberWithDouble:harvestTimer.timeElapsedInSeconds]
                                                         scope:@""]];

--- a/Agent/Utilities/NewRelicInternalUtils.m
+++ b/Agent/Utilities/NewRelicInternalUtils.m
@@ -126,17 +126,11 @@ static NSString* _osVersion;
 + (NSString*) osName {
     // We do this to retain the "iOS" value. +systemName returns "iphone OS" for iOS now.
 #if TARGET_OS_WATCH
-    // TODO: When support exists, have this return WatchOS, not IOS
-//    return NRMA_OSNAME_WATCHOS;
-    return NRMA_OSNAME_IOS;
+    return NRMA_OSNAME_WATCHOS;
 #else
     if ([[[UIDevice currentDevice] systemName] isEqualToString:NRMA_OSNAME_TVOS]) {
         return NRMA_OSNAME_TVOS;
     }
-    else if([[[UIDevice currentDevice] systemName] isEqualToString:NRMA_OSNAME_WATCHOS]) {
-        return NRMA_OSNAME_WATCHOS;
-    }
-
 
     return NRMA_OSNAME_IOS;
 #endif
@@ -144,8 +138,6 @@ static NSString* _osVersion;
 
 + (NSString*) agentName {
 #if TARGET_OS_WATCH
-    // TODO: When support exists, have this return WatchOS, not IOS
-    return @"iOSAgent";
     return @"watchOSAgent";
 #else
     if ([[[UIDevice currentDevice] systemName] isEqualToString:NRMA_OSNAME_TVOS]) {

--- a/fastlane/BuildFastfile
+++ b/fastlane/BuildFastfile
@@ -61,7 +61,7 @@ platform :ios do
   end 
 
   desc "Build watchOS.xcarchive / watchOS Sim framework"
-  lane : buildWatchOS do 
+  lane :buildWatchOS do 
     # Build Device
     xcodebuild(
       archive: true,


### PR DESCRIPTION
The APIs that background relies on are not available for watchOS. For now I macro'd around it to get it to build. More research needed to include it.