### PR TITLE
NR-317126 New Event System session attribute can't contain a reservedAttributeNames

### DIFF
--- a/Agent/Analytics/NRMAAnalytics.h
+++ b/Agent/Analytics/NRMAAnalytics.h
@@ -75,5 +75,6 @@
 
 + (int64_t) currentTimeMillis;
 + (NSArray<NSString*>*) reservedKeywords;
++ (NSArray<NSString*>*) reservedPrefixes;
 
 @end

--- a/Agent/Analytics/NRMAAnalytics.mm
+++ b/Agent/Analytics/NRMAAnalytics.mm
@@ -131,11 +131,14 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
                         NRLOG_AGENT_ERROR(@"invalid attribute: name prefix disallowed");
                         return false;
                     }
+                }
+                for (NSString* key in [NRMAAnalytics reservedPrefixes]) {
                     if ([name hasPrefix:key])  {
                         NRLOG_AGENT_ERROR(@"invalid attribute: name prefix disallowed");
                         return false;
                     }
                 }
+
                 // check if attribute name exceeds max length.
                 if ([name length] > kNRMA_Attrib_Max_Name_Length) {
                     NRLOG_AGENT_ERROR(@"invalid attribute: name length exceeds limit");
@@ -1267,6 +1270,13 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
             kNRMA_RA_platformVersion,
             kNRMA_RA_lastInteraction
         ,nil];
+}
+
++ (NSArray<NSString*>*) reservedPrefixes {
+    return [NSArray arrayWithObjects:
+            kNRMA_RP_newRelic,
+            kNRMA_RP_nr,
+            nil];
 }
 
 @end

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
@@ -42,12 +42,14 @@
         // check if attribute name is reserved or attribute name matches reserved prefix.
         for (NSString* key in [NRMAAnalytics reservedKeywords]) {
             if ([key isEqualToString:name]) {
-                NRLOG_AGENT_ERROR(@"invalid attribute: name prefix disallowed");
+                NRLOG_AGENT_ERROR(@"invalid attribute: name disallowed");
                 return NO;
             }
-            if ([key hasPrefix:name])  {
+        }
+        for (NSString* key in [NRMAAnalytics reservedPrefixes]) {
+            if ([name hasPrefix:key])  {
                 NRLOG_AGENT_ERROR(@"invalid attribute: name prefix disallowed");
-                return NO;
+                return false;
             }
         }
         // check if attribute name exceeds max length.
@@ -89,6 +91,19 @@
                                                            options:0
                                                              error:nil];
     XCTAssertTrue([decode[@"blarg"] isEqualToString:@"blurg"]);
+}
+
+- (void) testSetSessionAttributeFail {
+    XCTAssertFalse([manager setSessionAttribute:@"platform" value:@"blurg"], @"Failed to successfully find reserved key for session attribute");
+
+    XCTAssertFalse([manager setSessionAttribute:@"nr.test" value:@"blurg"], @"Failed to successfully find reserved prefix key for session attribute");
+
+    NSString* attributes = [manager sessionAttributeJSONString];
+
+    NSDictionary* decode = [NSJSONSerialization JSONObjectWithData:[attributes dataUsingEncoding:NSUTF8StringEncoding]
+                                                           options:0
+                                                             error:nil];
+    XCTAssertNil(decode[@"platform"]);
 }
 
 - (void) testSetNRSessionAttribute {
@@ -280,8 +295,8 @@
     XCTAssertFalse([manager setSessionAttribute:@"  x" value:@"blurg"], @"Failed to successfully fail when setting invalid name for session attribute");
     XCTAssertFalse([manager setSessionAttribute:@"  " value:@"blurg"], @"Failed to successfully fail when setting invalid name for session attribute");
 
-    XCTAssertFalse([manager setSessionAttribute:@"even" value:@"blurg"], @"Failed to successfully fail when setting invalid name for session attribute");
-    XCTAssertFalse([manager setSessionAttribute:@"event" value:@"blurg"], @"Failed to successfully fail when setting invalid name for session attribute");
+    XCTAssertFalse([manager setSessionAttribute:@"newRelictest" value:@"blurg"], @"Failed to successfully fail when setting invalid name for session attribute");
+    XCTAssertFalse([manager setSessionAttribute:@"nr.test" value:@"blurg"], @"Failed to successfully fail when setting invalid name for session attribute");
 
     // Test Max Attribute Length
     NSString *validAttributeName =  [@"" stringByPaddingToLength:kNRMA_Attrib_Max_Name_Length withString:@"x" startingAtIndex:0];


### PR DESCRIPTION
Added the prefix list to use in the new event system attribute validator.