### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions - ‎.github/workflows/uploadApp.yml‎

### DIFF
--- a/.github/workflows/uploadApp.yml
+++ b/.github/workflows/uploadApp.yml
@@ -7,6 +7,10 @@
 
 name: Upload iOS NRTestApp to LambdaTest
 
+permissions:
+  contents: read
+  actions: read
+
 on:
  # enables option for workflow to be manually executed in Github UI
  workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/30](https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/30)

Add an explicit `permissions` block to `.github/workflows/uploadApp.yml` at the workflow root (right after `name` and before `on`), so it applies to all jobs unless overridden.  
The least-privilege baseline for this workflow is:

- `contents: read` (needed by `actions/checkout`)
- `actions: read` (safe/compatible for artifact and workflow metadata interactions)

This keeps functionality unchanged while removing dependence on potentially over-privileged repository defaults. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
