### PR TITLE
NR-261761: NSSecureCoding

### DIFF
--- a/Agent/Analytics/Events/NRMAMobileEvent.h
+++ b/Agent/Analytics/Events/NRMAMobileEvent.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
  
-@interface NRMAMobileEvent : NSObject <NRMAAnalyticEventProtocol, NSCoding>
+@interface NRMAMobileEvent : NSObject <NRMAAnalyticEventProtocol, NSSecureCoding>
 
 @property  NSTimeInterval timestamp;
 @property  NSTimeInterval sessionElapsedTimeSeconds;

--- a/Agent/Analytics/NRMAAnalyticEventProtocol.h
+++ b/Agent/Analytics/NRMAAnalyticEventProtocol.h
@@ -11,7 +11,7 @@
 
 #import "NRMAJSON.h"
 
-@protocol NRMAAnalyticEventProtocol <NSObject, NRMAJSONABLE, NSCoding>
+@protocol NRMAAnalyticEventProtocol <NSObject, NRMAJSONABLE, NSSecureCoding>
 
 @property (readonly) NSTimeInterval timestamp;
 @property (readonly) NSTimeInterval sessionElapsedTimeSeconds;

--- a/Agent/Analytics/NRMAPayload.h
+++ b/Agent/Analytics/NRMAPayload.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NRMAPayload : NSObject <NRMAJSONABLE, NSCoding>
+@interface NRMAPayload : NSObject <NRMAJSONABLE, NSSecureCoding>
 @property  NSTimeInterval timestamp;
 @property (nonatomic, strong) NSString *payloadType;
 @property (nonatomic, strong) NSString *accountId;


### PR DESCRIPTION
This PR replaces the New Relic iOS agent usage of NSCoding with NSSecureCoding.

More information in JIRA ticket here: https://new-relic.atlassian.net/browse/NR-261761

> Capital One has found that, in our open source agent, there are several instances where NSCoding is used instead of the more secure NSSecureCoding. The files indicated by them are NRMAAnalyticEventProtocol, NRMAMobileEvent, and NRMAPayload. We should investigate whether these can be updated to use NSSecureCoding, and if possible, do so. 