### PR TITLE
NR-489883 added a social media facsimile and fixed reusable images in playback

### DIFF
--- a/Agent/SessionReplay/SwiftUI/UIHostingViewRecordOrchestrator.swift
+++ b/Agent/SessionReplay/SwiftUI/UIHostingViewRecordOrchestrator.swift
@@ -307,12 +307,7 @@ final class UIHostingViewRecordOrchestrator {
                 break
             }
             
-            if let id = image?.swiftUISessionReplayIdentifier {
-                contentId = id
-            } else {
-                contentId = IDGenerator.shared.getId()
-                image?.swiftUISessionReplayIdentifier = contentId
-            }
+            contentId = getContentId(for: content, identity: item.identity)
             
             viewName = "SwiftUIImageView"
             var details = makeDetails()
@@ -335,24 +330,6 @@ final class UIHostingViewRecordOrchestrator {
             var details = makeDetails()
             details.backgroundColor = .clear
             return UIViewThingy(viewDetails: details)
-        }
-    }
-}
-
-fileprivate var associatedSwiftUISessionReplayIdentifierKey: String = "SessionReplayIdentifier"
-
-extension CGImage {
-    var swiftUISessionReplayIdentifier: Int? {
-        set {
-            withUnsafePointer(to: &associatedSwiftUISessionReplayIdentifierKey) {
-                objc_setAssociatedObject(self, $0, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            }
-        }
-
-        get {
-            withUnsafePointer(to: &associatedSwiftUISessionReplayIdentifierKey) {
-                objc_getAssociatedObject(self, $0) as? Int
-            }
         }
     }
 }

--- a/Test Harness/NRTestApp/NRTestApp.xcodeproj/project.pbxproj
+++ b/Test Harness/NRTestApp/NRTestApp.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		F84EEFB52E21B19C000E2A5A /* SecureLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84EEFAD2E21B18B000E2A5A /* SecureLabel.swift */; };
 		F84EEFB62E21B19C000E2A5A /* SecureLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84EEFAD2E21B18B000E2A5A /* SecureLabel.swift */; };
 		F84EEFB72E21B19C000E2A5A /* SecureLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84EEFAD2E21B18B000E2A5A /* SecureLabel.swift */; };
+		F85CEDDF2ECE1DBE004A314F /* SocialMediaFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85CEDDE2ECE1DBE004A314F /* SocialMediaFeedView.swift */; };
 		F86428412971BD5B002ABA01 /* UtilitiesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F86428402971BD5B002ABA01 /* UtilitiesViewController.swift */; };
 		F86428482971C661002ABA01 /* UtilViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F86428472971C661002ABA01 /* UtilViewModel.swift */; };
 		F864284C2971DFA5002ABA01 /* triggerException.m in Sources */ = {isa = PBXBuildFile; fileRef = F864284B2971DFA5002ABA01 /* triggerException.m */; };
@@ -391,6 +392,7 @@
 		F848CDE32AA270E80082052F /* NRTestApp_tvOS_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NRTestApp_tvOS_Tests.swift; sourceTree = "<group>"; };
 		F848CDE52AA270E80082052F /* NRTestApp_tvOS_TestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NRTestApp_tvOS_TestsLaunchTests.swift; sourceTree = "<group>"; };
 		F84EEFAD2E21B18B000E2A5A /* SecureLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureLabel.swift; sourceTree = "<group>"; };
+		F85CEDDE2ECE1DBE004A314F /* SocialMediaFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialMediaFeedView.swift; sourceTree = "<group>"; };
 		F86428402971BD5B002ABA01 /* UtilitiesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitiesViewController.swift; sourceTree = "<group>"; };
 		F86428472971C661002ABA01 /* UtilViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilViewModel.swift; sourceTree = "<group>"; };
 		F864284A2971DFA4002ABA01 /* NRTestApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NRTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -472,6 +474,7 @@
 			children = (
 				2B3493692E8EF15A006DE9D0 /* MaskingView.swift */,
 				2BAE5C7D2E860C7D001D2B88 /* ButtonsView.swift */,
+				F85CEDDE2ECE1DBE004A314F /* SocialMediaFeedView.swift */,
 				2BAE5C7E2E860C7D001D2B88 /* ContentView.swift */,
 				2BAE5C7F2E860C7D001D2B88 /* DatePickersView.swift */,
 				F8672A552EAA69820055FA51 /* SimpleScrollView.swift */,
