### PR TITLE
Fixes issue building any app that consumes this package via SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
- There was a recent change that added support for `.tvOS(.v9)` `.watchOS(.v10)` without updating the swift tools version to match
  - See: https://github.com/newrelic/newrelic-ios-agent/pull/291
  - This causes an error building any app that consumes this package via SPM

```
PackageDescription.SupportedPlatform:99:27: note: 'v10' was introduced in PackageDescription 5.9
        public static let v10: PackageDescription.SupportedPlatform.WatchOSVersion
                          ^ in https://github.com/newrelic/newrelic-ios-agent-spm
```