### PR TITLE
NR-347591 added a synchronized lock to the deferredMetrics

### DIFF
--- a/Agent/Measurements/NRMASupportMetricHelper.h
+++ b/Agent/Measurements/NRMASupportMetricHelper.h
@@ -9,8 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "NewRelicFeatureFlags.h"
 
-static NSMutableArray *deferredMetrics = NULL;
-
 @interface NRMASupportMetricHelper : NSObject
 + (void) enqueueDataUseMetric:(NSString*)subDestination size:(long)size received:(long)received;
 + (void) enqueueFeatureFlagMetric:(BOOL)enabled features:(NRMAFeatureFlags)features;


### PR DESCRIPTION
These changes ensure that access to deferredMetrics is thread-safe. Multiple threads can modify deferredMetrics so synchronization blocks were added to protect access.