### PR TITLE
NR-305349 - NRMAAnalytics lazy initialization

### DIFF
--- a/Agent/Analytics/NRMAAnalytics.h
+++ b/Agent/Analytics/NRMAAnalytics.h
@@ -35,6 +35,7 @@
 
 - (void) sessionWillEnd;
 - (void) newSession;
+- (void) newSessionWithStartTime:(long long) sessionStartTime;
 
 //value is either a NSString or NSNumber;
 - (BOOL) setSessionAttribute:(NSString*)name value:(id)value;

--- a/Agent/General/NewRelicAgentInternal.m
+++ b/Agent/General/NewRelicAgentInternal.m
@@ -445,7 +445,9 @@ static NSString* kNRMAAnalyticsInitializationLock = @"AnalyticsInitializationLoc
 - (void) initializeAnalytics {
     @synchronized(kNRMAAnalyticsInitializationLock) {
         // [NRMAAnalytics clearDuplicationStores];
-        self.analyticsController = [[NRMAAnalytics alloc] initWithSessionStartTimeMS:(long long)([self.appSessionStartDate timeIntervalSince1970] * 1000)];
+        if(!self.analyticsController) {
+            self.analyticsController = [[NRMAAnalytics alloc] initWithSessionStartTimeMS:(long long)([self.appSessionStartDate timeIntervalSince1970] * 1000)];
+        }
     }
 
     [[NSNotificationCenter defaultCenter] postNotificationName:kNRMAAnalyticsInitializedNotification

--- a/Agent/General/NewRelicAgentInternal.m
+++ b/Agent/General/NewRelicAgentInternal.m
@@ -447,7 +447,13 @@ static NSString* kNRMAAnalyticsInitializationLock = @"AnalyticsInitializationLoc
         // [NRMAAnalytics clearDuplicationStores];
         if(!self.analyticsController) {
             self.analyticsController = [[NRMAAnalytics alloc] initWithSessionStartTimeMS:(long long)([self.appSessionStartDate timeIntervalSince1970] * 1000)];
+        } else if(didFireEnterForeground && didFireEnterBackground) {
+            // We are coming back to the foreground after having a background stint
+            [self.analyticsController newSessionWithStartTime:(long long)([self.appSessionStartDate timeIntervalSince1970] * 1000)];
+//            self.analyticsController = [[NRMAAnalytics alloc] initWithSessionStartTimeMS:(long long)([self.appSessionStartDate timeIntervalSince1970] * 1000)];
         }
+        
+        // We are coming back to the foreground after having a background stint
     }
 
     [[NSNotificationCenter defaultCenter] postNotificationName:kNRMAAnalyticsInitializedNotification
@@ -628,7 +634,7 @@ static const NSString* kNRMA_APPLICATION_WILL_TERMINATE = @"com.newrelic.appWill
                     [self.analyticsController addCustomEvent:@"Return Harvest" withAttributes:nil];
                     [NewRelicAgentInternal harvestNow];
                 }
-                didFireEnterBackground = NO;
+                
 
                 /*
                  * NRMAMeasurements must be started before the
@@ -658,6 +664,7 @@ static const NSString* kNRMA_APPLICATION_WILL_TERMINATE = @"com.newrelic.appWill
                  * initialization.
                  */
                 [self sessionStartInitialization];
+                didFireEnterBackground = NO;
             }
         }
     });

--- a/libMobileAgent/src/Analytics/include/Analytics/AnalyticsController.hpp
+++ b/libMobileAgent/src/Analytics/include/Analytics/AnalyticsController.hpp
@@ -100,6 +100,8 @@ namespace NewRelic {
         const AttributeValidator &getAttributeValidator() const;
 
         bool addSessionEndAttribute();
+        
+        void newSessionWithStartTime(unsigned long long sessionStartTime_ms);
 
         AnalyticsController(unsigned long long sessionStartTime_ms, const char *sharedPath,
                             PersistentStore<std::string, AnalyticEvent> &eventDupStore,

--- a/libMobileAgent/src/Analytics/src/AnalyticsController.cxx
+++ b/libMobileAgent/src/Analytics/src/AnalyticsController.cxx
@@ -188,6 +188,10 @@ namespace NewRelic {
         }
     }
 
+    void AnalyticsController::newSessionWithStartTime(unsigned long long sessionStartTime_ms) {
+        _session_start_time_ms = sessionStartTime_ms;
+    }
+
     bool AnalyticsController::addUserActionEvent(const char *functionName,
                                              const char *targetObject,
                                              const char *label,


### PR DESCRIPTION
Check if NRMAAnalytics is already initialized before blindly re-initializing it again.

This still needs to be tested for background instrumentation. 