### PR TITLE
NR-160576 change to make sure the minimum time is respected.

### DIFF
--- a/Agent/Analytics/NRMAEventManager.m
+++ b/Agent/Analytics/NRMAEventManager.m
@@ -17,6 +17,7 @@
 static const NSUInteger kDefaultBufferSize = 1000;
 static const NSUInteger kDefaultBufferTimeSeconds = 600; // 10 Minutes
 static const NSUInteger kMinBufferTimeSeconds = 60; // 60 seconds
+static const NSUInteger kBufferTimeSecondsLeeway = 60; // 60 seconds
 
 // Event Key Format String: TimeStamp|SessionElapsedTime|EventType
 static NSString* const eventKeyFormat = @"%f|%f|%@";
@@ -76,7 +77,7 @@ static NSString* const eventKeyFormat = @"%f|%f|%@";
     }
     
     NSTimeInterval oldestEventAge = currentTimeMilliseconds - oldestEventTimestamp;
-    return (oldestEventAge / 1000) >= maxBufferTimeSeconds;
+    return (oldestEventAge / 1000) + kBufferTimeSecondsLeeway >= maxBufferTimeSeconds;
 }
 
 - (NSUInteger)getEvictionIndex {

--- a/libMobileAgent/src/Analytics/src/EventManager.cxx
+++ b/libMobileAgent/src/Analytics/src/EventManager.cxx
@@ -11,6 +11,8 @@
 #include "Analytics/EventDeserializer.hpp"
 #include "Analytics/EventBufferConfig.hpp"
 
+static const int kBufferTimeSecondsLeeway = 60; // 60 seconds
+
 namespace NewRelic {
 
 EventManager::EventManager(PersistentStore<std::string, AnalyticEvent>& store) :
@@ -25,7 +27,7 @@ EventManager::~EventManager() {
 bool EventManager::didReachMaxQueueTime(unsigned long long currentTimestamp_ms) {
     if (_oldest_event_timestamp_ms == 0) return false; //default value of _oldest_event_timestamp_ms
     unsigned long long oldest_event_age_ms = currentTimestamp_ms - _oldest_event_timestamp_ms;
-    return oldest_event_age_ms / 1000 >= EventBufferConfig::getInstance().get_max_buffer_time_sec();
+    return (oldest_event_age_ms / 1000) + kBufferTimeSecondsLeeway >= EventBufferConfig::getInstance().get_max_buffer_time_sec();
 }
 
 void EventManager::setMaxBufferSize(unsigned int size) {


### PR DESCRIPTION
This PR changes the maxQueueTime detection to account for the 1 min harvest cycle. This change allows events to be harvested within the maxBufferTime instead of the minute after when the harvest cycle ticks.

- Scenario 1: No events in the queue. 
      Events will not be harvested
- Scenario 2: maxBufferTimeSeconds = 60 seconds. 
       As long as an event exists it will be harvested every harvest cycle.(1 min)
- Scenario 3: maxBufferTimeSeconds = 600 seconds. 
       Events will be sent when the oldest event is between 541-600 seconds old at the harvest cycle tick.
