### PR TITLE
NR-472539 changed the distributed tracing not attaching log to debug

### DIFF
--- a/Agent/Harvester/NRMAHarvestController.m
+++ b/Agent/Harvester/NRMAHarvestController.m
@@ -100,8 +100,12 @@ static NSString* NRMAHarvestControllerAccessorLock = @"LOCK";
         @synchronized(controller) {
             [controller createHarvester];
             [[controller harvester] setAgentConfiguration:configuration];
-            NRLOG_AGENT_VERBOSE(@"config: defaultHarvesterConfiguration set.");
-            [[controller harvester] configureHarvester:[NRMAHarvesterConfiguration defaultHarvesterConfiguration]];
+            NRMAHarvesterConfiguration* harvestConfiguration = [[controller harvester] fetchHarvestConfiguration];
+            if(harvestConfiguration == nil) {
+                harvestConfiguration = [NRMAHarvesterConfiguration defaultHarvesterConfiguration];
+                NRLOG_AGENT_VERBOSE(@"config: defaultHarvesterConfiguration set.");
+            }
+            [[controller harvester] configureHarvester:harvestConfiguration];
         }
     }
 }

--- a/Agent/Network/NRMAHTTPUtilities.mm
+++ b/Agent/Network/NRMAHTTPUtilities.mm
@@ -187,7 +187,7 @@ NSString* currentParentId = @"";
     payload = NewRelic::Connectivity::Facade::getInstance().startTrip();
     
     if(payload == nullptr) {
-        NRLOG_ERROR(@"Not attaching distributed tracing because account or application id are missing.");
+        NRLOG_DEBUG(@"Not attaching distributed tracing because account or application id are missing.");
         return nil;
     }
     payload->setDistributedTracing(true);
@@ -196,7 +196,7 @@ NSString* currentParentId = @"";
 
 + (NRMAPayload *) startTrip {
     if(!NewRelic::Application::getInstance().isValid()) {
-        NRLOG_ERROR(@"Not attaching distributed tracing because account or application id are missing.");
+        NRLOG_DEBUG(@"Not attaching distributed tracing because account or application id are missing.");
         return nil;
     }
     


### PR DESCRIPTION
This PR changes error logs to debug level. These logs occurred when a network request happened while the agent was using the default harvester config. It also changes it so if there is a fetch-able harvest config, use that for harvester initialization. 
I can not find a reason to not just use the fetched config if it is available as early as possible. The mechanisms for requesting an updated config if there is an app / agent update or 409 CONFIGURATION_UPDATE still function.