### PR TITLE
fix: just in case persisted files get uploaded when not sampled or enabled. haven't reproduced this

### DIFF
--- a/Agent/General/NewRelicAgentInternal.m
+++ b/Agent/General/NewRelicAgentInternal.m
@@ -373,7 +373,11 @@ static NewRelicAgentInternal* _sharedInstance;
         _sessionReplay = [[SessionReplayManager alloc] initWithReporter:reporter url: [self->_agentConfiguration sessionReplayURL]];
 
         // CHECK FOR MSR FILES FROM PREVIOUSLY CRASHED SESSIONS
-         [_sessionReplay checkForPreviousSessionFiles];
+        BOOL isSampled = [self isSessionReplaySampled];
+
+        if (isSampled && [self isSessionReplayEnabled]) {
+            [_sessionReplay checkForPreviousSessionFiles];
+        }
     }
 #endif
 }


### PR DESCRIPTION
crashed session files are deleted on app launch if no pending crash.