@@ -1199,6 +1202,7 @@
 				2BAE5C922E860C7D001D2B88 /* ListsView.swift in Sources */,
 				2BAE5C932E860C7D001D2B88 /* PickersView.swift in Sources */,
 				2BAE5C942E860C7D001D2B88 /* SegmentedControlsView.swift in Sources */,
+				F85CEDDF2ECE1DBE004A314F /* SocialMediaFeedView.swift in Sources */,
 				2BAE5C952E860C7D001D2B88 /* GridsView.swift in Sources */,
 				2BAE5C962E860C7D001D2B88 /* TextFieldsView.swift in Sources */,
 				2BAE5C972E860C7D001D2B88 /* DatePickersView.swift in Sources */,

--- a/Test Harness/NRTestApp/NRTestApp/SwiftUI/ContentView.swift
+++ b/Test Harness/NRTestApp/NRTestApp/SwiftUI/ContentView.swift
@@ -72,7 +72,9 @@ struct SwiftUIContentView: View {
                     }
                     NavigationLink(destination: InfiniteImageCollectionView()) {
                         Text("Infinite Images")
-                        
+                    }
+                    NavigationLink(destination: SocialMediaFeedView()) {
+                        Text("Social Media Feed")
                     }
                 }
                 .navigationBarTitle("SwiftUI Elements")

