### PR TITLE
NR-283336: Fix missing attribs - call createDirectoryAtPath when hex disabled.

### DIFF
--- a/Agent/Analytics/Events/NRMAMobileEvent.m
+++ b/Agent/Analytics/Events/NRMAMobileEvent.m
@@ -105,7 +105,7 @@ static NSString* const kAttributesKey = @"Attributes";
         self.timestamp = [coder decodeDoubleForKey:kTimestampKey];
         self.sessionElapsedTimeSeconds = [coder decodeDoubleForKey:kSessionElapsedTimeKey];
         self.eventType = [coder decodeObjectOfClass:[NSString class] forKey:kEventTypeKey];
-        self.attributes = [coder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class],[NSMutableDictionary class],[NSString class]]] forKey:kAttributesKey];
+        self.attributes = [coder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class],[NSMutableDictionary class],[NSString class],[NSNumber class]]] forKey:kAttributesKey];
     }
     
     return self;

--- a/Agent/Analytics/PersistentEventStore.m
+++ b/Agent/Analytics/PersistentEventStore.m
@@ -128,7 +128,7 @@
     }
 
     NSKeyedUnarchiver* unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:storedData error:error];
-    NSDictionary* storedDictionary = [unarchiver decodeObjectOfClasses:[[NSSet alloc] initWithArray:@[[NRMAMobileEvent class],[NSMutableDictionary class],[NSDictionary class],[NSString class], [NSNumber class]]] forKey:NSKeyedArchiveRootObjectKey];
+    NSDictionary* storedDictionary = [unarchiver decodeObjectOfClasses:[[NSSet alloc] initWithArray:@[[NRMAMobileEvent class],[NSMutableDictionary class],[NSDictionary class],[NSString class],[NSNumber class]]] forKey:NSKeyedArchiveRootObjectKey];
 
     if(storedDictionary == nil) {
         if(error != NULL && *error != nil) {
@@ -177,7 +177,7 @@
     }
 
     NSKeyedUnarchiver* unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:storedData error:error];
