### PR TITLE
update: Use macos-14 on productionDeploy to prevent update issues

### DIFF
--- a/.github/workflows/productionDeploy.yml
+++ b/.github/workflows/productionDeploy.yml
@@ -44,7 +44,7 @@ jobs:
   # The deployProductionSpecs job creates the prod Podspec and Prod Package.swift from template and pushes to cp trunk.
   deployProductionSpecs:
     name: deployProductionSpecs
-    runs-on: macos-15
+    runs-on: macos-14
     needs: [deployS3Production]
     if: github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
It seems like the macos-15 image now returns something that uses Xcode 26 or Xcode 16.4 and it auto updated to latest. this should use compatible version.