### PR TITLE
[iOS] NR-266202: Adjust CryptoKit sha1 -> sha1256

### DIFF
--- a/Agent/Utilities/NRMAUDIDManager.m
+++ b/Agent/Utilities/NRMAUDIDManager.m
@@ -65,17 +65,22 @@ static __strong NSString* __UDID;
     if ([NRMAFlags shouldSaltDeviceUUID]) {
         // We use app ID as salt. This will prevent apps across bundle Ids sharing device Ids.
         NSString* clearStr = [[NRMAUDIDManager saltValue] stringByAppendingString:[NRMAUDIDManager deviceIdentifier]];
-        NSData* clearData = [clearStr dataUsingEncoding:NSUTF8StringEncoding];
-        uint8_t digest[CC_SHA1_DIGEST_LENGTH];
-        CC_SHA1([clearData bytes],(CC_LONG)clearData.length,digest);
-        NSMutableString* output = [NSMutableString stringWithCapacity:CC_SHA1_DIGEST_LENGTH * 2];
-        for (int i = 0; i < CC_SHA1_DIGEST_LENGTH; i++) {
-            [output appendFormat:@"%02x",digest[i]];
-        }
+        NSString *output = [NRMAUDIDManager sha256Hash:clearStr];
         return output;
     } else {
         return [NRMAUDIDManager deviceIdentifier];
     }
+}
+
++ (NSString*)sha256Hash:(NSString*)text {
+    const char* chars = [text UTF8String];
+    unsigned char result[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(chars, (CC_LONG)strlen(chars), result);
+    NSMutableString *ret = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH*2];
+    for(int i = 0; i<CC_SHA256_DIGEST_LENGTH; i++) {
+        [ret appendFormat:@"%02x",result[i]];
+    }
+    return ret;
 }
 
 + (NSString*) saltValue {

--- a/Test Harness/NRTestApp/NRTestApp/AppDelegate.swift
+++ b/Test Harness/NRTestApp/NRTestApp/AppDelegate.swift
@@ -46,7 +46,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         //NRLogger.setLogTargets(NRLogTargetConsole.rawValue | NRLogTargetFile.rawValue)
 
 
-        NewRelic.replaceDeviceIdentifier("myDeviceId")
+        NewRelic.saltDeviceUUID(true)
+
+       // NewRelic.replaceDeviceIdentifier("myDeviceId")
         
         NewRelic.setMaxEventPoolSize(5000)
         NewRelic.setMaxEventBufferTime(60)

--- a/Test Harness/NRTestApp/NRTestApp/Helpers/NewRelic+Replace.h
+++ b/Test Harness/NRTestApp/NRTestApp/Helpers/NewRelic+Replace.h
@@ -9,4 +9,5 @@
 
 @interface NewRelic (Replace)
 + (void) replaceDeviceIdentifier:(NSString*)identifier;
++ (void) saltDeviceUUID:(BOOL)enabled;
 @end


### PR DESCRIPTION
https://new-relic.atlassian.net/browse/NR-266202 


**Description**

Hero request received related to code in the new relic agent related to cryptography

> Hi hero, Capital One shared this:“We recently have received a new security finding from our DAST tool Data Theorem that the New Relic iOS agent is in violation for Hash Generated Using Broken Cryptography API (SHA1) due to the vulnerable code locations use the CC_SHA1 or CryptoKit.Insecure.SHA1 hashing functions, which leverage hashing algorithms that are proven to be vulnerable to collision attacks, and are unsuitable for modern use..Looking at the open source Agent this looks to be in NRMAUDIDManager for secureUDIDStore, getUDID & setUDID.
Would it be possible to look to get an update when these are updated to use SHA512 instead of CC_SHA1? If so, what would be the timeline for such an update?”
Thanks for your help with this!



**Acceptance Criteria:** 

Remove all the code related to sha1 encryption that the agent uses so its not in violation anymore. 