-    NSDictionary* storedDictionary = [unarchiver decodeObjectOfClasses:[[NSSet alloc] initWithArray:@[[NRMAMobileEvent class],[NSMutableDictionary class],[NSDictionary class],[NSString class], [NSNumber class]]] forKey:NSKeyedArchiveRootObjectKey];
+    NSDictionary* storedDictionary = [unarchiver decodeObjectOfClasses:[[NSSet alloc] initWithArray:@[[NRMAMobileEvent class],[NSMutableDictionary class],[NSDictionary class],[NSString class],[NSNumber class]]] forKey:NSKeyedArchiveRootObjectKey];
 
     if(storedDictionary == nil) {
         if(error != NULL && *error != nil) {

--- a/Agent/General/NewRelicAgentInternal.m
+++ b/Agent/General/NewRelicAgentInternal.m
@@ -546,7 +546,7 @@ static NSString* kNRMAAnalyticsInitializationLock = @"AnalyticsInitializationLoc
 #endif
     }
 
-    NSString* backupStorePath = [NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kHexBackupStoreFolder];
+    NSString* backupStorePath = [NSString stringWithFormat:@"%@",[NewRelicInternalUtils getStorePath]];
 
     [[NSFileManager defaultManager] createDirectoryAtPath:backupStorePath
                               withIntermediateDirectories:YES

--- a/Agent/General/NewRelicAgentInternal.m
+++ b/Agent/General/NewRelicAgentInternal.m
@@ -534,6 +534,17 @@ static NSString* kNRMAAnalyticsInitializationLock = @"AnalyticsInitializationLoc
     NRMA_setSessionStartTime([NSString stringWithFormat:@"%lld",
                               (long long)NRMAMillisecondTimestamp()].UTF8String);
 
+    NSString* backupStorePath = [NSString stringWithFormat:@"%@",[NewRelicInternalUtils getStorePath]];
+    NSError* error = nil;
+
+    [[NSFileManager defaultManager] createDirectoryAtPath:backupStorePath
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:&error];
+    if (error) {
+        NRLOG_AGENT_ERROR(@"NEWRELIC SETUP - Failed to create store directory: %@",error);
+    }
+
     // Initializing analytics take a while. Take care executing time sensitive code after this point the since initializeAnalytics method will delay its execution.
     [self initializeAnalytics];
     NRMAReachability* r = [NewRelicInternalUtils reachability];
@@ -545,13 +556,6 @@ static NSString* kNRMAAnalyticsInitializationLock = @"AnalyticsInitializationLoc
         status = [r currentReachabilityStatus];
 #endif
     }
-
-    NSString* backupStorePath = [NSString stringWithFormat:@"%@",[NewRelicInternalUtils getStorePath]];
-
-    [[NSFileManager defaultManager] createDirectoryAtPath:backupStorePath
-                              withIntermediateDirectories:YES
-                                               attributes:nil
-                                                    error:nil];
 
     if ([NRMAFlags shouldEnableHandledExceptionEvents]) {
         self.handledExceptionsController = [[NRMAHandledExceptions alloc] initWithAnalyticsController:self.analyticsController

--- a/Agent/General/NewRelicAgentInternal.m
+++ b/Agent/General/NewRelicAgentInternal.m
@@ -545,13 +545,20 @@ static NSString* kNRMAAnalyticsInitializationLock = @"AnalyticsInitializationLoc
         status = [r currentReachabilityStatus];
 #endif
     }
+
+    NSString* backupStorePath = [NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kHexBackupStoreFolder];
+
+    [[NSFileManager defaultManager] createDirectoryAtPath:backupStorePath
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+
     if ([NRMAFlags shouldEnableHandledExceptionEvents]) {
         self.handledExceptionsController = [[NRMAHandledExceptions alloc] initWithAnalyticsController:self.analyticsController
                                                                                      sessionStartTime:self.appSessionStartDate
                                                                                    agentConfiguration:self.agentConfiguration
                                                                                              platform:[NewRelicInternalUtils osName]
                                                                                             sessionId:[self currentSessionId]];
-
 
         if (status != NotReachable) { // Because we support offline mode check if we're online before sending the handled exceptions
             [self.handledExceptionsController processAndPublishPersistedReports];
@@ -560,14 +567,7 @@ static NSString* kNRMAAnalyticsInitializationLock = @"AnalyticsInitializationLoc
         [NRMAHarvestController addHarvestListener:self.handledExceptionsController];
 
     }
-    else {
-        NSString* backupStorePath = [NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kHexBackupStoreFolder];
 
-        [[NSFileManager defaultManager] createDirectoryAtPath:backupStorePath
-                                  withIntermediateDirectories:YES
-                                                   attributes:nil
-                                                        error:nil];
-    }
     [self.analyticsController setNRSessionAttribute:@"sessionId"
                                               value:self->_agentConfiguration.sessionIdentifier];
 

--- a/Agent/General/NewRelicAgentInternal.m
+++ b/Agent/General/NewRelicAgentInternal.m
@@ -560,6 +560,14 @@ static NSString* kNRMAAnalyticsInitializationLock = @"AnalyticsInitializationLoc
         [NRMAHarvestController addHarvestListener:self.handledExceptionsController];
 
     }
+    else {
+        NSString* backupStorePath = [NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kHexBackupStoreFolder];
+
+        [[NSFileManager defaultManager] createDirectoryAtPath:backupStorePath
+                                  withIntermediateDirectories:YES
+                                                   attributes:nil
+                                                        error:nil];
+    }
     [self.analyticsController setNRSessionAttribute:@"sessionId"
                                               value:self->_agentConfiguration.sessionIdentifier];
 

--- a/Agent/HandledException/NRMAHandledExceptions.mm
+++ b/Agent/HandledException/NRMAHandledExceptions.mm
@@ -114,13 +114,7 @@ const NSString* kHexBackupStoreFolder = @"hexbkup/";
                                                                         version.UTF8String,
                                                                         collectorHost.UTF8String);
 
-
         NSString* backupStorePath = [NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kHexBackupStoreFolder];
-
-        [[NSFileManager defaultManager] createDirectoryAtPath:backupStorePath
-                                  withIntermediateDirectories:YES
-                                                   attributes:nil
-                                                        error:nil];
 
         _store = std::make_shared<NewRelic::Hex::HexStore>(backupStorePath.UTF8String);
 

--- a/Agent/HandledException/NRMAHandledExceptions.mm
+++ b/Agent/HandledException/NRMAHandledExceptions.mm
@@ -115,11 +115,15 @@ const NSString* kHexBackupStoreFolder = @"hexbkup/";
                                                                         collectorHost.UTF8String);
 
         NSString* backupStorePath = [NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kHexBackupStoreFolder];
+        NSError* error = nil;
 
         [[NSFileManager defaultManager] createDirectoryAtPath:backupStorePath
                                   withIntermediateDirectories:YES
                                                    attributes:nil
-                                                        error:nil];
+                                                        error:&error];
+        if (error) {
+            NRLOG_AGENT_ERROR(@"NEWRELIC SETUP - Failed to create handled exceptions directory: %@",error);
+        }
 
         _store = std::make_shared<NewRelic::Hex::HexStore>(backupStorePath.UTF8String);
 

--- a/Agent/HandledException/NRMAHandledExceptions.mm
+++ b/Agent/HandledException/NRMAHandledExceptions.mm
@@ -116,6 +116,11 @@ const NSString* kHexBackupStoreFolder = @"hexbkup/";
 
         NSString* backupStorePath = [NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kHexBackupStoreFolder];
 
+        [[NSFileManager defaultManager] createDirectoryAtPath:backupStorePath
+                                  withIntermediateDirectories:YES
+                                                   attributes:nil
+                                                        error:nil];
+
         _store = std::make_shared<NewRelic::Hex::HexStore>(backupStorePath.UTF8String);
 
         _persistenceManager = std::make_shared<NewRelic::Hex::HexPersistenceManager>(_store,_publisher);

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/PersistentStoreTests.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/PersistentStoreTests.m
@@ -56,7 +56,7 @@
         self.timestamp = [coder decodeDoubleForKey:@"Timestamp"];
         self.sessionElapsedTimeSeconds = [coder decodeDoubleForKey:@"SessionElapsedTimeInSeconds"];
         self.eventType = [coder decodeObjectOfClass:[NSString class] forKey:@"EventType"];
