### PR TITLE
fix: move swizzle to start to only touch swizzle when enabled

### DIFF
--- a/Agent/SessionReplay/NRMASessionReplay.swift
+++ b/Agent/SessionReplay/NRMASessionReplay.swift
@@ -48,16 +48,19 @@ public class NRMASessionReplay: NSObject {
         try? FileManager.default.createDirectory(at: framesDirectory, withIntermediateDirectories: true)
     }
 
-    @MainActor public func start() {
+    public func start() {
 
         sessionReplayFrameProcessor.lastFullFrame = nil // We want to start a new session with no last Frame tracked
-        
-        guard let window = getWindow() else {
-            NRLOG_DEBUG("No key window found on didBecomeActive")
-            return
+        Task{
+            await MainActor.run {
+                guard let window = getWindow() else {
+                    NRLOG_DEBUG("No key window found on didBecomeActive")
+                    return
+                }
+                self.sessionReplayTouchCapture = SessionReplayTouchCapture(window: window)
+                swizzleSendEvent()
+            }
         }
-        self.sessionReplayTouchCapture = SessionReplayTouchCapture(window: window)
-        swizzleSendEvent()
     }
 
     public func stop() {

--- a/Agent/SessionReplay/NRMASessionReplay.swift
+++ b/Agent/SessionReplay/NRMASessionReplay.swift
@@ -46,16 +46,18 @@ public class NRMASessionReplay: NSObject {
         super.init()
 
         try? FileManager.default.createDirectory(at: framesDirectory, withIntermediateDirectories: true)
-
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(didBecomeActive),
-                                               name: UIApplication.didBecomeActiveNotification,
-                                               object: nil)
     }
 
-    public func start() {
+    @MainActor public func start() {
 
         sessionReplayFrameProcessor.lastFullFrame = nil // We want to start a new session with no last Frame tracked
+        
+        guard let window = getWindow() else {
+            NRLOG_DEBUG("No key window found on didBecomeActive")
+            return
+        }
+        self.sessionReplayTouchCapture = SessionReplayTouchCapture(window: window)
+        swizzleSendEvent()
     }
 
     public func stop() {
@@ -119,17 +121,6 @@ public class NRMASessionReplay: NSObject {
             let newImp = imp_implementationWithBlock(block)
             self.NRMAOriginal__sendEvent = NRMAReplaceInstanceMethod(clazz as? AnyClass, originalSelector, newImp)
         }
-    }
-
-    @MainActor
-    @objc func didBecomeActive() {
-        //NRLOG_DEBUG("[SESSION REPLAY] - App did become active")
-        guard let window = getWindow() else {
-            NRLOG_DEBUG("No key window found on didBecomeActive")
-            return
-        }
-        self.sessionReplayTouchCapture = SessionReplayTouchCapture(window: window)
-        swizzleSendEvent()
     }
 
     func takeFrame() {


### PR DESCRIPTION
fix: move swizzle to start to only touch swizzle when enabled.

Checking if touch tracking still works after backgrounding and foregrounding with the various mechanisms MSR can start in like remotely.