### PR TITLE
Created a converter for Apple font names to be used in CSS

### DIFF
--- a/Agent.xcodeproj/project.pbxproj
+++ b/Agent.xcodeproj/project.pbxproj
@@ -1557,6 +1557,7 @@
 		F85558532DE7C4F6008B6EDD /* SessionReplayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85558522DE7C4F6008B6EDD /* SessionReplayData.swift */; };
 		F858F3602AE04B0C00CF9EB5 /* NRMAURLSessionHeaderTrackingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F858F35F2AE04B0C00CF9EB5 /* NRMAURLSessionHeaderTrackingTests.m */; };
 		F858F3612AE04B0C00CF9EB5 /* NRMAURLSessionHeaderTrackingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F858F35F2AE04B0C00CF9EB5 /* NRMAURLSessionHeaderTrackingTests.m */; };
+		F8672AB52EB11B2C0055FA51 /* UIFont+CSSConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8672AB42EB11B2C0055FA51 /* UIFont+CSSConversion.swift */; };
 		F86741072BD30F3F00DAA1A2 /* NRMAExceptionDataCollectionWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 02FF48D024DC622400115469 /* NRMAExceptionDataCollectionWrapper.m */; };
 		F8678AAE2CDBC62B008FD2A2 /* NRAutoCollectLogStressTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F8678AAC2CDBC62B008FD2A2 /* NRAutoCollectLogStressTest.m */; };
 		F8728E412ACC9D5A0056F641 /* NRMANetworkMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = F8728E402ACC9D5A0056F641 /* NRMANetworkMonitor.m */; };
@@ -2599,6 +2600,7 @@
 		F848CDD52AA133FB0082052F /* NRMAInteractionEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NRMAInteractionEvent.h; sourceTree = "<group>"; };
 		F85558522DE7C4F6008B6EDD /* SessionReplayData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayData.swift; sourceTree = "<group>"; };
 		F858F35F2AE04B0C00CF9EB5 /* NRMAURLSessionHeaderTrackingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRMAURLSessionHeaderTrackingTests.m; sourceTree = "<group>"; };
+		F8672AB42EB11B2C0055FA51 /* UIFont+CSSConversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+CSSConversion.swift"; sourceTree = "<group>"; };
 		F8678AAC2CDBC62B008FD2A2 /* NRAutoCollectLogStressTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRAutoCollectLogStressTest.m; sourceTree = "<group>"; };
 		F8728E402ACC9D5A0056F641 /* NRMANetworkMonitor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRMANetworkMonitor.m; sourceTree = "<group>"; };
 		F8728E562ACC9F840056F641 /* NRMANetworkMonitor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NRMANetworkMonitor.h; sourceTree = "<group>"; };
@@ -3927,6 +3929,7 @@
 				2B58144F2E87218F005D62D4 /* SVGStrings.swift */,
 				2B0340942E8B056B00182A70 /* Data+md5Hex.swift */,
 				2B0340962E8B0B9C00182A70 /* UIImageOrientation.swift */,
+				F8672AB42EB11B2C0055FA51 /* UIFont+CSSConversion.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -5714,6 +5717,7 @@
 				F8E17C542DB681820098C3CB /* NRLogger.swift in Sources */,
 				02FF491D24DC624400115469 /* NRMACrashReport_Thread.m in Sources */,
 				02FF49B024DC62B800115469 /* NRMAActivityTraces.m in Sources */,
+				F8672AB52EB11B2C0055FA51 /* UIFont+CSSConversion.swift in Sources */,
 				02FF49C824DC62B800115469 /* NRMAHarvestableAnalytics.m in Sources */,
 				02FF493324DC625A00115469 /* NRMAHexUploader.m in Sources */,
 				2B706115293F990D0097BDC4 /* NRMAURLSessionTaskSearch.m in Sources */,

--- a/Agent/SessionReplay/SwiftUI/Helpers/UIFont+CSSConversion.swift
+++ b/Agent/SessionReplay/SwiftUI/Helpers/UIFont+CSSConversion.swift
@@ -1,0 +1,74 @@
+//
+//  UIFont+CSSConversion.swift
+//  Agent
+//
+//  Created by Mike Bruin on 10/28/25.
+//  Copyright © 2025 New Relic. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+internal extension UIFont {
+
+    // Fonts are ordered: 1) Most accurate visual match, 2) Most universally available
+    private static let fontFamilyMap: [String: String] = [
+        "sfui": "-apple-system, system-ui",
+        "applesystemuifont": "-apple-system, system-ui",
+        "sf pro text": "-apple-system, system-ui",
+        "sf pro display": "-apple-system, system-ui",
+        "sf pro": "-apple-system, system-ui",
+        "sfprotext": "-apple-system, system-ui",
+        "sfprodisplay": "-apple-system, system-ui",
+        "sf compact": "-apple-system, system-ui",
+        "sfcompact": "-apple-system, system-ui",
+        
+        "new york": "Charter, Georgia",
+        "newyork": "Charter, Georgia"
+    ]
+    
+    private static let prefixPatterns: [(String, String)] = [
+        ("applesystemuifont", "-apple-system, system-ui"),  // Most common iOS font
+        ("sfui", "-apple-system, system-ui"),
+        ("sfpro", "-apple-system, system-ui"),
+        ("sf pro", "-apple-system, system-ui"),
+        ("helvetica", "Helvetica, Arial"),
+        ("arial", "Arial, sans-serif"),
+        ("avenir", "Avenir, Arial")
+    ]
+    
+    /// Converts an Apple font family name to a CSS-compatible font family
+    /// - Parameter fontFamily: The UIFont familyName
+    /// - Returns: A CSS-compatible font family name
+    static func convertToCSSFontFamily(_ fontFamily: String) -> String {
+        // Remove leading dot if present (Apple's system font indicator)
+        let cleanedFamily = fontFamily.hasPrefix(".") && fontFamily.count > 1
+            ? String(fontFamily.dropFirst())
+            : fontFamily
+        
+        let lowercasedFamily = cleanedFamily.lowercased()
+        
+        if let cssFont = fontFamilyMap[lowercasedFamily] {
+            return cssFont
+        }
+
+        for (prefix, cssFont) in prefixPatterns {
+            if lowercasedFamily.hasPrefix(prefix) {
+                return cssFont
+            }
+        }
+        
+        // For unknown fonts, quote the name if it contains spaces and provide fallbacks
+        if cleanedFamily.contains(" ") {
+            return "'\(cleanedFamily)', system-ui"
+        } else {
+            return "\(cleanedFamily), system-ui"
+        }
+    }
+    
+    /// Converts the current UIFont instance to a CSS font family string
+    /// - Returns: A CSS-compatible font family name
+    func toCSSFontFamily() -> String {
+        return UIFont.convertToCSSFontFamily(self.familyName)
+    }
+}

