### PR TITLE
NR-334116: allow http header tracking when using noticeNetworkRequest manually. Update NRMAAnalyticsTest

### DIFF
--- a/Agent/Analytics/NRMAAnalytics.mm
+++ b/Agent/Analytics/NRMAAnalytics.mm
@@ -278,6 +278,7 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
     }
 }
 
+// New Event System
 - (BOOL) addNetworkRequestEvent:(NRMANetworkRequestData *)requestData
                   withResponse:(NRMANetworkResponseData *)responseData
                withNRMAPayload:(NRMAPayload *)payload {
@@ -517,6 +518,7 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
     }
 }
 
+// Old Event System
 - (BOOL)addNetworkRequestEvent:(NRMANetworkRequestData *)requestData
                   withResponse:(NRMANetworkResponseData *)responseData
                    withPayload:(std::unique_ptr<const Connectivity::Payload>)payload {
@@ -528,6 +530,7 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
     return NO;
 }
 
+// Old Event System
 - (BOOL)addNetworkErrorEvent:(NRMANetworkRequestData *)requestData
                 withResponse:(NRMANetworkResponseData *)responseData
                  withPayload:(std::unique_ptr<const NewRelic::Connectivity::Payload>)payload {
@@ -541,6 +544,7 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
     return NO;
 }
 
+// Old Event System
 - (BOOL)addHTTPErrorEvent:(NRMANetworkRequestData *)requestData
              withResponse:(NRMANetworkResponseData *)responseData
             withPayload:(std::unique_ptr<const NewRelic::Connectivity::Payload>)payload {

--- a/Test Harness/NRTestApp/NRTestApp/ViewModels/UtilViewModel.swift
+++ b/Test Harness/NRTestApp/NRTestApp/ViewModels/UtilViewModel.swift
@@ -51,6 +51,11 @@ class UtilViewModel {
         options.append(UtilOption(title: "Notice Network Request", handler: { [self] in noticeNWRequest()}))
         options.append(UtilOption(title: "Notice Network Failure", handler: { [self] in noticeFailedNWRequest()}))
 
+        options.append(UtilOption(title: "Notice Network Request w headers/params", handler: { [self] in 
+            Task { await noticeNetworkRequestWithParams() }
+        }))
+
+
         options.append(UtilOption(title: "Test Log Dict", handler: { [self] in testLogDict()}))
         options.append(UtilOption(title: "Test Log Error", handler: { [self] in testLogError()}))
         options.append(UtilOption(title: "Test Log Attributes", handler: { [self] in testLogAttributes()}))
@@ -147,6 +152,34 @@ class UtilViewModel {
     func noticeFailedNWRequest() {
         NewRelic.noticeNetworkFailure(for: URL(string: "https://www.google.com"), httpMethod: "GET",
                                       with: NRTimer(), andFailureCode: NSURLErrorTimedOut)
+    }
+
+    func noticeNetworkRequestWithParams() async {
+        let url = URL(string: "https://www.apple.com")!
+
+        let request = URLRequest(url: url)
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            print("Async-Await Data request made.")
+            NewRelic.noticeNetworkRequest(
+                for: url,
+                httpMethod: "GET",
+                with: NRTimer(),
+                responseHeaders: ["x-response-header":"12345"],
+                statusCode: 200,
+                bytesSent: 0,
+                bytesReceived: UInt(data.count),
+                responseData: data,
+                traceHeaders: [:],
+                andParams: ["x-foo-header-id": "foo", "x-bar-header-id": "bar"]
+            )
+        }
+        catch {
+            print("\(error): Error making async-await data request.")
+
+        }
+
+
     }
 
     func testLogDict() {

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMAAnalyticsTest.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMAAnalyticsTest.mm
@@ -19,6 +19,7 @@
 #import "NRMAHarvestController.h"
 #import "NRMAAppToken.h"
 #import "NRTestConstants.h"
+#import "NRMAHTTPUtilities.h"
 
 @interface NRMAAnalyticsTest : XCTestCase
 {
@@ -95,6 +96,7 @@
 
 - (void) testRequestEvents {
     [NRMAFlags enableFeatures:NRFeatureFlag_NetworkRequestEvents];
+    
     NRTimer* timer = [NRTimer new];
 
     NRMAAnalytics* analytics = [[NRMAAnalytics alloc] initWithSessionStartTimeMS:0];
@@ -107,6 +109,8 @@
                                                                               connectionType:@"wifi"
                                                                                  contentType:@"application/json"
                                                                                    bytesSent:100];
+    [NRMAHTTPUtilities addHTTPHeaderTrackingFor:@[@"trackedHeaderName"]];
+    [NRMAHTTPUtilities addTrackedHeaders:@{@"trackedHeaderName": @"trackedHeaderValue"} to:requestData];
 
     NRMANetworkResponseData* responseData = [[NRMANetworkResponseData alloc] initWithSuccessfulResponse:200
                                                                                           bytesReceived:200
@@ -135,6 +139,9 @@
     XCTAssertFalse([decode[0][@"requestUrl"] containsString:@"request"]);
     XCTAssertFalse([decode[0][@"requestUrl"] containsString:@"parameter"]);
     XCTAssertFalse([json containsString:@"offline"]);
+
+    XCTAssertTrue([decode[0][@"trackedHeaderName"] isEqualToString:@"trackedHeaderValue"]);
+
 
     [NRMAFlags disableFeatures:NRFeatureFlag_NetworkRequestEvents];
 }
@@ -1540,5 +1547,6 @@
    XCTAssertTrue([analytics addSessionEvent], @"failed to successfully add session event");
 
 }
+
 
 @end


### PR DESCRIPTION
https://new-relic.atlassian.net/browse/NR-334116

Update NRMANetworkFacade noticeNetworkRequest to work with passed params