### PR TITLE
Session Replay: This fixes a compile error that could occur when building NRMAFeatureFlags inside a swift framework

### DIFF
--- a/Agent/General/NewRelicAgentInternal.h
+++ b/Agent/General/NewRelicAgentInternal.h
@@ -7,7 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "NewRelicFeatureFlags.h"
 #import "NRMAMeasurements.h"
 #import "NRMAHandledExceptions.h"
 #import "NRMAUserActionFacade.h"

--- a/Agent/Measurements/NRMASupportMetricHelper.h
+++ b/Agent/Measurements/NRMASupportMetricHelper.h
@@ -7,13 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "NewRelicFeatureFlags.h"
 
 static NSMutableArray *deferredMetrics;
 
 @interface NRMASupportMetricHelper : NSObject
 + (void) enqueueDataUseMetric:(NSString*)subDestination size:(long)size received:(long)received;
-+ (void) enqueueFeatureFlagMetric:(BOOL)enabled features:(NRMAFeatureFlags)features;
++ (void) enqueueFeatureFlagMetric:(BOOL)enabled features:(unsigned long long)features;
 + (void) enqueueInstallMetric;
 + (void) enqueueMaxPayloadSizeLimitMetric:(NSString*)endpoint;
 + (void) enqueueUpgradeMetric;

--- a/Agent/Measurements/NRMASupportMetricHelper.m
+++ b/Agent/Measurements/NRMASupportMetricHelper.m
@@ -32,7 +32,7 @@ static NSMutableArray<NRMAMetric *> *deferredMetrics;
                                           additionalValue:[NSNumber numberWithLongLong:received]]];
 }
 
-+ (void) enqueueFeatureFlagMetric:(BOOL)enabled features:(NRMAFeatureFlags)features {
++ (void) enqueueFeatureFlagMetric:(BOOL)enabled features:(unsigned long long)features {
     NSString* nativePlatform = [NewRelicInternalUtils osName];
     for (NSString *name in [NRMAFlags namesForFlags:features]) {
         NSString* featureFlagString = [NSString stringWithFormat:@"Supportability/Mobile/%@/%@/API/%@/%@",


### PR DESCRIPTION
Fixes this bug that could occur: 

![image](https://github.com/user-attachments/assets/f287ab1a-5821-4337-8f75-ea276c8086dd)
