### PR TITLE
NR-371375 changes to address startTrip crash

### DIFF
--- a/Agent/Network/NRMAHTTPUtilities.mm
+++ b/Agent/Network/NRMAHTTPUtilities.mm
@@ -36,8 +36,8 @@ static NSString* _operationType = @"X-APOLLO-OPERATION-TYPE";
 static NSString* _operationId = @"X-APOLLO-OPERATION-ID";
 
 @implementation NRMAHTTPUtilities
-NSString* currentTraceId;
-NSString* currentParentId;
+NSString* currentTraceId = @"";
+NSString* currentParentId = @"";
 
 + (NSArray*) trackedHeaderFields
 {
@@ -195,7 +195,7 @@ NSString* currentParentId;
         return nil;
     }
     
-    @synchronized (currentTraceId) {
+    @synchronized (self) {
         NSString * accountID = @(NewRelic::Application::getInstance().getContext().getAccountId().c_str());
         NSString * appId = @(NewRelic::Application::getInstance().getContext().getApplicationId().c_str());
         NSString * trustedAccountKey =  @(NewRelic::Application::getInstance().getContext().getTrustedAccountKey().c_str());


### PR DESCRIPTION
The startTrip method is now synchronized using @synchronized (self). This ensures that the method is thread-safe and prevents race conditions when multiple threads attempt to access or modify currentTraceId and currentParentId.
The currentTraceId and currentParentId variables are initialized to empty string at the beginning of the implementation. This ensures that they have a known state before being used.