### PR TITLE
Feature/NR-270936 - watchOS Orientation Reporting

### DIFF
--- a/Agent/General/NewRelicAgentInternal.m
+++ b/Agent/General/NewRelicAgentInternal.m
@@ -399,10 +399,11 @@ static NewRelicAgentInternal* _sharedInstance;
     if (![NRMACollectionViewInstrumentation instrument]) {
         NRLOG_VERBOSE(@"Failed to instrument UICollectionView.");
     }
-#endif
     if (![NRMAGestureRecognizerInstrumentation instrumentUIGestureRecognizer]) {
         NRLOG_VERBOSE(@"Failed to instrument gesture recognizer.");
     }
+#endif
+
 }
 
 // De-initialize agent instrumentation

--- a/Agent/Utilities/NewRelicInternalUtils.m
+++ b/Agent/Utilities/NewRelicInternalUtils.m
@@ -324,9 +324,28 @@ static NSString* _osVersion;
 }
 
 + (NSString*) deviceOrientation {
-
-
-#if !TARGET_OS_TV && !TARGET_OS_WATCH
+#if TARGET_OS_TV
+    return @"Landscape";
+#elif TARGET_OS_WATCH
+    NSMutableString *orientation = [NSMutableString string];
+    if([[WKInterfaceDevice currentDevice] wristLocation] == WKInterfaceDeviceWristLocationLeft) {
+        [orientation appendString:@"Left Wrist - "];
+    } else {
+        [orientation appendString:@"Right Wrist - "];
+    }
+    
+    if([[WKInterfaceDevice currentDevice] crownOrientation] == WKInterfaceDeviceCrownOrientationLeft) {
+        [orientation appendString:@"Crown Left"];
+    } else {
+        [orientation appendString:@"Crown Right"];
+    }
+    
+    if([WKExtension sharedExtension].autorotated ) {
+        [orientation appendString:@" - Autorotated"];
+    }
+    
+    return [NSString stringWithString:orientation];
+#else
     switch ([[UIDevice currentDevice] orientation]) {
         case UIDeviceOrientationLandscapeLeft:
         case UIDeviceOrientationLandscapeRight:
@@ -346,8 +365,6 @@ static NSString* _osVersion;
             return @"Unknown";
             break;
     }
-#else
-    return @"Landscape";
 #endif
 }
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMAAnalyticsTest.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMAAnalyticsTest.mm
@@ -1114,10 +1114,13 @@
     XCTAssertTrue([decode[0][@"controlRect"] isEqualToString:@"{{1, 1}, {1, 1}}"]);
     XCTAssertTrue([decode[0][@"touchCoordinates"] isEqualToString:@"{1, 1}"]);
     
-#if !TARGET_OS_TV
-    XCTAssertTrue([decode[0][@"orientation"] isEqualToString:@"Unknown"]);
-#else
+#if TARGET_OS_TV
     XCTAssertTrue([decode[0][@"orientation"] isEqualToString:@"Landscape"]);
+
+#elif TARGET_OS_WATCH
+    XCTAssertTrue(decode[0][@"orientation"] != nil);
+#else
+    XCTAssertTrue([decode[0][@"orientation"] isEqualToString:@"Unknown"]);
 #endif
 }
 


### PR DESCRIPTION
Instead of being hardcoded to "Landscape" like tvOS, watchOS now reports what wrist the device is on, whether the crown is on the left or right side of the device, and if the display has been autorotated. Autorotation would be the case if the user has flipped their wrist to show someone else the screen, for instance.