### PR TITLE
Nr-296083: Fix up getSessionAttributesResultMap to nil check sess attribs

### DIFF
--- a/Agent/Analytics/NRMAAnalytics.mm
+++ b/Agent/Analytics/NRMAAnalytics.mm
@@ -167,7 +167,7 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
 
 
             NSString* attributes = [self sessionAttributeJSONString];
-            if (attributes != nil) {
+            if (attributes != nil && [attributes length] > 0) {
                 NSDictionary* dictionary = [NSJSONSerialization JSONObjectWithData:[attributes dataUsingEncoding:NSUTF8StringEncoding]
                                                                            options:0
                                                                              error:nil];
@@ -207,7 +207,7 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
             //They can be removed now and it shouldn't interfere with the generation
             //of these attributes if it should occur.
             NSString* attributes = [self sessionAttributeJSONString];
-            if (attributes != nil) {
+            if (attributes != nil && [attributes length] > 0) {
                 NSDictionary* dictionary = [NSJSONSerialization JSONObjectWithData:[attributes dataUsingEncoding:NSUTF8StringEncoding]
                                                                            options:0
                                                                              error:nil];

--- a/Agent/HandledException/NRMAHandledExceptions.mm
+++ b/Agent/HandledException/NRMAHandledExceptions.mm
@@ -396,13 +396,17 @@ const NSString* kHexBackupStoreFolder = @"hexbkup/";
 }
 
 - (std::map<std::string, std::shared_ptr<NewRelic::AttributeBase> >) getSessionAttributesResultMap {
-    NSString *sessionAttributes = [analyticsParent sessionAttributeJSONString];
-    NSDictionary* dictionary = [NSJSONSerialization JSONObjectWithData:[sessionAttributes dataUsingEncoding:NSUTF8StringEncoding]
-                                                               options:0
-                                                                 error:nil];
 
     // Convert NSDictionary => std::map<std::string, std::shared_ptr<NewRelic::AttributeBase> >
     std::map<std::string, std::shared_ptr<NewRelic::AttributeBase> > resultMap;
+
+    NSString *sessionAttributes = [analyticsParent sessionAttributeJSONString];
+    if (sessionAttributes == nil || [sessionAttributes length] == 0) {
+        return resultMap;
+    }
+    NSDictionary* dictionary = [NSJSONSerialization JSONObjectWithData:[sessionAttributes dataUsingEncoding:NSUTF8StringEncoding]
+                                                               options:0
+                                                                 error:nil];
 
     for (NSString *key in dictionary) {
         id value = [dictionary objectForKey:key];

--- a/Agent/Public/NRMAExceptionHandlerStartupManager.m
+++ b/Agent/Public/NRMAExceptionHandlerStartupManager.m
@@ -32,9 +32,12 @@
             NSDictionary* attributes;
 
             @try {
-                events = [NSJSONSerialization JSONObjectWithData:[self.eventJson dataUsingEncoding:NSUTF8StringEncoding]
-                                                         options:0
-                                                           error:&serializationError];
+                if (self.eventJson != nil && [self.eventJson length] > 0) {
+
+                    events = [NSJSONSerialization JSONObjectWithData:[self.eventJson dataUsingEncoding:NSUTF8StringEncoding]
+                                                             options:0
+                                                               error:&serializationError];
+                }
                 if (serializationError != nil) {
                     NRLOG_AGENT_VERBOSE(@"Failed to load last session's events for crash: %@",serializationError.localizedDescription);
                 }
@@ -43,9 +46,12 @@
             }
 
             @try {
-                attributes = [NSJSONSerialization JSONObjectWithData:[self.attributeJson dataUsingEncoding:NSUTF8StringEncoding]
-                                                             options:0
-                                                               error:&serializationError];
+                if (self.attributeJson != nil && [self.attributeJson length] > 0) {
+
+                    attributes = [NSJSONSerialization JSONObjectWithData:[self.attributeJson dataUsingEncoding:NSUTF8StringEncoding]
+                                                                 options:0
+                                                                   error:&serializationError];
+                }
                 if (serializationError != nil) {
                     NRLOG_AGENT_VERBOSE(@"Failed to load last session's attribute for crash: %@",serializationError.localizedDescription);
                 }


### PR DESCRIPTION
Hybrid agent - Flutter is experiencing a crash when calling recordHandledException. I wasn't able to reproduce it or create a test that reproduces it, but this code should protect us against passing nil to JSONObjectWithData.

add some protection places we use sessionAttributeJSONString + NSJSONSerialization JSONObjectWithData