### PR TITLE
Resolve Issue #520 - warning about not found parameter in comments

### DIFF
--- a/Agent/Public/NewRelic.h
+++ b/Agent/Public/NewRelic.h
@@ -856,8 +856,8 @@ extern "C" {
  * <p>
  * Example: addSessionReplayMaskedAccessibilityIdentifier("private")
  *
- * @param viewTag The tag value to mask
- * @return true if the view tag was successfully added to the mask list
+ * @param identifier The identifier value to mask
+ * @return true if the identifier was successfully added to the mask list
  */
 + (BOOL) addSessionReplayMaskedAccessibilityIdentifier:(NSString*_Nonnull) identifier;
 
@@ -868,8 +868,8 @@ extern "C" {
  * <p>
  * Example: addSessionReplayUnmaskedAccessibilityIdentifier("public_info")
  *
- * @param viewTag The tag value to unmask
- * @return true if the view tag was successfully added to the unmask list
+ * @param identifier The identifier value to unmask
+ * @return true if the identifier was successfully added to the unmask list
  */
 + (BOOL) addSessionReplayUnmaskedAccessibilityIdentifier:(NSString*_Nonnull) identifier;
 


### PR DESCRIPTION
* Update the comment documentation for `addSessionReplayMaskedAccessibilityIdentifier` & `addSessionReplayUnmaskedAccessibilityIdentifier`