--- a/Test Harness/NRTestApp/NRTestApp/SwiftUI/SocialMediaFeedView.swift
+++ b/Test Harness/NRTestApp/NRTestApp/SwiftUI/SocialMediaFeedView.swift
@@ -1,0 +1,234 @@
+import SwiftUI
+
+struct SocialMediaFeedView: View {
+    @StateObject private var viewModel = SocialMediaViewModel()
+    
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(viewModel.posts) { post in
+                    SocialMediaPostCard(post: post)
+                        .onAppear {
+                            if post.id == viewModel.posts.last?.id {
+                                viewModel.loadMorePosts()
+                            }
+                        }
+                }
+                
+                if viewModel.isLoading {
+                    ProgressView()
+                        .frame(height: 60)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+        }
+        .navigationTitle("Social Feed")
+        .onAppear {
+            viewModel.loadInitialPosts()
+        }
+    }
+}
+
+struct SocialMediaPostCard: View {
+    let post: SocialMediaPost
+    @State private var isLiked = false
+    @State private var likeCount: Int
+    @State private var isBookmarked = false
+    
+    init(post: SocialMediaPost) {
+        self.post = post
+        _likeCount = State(initialValue: post.likes)
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header with profile
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(post.profileColor)
+                    .frame(width: 40, height: 40)
+                    .overlay(
+                        Text(post.author.prefix(1))
+                            .font(.headline)
+                            .foregroundColor(.white)
+                    )
+                
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(post.author)
+                        .font(.headline)
+                    Text(post.timeAgo)
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                }
+                
+                Spacer()
+                
+                Button(action: {}) {
+                    Image(systemName: "ellipsis")
+                        .foregroundColor(.gray)
+                }
+            }
+            .padding()
+            
+            // Post content
+            Text(post.content)
+                .font(.body)
+                .padding(.horizontal)
+                .padding(.bottom, 12)
+            
+            // Post image (if available)
+            if let imageURL = post.imageURL {
+                AsyncImageView(imageURL: imageURL)
+                    .frame(height: 300)
+                    .frame(maxWidth: .infinity)
+                    .clipped()
+            }
+            
+            // Action buttons
+            HStack(spacing: 20) {
+                Button(action: {
+                    isLiked.toggle()
+                    likeCount += isLiked ? 1 : -1
+                }) {
+                    HStack(spacing: 6) {
+                        Image(systemName: isLiked ? "heart.fill" : "heart")
+                            .foregroundColor(isLiked ? .red : .gray)
+                        Text("\(likeCount)")
+                            .font(.subheadline)
+                            .foregroundColor(.gray)
+                    }
+                }
+                
+                Button(action: {}) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "bubble.right")
+                            .foregroundColor(.gray)
+                        Text("\(post.comments)")
+                            .font(.subheadline)
+                            .foregroundColor(.gray)
+                    }
+                }
+                
+                Button(action: {}) {
+                    Image(systemName: "arrow.turn.up.right")
+                        .foregroundColor(.gray)
+                }
+                
+                Spacer()
+                
+                Button(action: {
+                    isBookmarked.toggle()
+                }) {
+                    Image(systemName: isBookmarked ? "bookmark.fill" : "bookmark")
+                        .foregroundColor(isBookmarked ? .blue : .gray)
+                }
+            }
+            .padding()
+            
+            Divider()
+        }
+    }
+}
+
+struct SocialMediaPost: Identifiable {
+    let id: UUID
+    let author: String
+    let profileColor: Color
+    let timeAgo: String
+    let content: String
+    let imageURL: String?
+    let likes: Int
+    let comments: Int
+}
+
+class SocialMediaViewModel: ObservableObject {
+    @Published var posts: [SocialMediaPost] = []
+    @Published var isLoading = false
+    
+    private let sampleAuthors = [
+        "Sarah Johnson", "Mike Chen", "Emma Davis", "Alex Rodriguez",
+        "Jessica Lee", "Tom Wilson", "Maya Patel", "Chris Anderson",
+        "Lisa Kim", "David Brown", "Rachel Green", "James Taylor"
+    ]
+    
+    private let sampleContent = [
+        "Just finished an amazing hike at the mountains! The view was absolutely breathtaking. 🏔️ #nature #hiking",
+        "New coffee shop opened downtown and I'm in love! ☕️ Best latte I've had in months.",
+        "Working on an exciting new project. Can't wait to share it with you all! Stay tuned... 🚀",
+        "Beautiful sunset today. Sometimes you just need to stop and appreciate the little things. 🌅",
+        "Finally tried that new restaurant everyone's been talking about. The food was incredible! 🍜",
+        "Weekend vibes! Time to relax and recharge. What are your plans? 😎",
+        "Throwback to last summer's road trip. Missing those carefree days! 🚗",
+        "Just finished reading an amazing book. Highly recommend it to anyone looking for a good read! 📚",
+        "Home cooked meal tonight. Nothing beats fresh ingredients! 🍝",
+        "Morning run complete! Starting the day off right. 💪 #fitness #motivation",
+        "Concert last night was epic! Still riding that high. 🎵🎸",
+        "Rainy days are perfect for staying in and watching movies. What's your favorite rainy day activity? ☔️"
+    ]
+    
+    private let imageURLs = [
+        "https://picsum.photos/400/300?random=",
+        nil // Some posts won't have images
+    ]
+    
+    private let colors: [Color] = [
+        .blue, .green, .orange, .purple, .pink, .red, .indigo, .teal, .mint, .cyan
+    ]
+    
+    private var postCounter = 0
+    
+    func loadInitialPosts() {
+        guard posts.isEmpty else { return }
+        posts = generatePosts(count: 10)
+    }
+    
+    func loadMorePosts() {
+        guard !isLoading else { return }
+        isLoading = true
+        
+        // Simulate network delay
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            guard let self = self else { return }
+            let newPosts = self.generatePosts(count: 5)
+            self.posts.append(contentsOf: newPosts)
+            self.isLoading = false
+        }
+    }
+    
+    private func generatePosts(count: Int) -> [SocialMediaPost] {
+        var posts: [SocialMediaPost] = []
+        
+        for _ in 0..<count {
+            let hasImage = Bool.random()
+            let imageURL = hasImage ? "https://picsum.photos/400/300?random=\(postCounter)" : nil
+            
+            let post = SocialMediaPost(
+                id: UUID(),
+                author: sampleAuthors.randomElement()!,
+                profileColor: colors.randomElement()!,
+                timeAgo: generateTimeAgo(),
+                content: sampleContent.randomElement()!,
+                imageURL: imageURL,
+                likes: Int.random(in: 5...500),
+                comments: Int.random(in: 0...150)
+            )
+            
+            posts.append(post)
+            postCounter += 1
+        }
+        
+        return posts
+    }
+    
+    private func generateTimeAgo() -> String {
+        let options = ["2m", "15m", "1h", "3h", "5h", "8h", "1d", "2d", "3d", "1w"]
+        return options.randomElement()!
+    }
+}
+
+// Preview
+#Preview {
+    NavigationView {
+        SocialMediaFeedView()
+    }
+}


### PR DESCRIPTION
When images got reused in a view they would show duplicates during playback. Is is because the id was being set on the image asset in memory. Causing the adds and removes of the image with the same id confusing the playback. This change makes it use the seed and identity of the SwiftUI element.