### PR TITLE
NR-415835 hasReplay attribute

### DIFF
--- a/Agent/APrivateHeader.h
+++ b/Agent/APrivateHeader.h
@@ -18,5 +18,6 @@
 #import "NewRelicAgentInternal.h"
 #import "NRMAHarvestController.h"
 #import "NRMAHarvesterConnection+GZip.h"
+#import "NRMABool.h"
 
 #endif /* APrivateHeader_h */

--- a/Agent/APrivateHeader.h
+++ b/Agent/APrivateHeader.h
@@ -19,5 +19,6 @@
 #import "NRMAHarvestController.h"
 #import "NRMAHarvesterConnection+GZip.h"
 #import "NRMABool.h"
+#import "Constants.h"
 
 #endif /* APrivateHeader_h */

--- a/Agent/Analytics/Constants.h
+++ b/Agent/Analytics/Constants.h
@@ -34,6 +34,7 @@ extern NSString *const kNRMA_RA_upgradeFrom;
 extern NSString *const kNRMA_RA_platform;
 extern NSString *const kNRMA_RA_platformVersion;
 extern NSString *const kNRMA_RA_lastInteraction;
+extern NSString *const kNRMA_RA_hasReplay;
 extern NSString *const kNRMA_RA_appDataHeader;
 extern NSString *const kNRMA_RA_responseBody;
 

--- a/Agent/Analytics/Constants.m
+++ b/Agent/Analytics/Constants.m
@@ -35,6 +35,7 @@ NSString * const kNRMA_RA_upgradeFrom        = @"upgradeFrom";
 NSString * const kNRMA_RA_platform           = @"platform";
 NSString * const kNRMA_RA_platformVersion    = @"platformVersion";
 NSString * const kNRMA_RA_lastInteraction    = @"lastInteraction";
+NSString * const kNRMA_RA_hasReplay          = @"hasReplay";
 NSString * const kNRMA_RA_appDataHeader      = @"nr.X-NewRelic-App-Data";
 NSString * const kNRMA_RA_responseBody       = @"nr.responseBody";
 

--- a/Agent/Analytics/NRMAAnalytics.mm
+++ b/Agent/Analytics/NRMAAnalytics.mm
@@ -137,6 +137,9 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
                 if (dictionary[kNRMA_RA_install]) {
                     [_sessionAttributeManager removeSessionAttributeNamed:kNRMA_RA_install];
                 }
+                if (dictionary[kNRMA_RA_hasReplay]) {
+                    [_sessionAttributeManager removeSessionAttributeNamed:kNRMA_RA_hasReplay];
+                }
 
                 //session duration is only valid for one session. This metric should be removed
                 //after the persistent attributes are loaded.

--- a/Agent/SessionReplay/SessionReplayManager.swift
+++ b/Agent/SessionReplay/SessionReplayManager.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import UIKit
+import NewRelicPrivate
 
 @available(iOS 13.0, *)
 @objcMembers
@@ -36,7 +37,8 @@ public class SessionReplayManager: NSObject {
                 NRLOG_WARNING("Session replay harvest timer attempting to start while already running.")
                 return
             }
-            
+            NewRelicAgentInternal.sharedInstance().analyticsController.setNRSessionAttribute("hasReplay", value: NRMABool(bool: true))
+
             NRLOG_DEBUG("Session replay harvest timer starting with a period of \(harvestPeriod) s")
             self.harvestTimer = Timer(timeInterval: TimeInterval(self.harvestPeriod), target: self, selector: #selector(self.harvestTick), userInfo: nil, repeats: true)
             

--- a/Agent/SessionReplay/SessionReplayManager.swift
+++ b/Agent/SessionReplay/SessionReplayManager.swift
@@ -37,7 +37,7 @@ public class SessionReplayManager: NSObject {
                 NRLOG_WARNING("Session replay harvest timer attempting to start while already running.")
                 return
             }
-            NewRelicAgentInternal.sharedInstance().analyticsController.setNRSessionAttribute("hasReplay", value: NRMABool(bool: true))
+            NewRelicAgentInternal.sharedInstance().analyticsController.setNRSessionAttribute(kNRMA_RA_hasReplay, value: NRMABool(bool: true))
 
             NRLOG_DEBUG("Session replay harvest timer starting with a period of \(harvestPeriod) s")
             self.harvestTimer = Timer(timeInterval: TimeInterval(self.harvestPeriod), target: self, selector: #selector(self.harvestTick), userInfo: nil, repeats: true)
@@ -56,6 +56,8 @@ public class SessionReplayManager: NSObject {
         
         harvestTimer?.invalidate()
         harvestTimer = nil
+        
+        NewRelicAgentInternal.sharedInstance().analyticsController.removeSessionAttributeNamed(kNRMA_RA_hasReplay)
     }
 
     func isRunning() -> Bool {


### PR DESCRIPTION
Added hasReplay to session attributes when session replay is recording. We add the attribute when the timers for session replay start. We remove the attribute when a new session starts, it will be added again if the session replay starts again.