### PR TITLE
NR-364636 fixing the persistent store memory leak

### DIFF
--- a/Agent/Analytics/NRMAAnalytics.mm
+++ b/Agent/Analytics/NRMAAnalytics.mm
@@ -115,7 +115,7 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
 
             PersistentEventStore *eventStore = [[PersistentEventStore alloc] initWithFilename:filename andMinimumDelay:.025];
             
-            _eventManager = [[NRMAEventManager alloc] initWithPersistentStore:eventStore];
+            _eventManager = [[NRMAEventManager alloc] initWithPersistentStore:[eventStore autorelease]];
             _attributeValidator = [[NRMAAttributeValidator alloc] init];
             _sessionAttributeManager = [[NRMASAM alloc] initWithAttributeValidator:_attributeValidator];
 

--- a/Agent/Analytics/NRMAEventManager.m
+++ b/Agent/Analytics/NRMAEventManager.m
@@ -77,7 +77,7 @@ static NSString* const eventKeyFormat = @"%f|%f|%@";
     }
     
     NSTimeInterval oldestEventAge = currentTimeMilliseconds - oldestEventTimestamp;
-    return (oldestEventAge / 1000) + kBufferTimeSecondsLeeway >= maxBufferTimeSeconds;
+    return (oldestEventAge / kDefaultBufferSize) + kBufferTimeSecondsLeeway >= maxBufferTimeSeconds;
 }
 
 - (NSUInteger)getEvictionIndex {

--- a/Agent/Analytics/PersistentEventStore.m
+++ b/Agent/Analytics/PersistentEventStore.m
@@ -51,7 +51,7 @@
     dispatch_async(self.writeQueue, ^{
         __strong PersistentEventStore *strongSelf = weakSelf;
         if (!strongSelf) { // Ensure strongSelf is not nil
-            NRLOG_WARNING(@"A block was scheduled but PersistentEventStore was deallocated before running");
+            NRLOG_AGENT_WARNING(@"A block was scheduled but PersistentEventStore was deallocated before running");
             return;
         }
 


### PR DESCRIPTION
Change it to use weak reference to prevent retain cycles and strong references to ensure the object is not deallocated while being used within the block.