### PR TITLE
NR-264174 - Retain/Release for _sessionStartTime

### DIFF
--- a/Agent/Analytics/NRMAAnalytics.mm
+++ b/Agent/Analytics/NRMAAnalytics.mm
@@ -239,6 +239,8 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
         } else {
             _sessionStartTime = [NSDate dateWithTimeIntervalSince1970:(sessionStartTime/1000)];
         }
+        
+        [_sessionStartTime retain];
     }
     return self;
 }
@@ -248,6 +250,7 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
     [_eventManager dealloc];
     [_sessionAttributeManager dealloc];
     [_attributeValidator release];
+    [_sessionStartTime release]
 
     [super dealloc];
 }

--- a/Agent/Analytics/NRMAAnalytics.mm
+++ b/Agent/Analytics/NRMAAnalytics.mm
@@ -250,7 +250,7 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
     [_eventManager dealloc];
     [_sessionAttributeManager dealloc];
     [_attributeValidator release];
-    [_sessionStartTime release]
+    [_sessionStartTime release];
 
     [super dealloc];
 }


### PR DESCRIPTION
On WatchOS, potentially due to having less memory, the NSDate object pointed to by _sessionStartTime becomes deallocated during a run. As this file does not use ARC, explicit retain/release calls need to be added to ensure the object is held on to.