--- a/Agent/SessionReplay/ViewCaptors/CustomTextThingy.swift
+++ b/Agent/SessionReplay/ViewCaptors/CustomTextThingy.swift
@@ -74,13 +74,7 @@ class CustomTextThingy: SessionReplayViewThingy {
             self.fontName = fontNameRaw
         }
         
-        let fontFamilyRaw = font.familyName
-        if(fontFamilyRaw.hasPrefix(".") && fontFamilyRaw.count > 1) {
-            self.fontFamily = String(fontFamilyRaw.dropFirst())
-        }
-        else {
-            self.fontFamily = fontFamilyRaw
-        }
+        self.fontFamily = font.toCSSFontFamily()
         
         if #available(iOS 13.0, *) {
             self.textColor = view.textColor ?? UIColor.label

--- a/Agent/SessionReplay/ViewCaptors/UILabelThingy.swift
+++ b/Agent/SessionReplay/ViewCaptors/UILabelThingy.swift
@@ -52,23 +52,20 @@ class UILabelThingy: SessionReplayViewThingy {
         else {
             self.labelText = view.text ?? ""
         }
+       
+        let font = view.font ?? UIFont.systemFont(ofSize: 17.0)
 
-        self.fontSize = view.font.pointSize
-        let fontNameRaw = view.font.fontName
-        if(fontNameRaw .hasPrefix(".") && fontNameRaw.count > 1) {
+        self.fontSize = font.pointSize
+        let fontNameRaw = font.fontName
+        if(fontNameRaw.hasPrefix(".") && fontNameRaw.count > 1) {
             self.fontName = String(fontNameRaw.dropFirst())
         }
         else {
             self.fontName = fontNameRaw
         }
         
-        let fontFamilyRaw = view.font.familyName
-        if(fontFamilyRaw.hasPrefix(".") && fontFamilyRaw.count > 1) {
-            self.fontFamily = String(fontFamilyRaw.dropFirst())
-        }
-        else {
-            self.fontFamily = fontFamilyRaw
-        }
+        self.fontFamily = font.toCSSFontFamily()
+        
         self.textAlignment = view.textAlignment.stringValue()
 
         self.textColor = view.textColor
@@ -131,12 +128,7 @@ class UILabelThingy: SessionReplayViewThingy {
             self.fontName = fontNameRaw
         }
         
-        let fontFamilyRaw = font.familyName
-        if(fontFamilyRaw.hasPrefix(".") && fontFamilyRaw.count > 1) {
-            self.fontFamily = String(fontFamilyRaw.dropFirst())
-        } else {
-            self.fontFamily = fontFamilyRaw
-        }
+        self.fontFamily = font.toCSSFontFamily()
         
         self.textAlignment = textAlignment
 
@@ -175,12 +167,8 @@ class UILabelThingy: SessionReplayViewThingy {
             self.fontName = fontNameRaw
         }
         
-        let fontFamilyRaw = fontFamily
-        if(fontFamilyRaw.hasPrefix(".") && fontFamilyRaw.count > 1) {
-            self.fontFamily = String(fontFamilyRaw.dropFirst())
-        } else {
-            self.fontFamily = fontFamilyRaw
-        }
+        self.fontFamily = UIFont.convertToCSSFontFamily(fontName)
+
         self.textAlignment = textAlignment
         self.textColor = textColor
     }

--- a/Agent/SessionReplay/ViewCaptors/UITextViewThingy.swift
+++ b/Agent/SessionReplay/ViewCaptors/UITextViewThingy.swift
@@ -63,14 +63,9 @@ class UITextViewThingy: SessionReplayViewThingy {
         else {
             self.fontName = fontNameRaw
         }
-
-        let fontFamilyRaw = font.familyName
-        if(fontFamilyRaw.hasPrefix(".") && fontFamilyRaw.count > 1) {
-            self.fontFamily = String(fontFamilyRaw.dropFirst())
-        }
-        else {
-            self.fontFamily = fontFamilyRaw
-        }
+        
+        // Convert Apple font to CSS-compatible font family
+        self.fontFamily = font.toCSSFontFamily()
 
         if #available(iOS 13.0, *) {
             self.textColor = view.textColor ?? UIColor.label


### PR DESCRIPTION
This PR introduces a UIFont extension that converts iOS font family names to CSS-compatible font family strings for the Session Replay feature. This enables accurate font rendering when replaying recorded sessions in NR One.