-        self.attributes = [coder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class],[NSMutableDictionary class],[NSString class]]] forKey:@"Attributes"];
+        self.attributes = [coder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class],[NSMutableDictionary class],[NSString class],[NSNumber class]]] forKey:@"Attributes"];
     }
     
     return self;
@@ -145,7 +145,7 @@ static NSTimeInterval shortTimeInterval = 10;
         NSData *retrievedData = [NSData dataWithContentsOfFile:testFilename];
         NSError *error = nil;
         NSKeyedUnarchiver* unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:retrievedData error:&error];
-        NSDictionary* retrievedDictionary = [unarchiver decodeObjectOfClasses:[[NSSet alloc] initWithArray:@[[NRMAMobileEvent class],[NSDictionary class],[NSMutableDictionary class],[NSString class], [NSNumber class]]] forKey:NSKeyedArchiveRootObjectKey];
+        NSDictionary* retrievedDictionary = [unarchiver decodeObjectOfClasses:[[NSSet alloc] initWithArray:@[[NRMAMobileEvent class],[NSDictionary class],[NSMutableDictionary class],[NSString class],[NSNumber class]]] forKey:NSKeyedArchiveRootObjectKey];
         if(retrievedDictionary.count == 1) {
             NSLog(@"Initial file found and full");
             NSDictionary *attributes = ((NRMAMobileEvent *)retrievedDictionary[@"aKey"]).attributes;
@@ -185,7 +185,7 @@ static NSTimeInterval shortTimeInterval = 10;
     NSData *retrievedData = [NSData dataWithContentsOfFile:testFilename];
     NSError *error = nil;
     NSKeyedUnarchiver* unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:retrievedData error:&error];
-    NSDictionary* retrievedDictionary = [unarchiver decodeObjectOfClasses:[[NSSet alloc] initWithArray:@[[NRMAMobileEvent class],[NSDictionary class],[NSMutableDictionary class],[NSString class], [NSNumber class]]] forKey:NSKeyedArchiveRootObjectKey];
+    NSDictionary* retrievedDictionary = [unarchiver decodeObjectOfClasses:[[NSSet alloc] initWithArray:@[[NRMAMobileEvent class],[NSDictionary class],[NSMutableDictionary class],[NSString class],[NSNumber class]]] forKey:NSKeyedArchiveRootObjectKey];
 
     XCTAssertNil(error, "Error testing file written: %@", [error localizedDescription]);
     XCTAssertEqual([retrievedDictionary count], 1);
@@ -225,7 +225,7 @@ static NSTimeInterval shortTimeInterval = 10;
         NSData *retrievedData = [NSData dataWithContentsOfFile:testFilename];
         NSError *error = nil;
         NSKeyedUnarchiver* unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:retrievedData error:&error];
-        NSDictionary* retrievedDictionary = [unarchiver decodeObjectOfClasses:[[NSSet alloc] initWithArray:@[[NRMAMobileEvent class],[NSDictionary class],[NSMutableDictionary class],[NSString class], [NSNumber class]]] forKey:NSKeyedArchiveRootObjectKey];
+        NSDictionary* retrievedDictionary = [unarchiver decodeObjectOfClasses:[[NSSet alloc] initWithArray:@[[NRMAMobileEvent class],[NSDictionary class],[NSMutableDictionary class],[NSString class],[NSNumber class]]] forKey:NSKeyedArchiveRootObjectKey];
 
         if(retrievedDictionary.count == 3) {
             NSLog(@"Initial file found and full");
@@ -311,7 +311,7 @@ static NSTimeInterval shortTimeInterval = 10;
         NSError *error = nil;
 
         NSKeyedUnarchiver* unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:retrievedData error:&error];
-        NSDictionary* retrievedDictionary = [unarchiver decodeObjectOfClasses:[[NSSet alloc] initWithArray:@[[NRMAMobileEvent class],[NSDictionary class],[NSMutableDictionary class],[NSString class], [NSNumber class]]] forKey:NSKeyedArchiveRootObjectKey];
+        NSDictionary* retrievedDictionary = [unarchiver decodeObjectOfClasses:[[NSSet alloc] initWithArray:@[[NRMAMobileEvent class],[NSDictionary class],[NSMutableDictionary class],[NSString class],[NSNumber class]]] forKey:NSKeyedArchiveRootObjectKey];
 
         if(retrievedDictionary.count == 3) {
             NSLog(@"Initial file found and full");


### PR DESCRIPTION
This PR corrects the NewRelicAgentInternal start class to create requisite folders on launch, regardless of whether or not handled exceptions are enabled.

Missing from previous NSSecureCoding PR.  I think that [NSNumber class] is needed in MobileEvent as well , missed that in the NSSecureCoding PR