### PR TITLE
Nr 348708: add session attributes to log common attribute

### DIFF
--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRLoggerTests.h
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRLoggerTests.h
@@ -18,4 +18,7 @@
 }
 @property (nonatomic) int fileDescriptor;
 @property (nonatomic, strong) dispatch_source_t source;
+
+@property id mockNewRelicInternals;
+
 @end


### PR DESCRIPTION
https://new-relic.atlassian.net/browse/NR-348708 

The task  ensures that all mobile log events include session attributes and custom attributes added via the setAttribute method. This applies to logs generated through any static log method as well.