### PR TITLE
NR-352010 Changed NRMASAM to add the persisted attributes individually so that they get re-persisted

### DIFF
--- a/Agent/Analytics/NRMASAM.mm
+++ b/Agent/Analytics/NRMASAM.mm
@@ -30,30 +30,31 @@
 - (id)initWithAttributeValidator:(__nullable id<AttributeValidatorProtocol>)validator {
     self = [super init];
     if (self) {
+        attributeValidator = validator;
+
         _attributePersistentStore = [[PersistentEventStore alloc] initWithFilename:[NRMASAM attributeFilePath] andMinimumDelay:.025];
         
         _privateAttributePersistentStore = [[PersistentEventStore alloc] initWithFilename:[NRMASAM privateAttributeFilePath] andMinimumDelay:.025];
 
         // Load public attributes from file.
         NSDictionary *lastSessionAttributes = [PersistentEventStore getLastSessionEventsFromFilename:[NRMASAM attributeFilePath]];
+        attributeDict = [[NSMutableDictionary alloc] init];
         if (lastSessionAttributes != nil) {
-            attributeDict = [lastSessionAttributes mutableCopy];
-        }
-        if (!attributeDict) {
-            attributeDict = [[NSMutableDictionary alloc] init];
+            for(NSString* key in [lastSessionAttributes allKeys]) {
+                [self setAttribute:key value:[lastSessionAttributes valueForKey:key]];
+            }
         }
 
         // Load private attributes from file.
         NSDictionary *lastSessionPrivateAttributes = [PersistentEventStore getLastSessionEventsFromFilename:[NRMASAM privateAttributeFilePath]];
-
+        privateAttributeDict = [[NSMutableDictionary alloc] init];
+        
         if (lastSessionPrivateAttributes != nil) {
-            privateAttributeDict = [lastSessionPrivateAttributes mutableCopy];
+            for(NSString* key in [lastSessionPrivateAttributes allKeys]) {
+                [self setNRSessionAttribute:key value:[lastSessionPrivateAttributes valueForKey:key]];
+            }
         }
-        if (!privateAttributeDict) {
-            privateAttributeDict = [[NSMutableDictionary alloc] init];
-        }
-
-        attributeValidator = validator;
+        
     }
     return self;
 }

--- a/Agent/Analytics/NRMASAM.mm
+++ b/Agent/Analytics/NRMASAM.mm
@@ -222,7 +222,7 @@
 + (NSString*) getLastSessionsAttributes {
     NSError *error;
     NSString *lastSessionAttributesJsonString = nil;
-    NSDictionary *lastSessionAttributes = [PersistentEventStore getLastSessionEventsFromFilename:[self attributeFilePath]];
+    NSDictionary *lastSessionAttributes = [PersistentEventStore getLastSessionEventsFromFilename:[NRMASAM attributeFilePath]];
     NSDictionary *lastSessionPrivateAttributes = [PersistentEventStore getLastSessionEventsFromFilename:[NRMASAM privateAttributeFilePath]];
 
     NSMutableDictionary *mergedDictionary = [NSMutableDictionary dictionary];

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
@@ -24,11 +24,6 @@
 
 - (void)setUp {
     [super setUp];
-    [NRLogger setLogLevels:NRLogLevelDebug];
-
-    manager = [self samTest];
-    [manager removeAllSessionAttributes];
-    
     NSFileManager *fileManager = [NSFileManager defaultManager];
     if([fileManager fileExistsAtPath:[NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kNRMA_Attrib_file]]) {
         [fileManager removeItemAtPath:[NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kNRMA_Attrib_file] error:nil];
@@ -36,6 +31,10 @@
     if([fileManager fileExistsAtPath:[NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kNRMA_Attrib_file_private]]) {
         [fileManager removeItemAtPath:[NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kNRMA_Attrib_file_private] error:nil];
     }
+    
+    [NRLogger setLogLevels:NRLogLevelDebug];
+
+    manager = [self samTest];
 }
 
 - (NRMASAM*) samTest {

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
@@ -32,7 +32,7 @@
         [fileManager removeItemAtPath:[NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kNRMA_Attrib_file_private] error:nil];
     }
     
-    [NRLogger setLogLevels:NRLogLevelDebug];
+   // [NRLogger setLogLevels:NRLogLevelDebug];
 
     manager = [self samTest];
 }

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
@@ -24,6 +24,7 @@
 
 - (void)setUp {
     [super setUp];
+    [NRLogger setLogLevels:NRLogLevelDebug];
 
     manager = [self samTest];
     [manager removeAllSessionAttributes];
@@ -288,6 +289,7 @@
         // Wait a short period before retrying
         [NSThread sleepForTimeInterval:0.1];
     }    
+    XCTFail(@"Failed to persist expected attributes.");
 }
 
 - (void)testPersistedSessionAnalytics {
@@ -336,7 +338,6 @@
 }
 
 - (void) testClearPersistedSessionAnalytics {
-    NRMASAM *manager = [self samTest];
     NSString *attribute = @"blarg";
     NSString *attribute2 = @"blarg2";
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
@@ -28,6 +28,14 @@
 
     manager = [self samTest];
     [manager removeAllSessionAttributes];
+    
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    if([fileManager fileExistsAtPath:[NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kNRMA_Attrib_file]]) {
+        [fileManager removeItemAtPath:[NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kNRMA_Attrib_file] error:nil];
+    }
+    if([fileManager fileExistsAtPath:[NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kNRMA_Attrib_file_private]]) {
+        [fileManager removeItemAtPath:[NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kNRMA_Attrib_file_private] error:nil];
+    }
 }
 
 - (NRMASAM*) samTest {
@@ -293,14 +301,6 @@
 }
 
 - (void)testPersistedSessionAnalytics {
-    
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-    if([fileManager fileExistsAtPath:[NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kNRMA_Attrib_file]]) {
-        [fileManager removeItemAtPath:[NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kNRMA_Attrib_file] error:nil];
-    }
-    if([fileManager fileExistsAtPath:[NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kNRMA_Attrib_file_private]]) {
-        [fileManager removeItemAtPath:[NSString stringWithFormat:@"%@/%@",[NewRelicInternalUtils getStorePath],kNRMA_Attrib_file_private] error:nil];
-    }
     
     NSString *attribute = @"blarg";
     NSString *attribute2 = @"blarg2";

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
@@ -37,6 +37,11 @@
     manager = [self samTest];
 }
 
+- (void) tearDown {
+    [super tearDown];
+    [manager removeAllSessionAttributes];
+}
+
 - (NRMASAM*) samTest {
     return [[NRMASAM alloc] initWithAttributeValidator:[[BlockAttributeValidator alloc] initWithNameValidator:^BOOL(NSString *name) {
         if ([name length] == 0) {


### PR DESCRIPTION
Changed NRMASAM to add the persisted attributes individually so that they get re-persisted which is closer to how the old event system does it in SessionAttributeManager::restorePersistentAttributes().
Now the session attributes should persist until removed like in the old event system.
