### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/beta-tests.yml
+++ b/.github/workflows/beta-tests.yml
@@ -9,6 +9,9 @@ on:
         required: true
         default: "17.0"
 
+permissions:
+  contents: read
+
 jobs:
   testIOSBeta:
     name: TestIOSBeta


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/2](https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/beta-tests.yml` so all jobs inherit least-privilege token access by default.  
Best minimal safe fix (without changing intended functionality) is:

- Add at workflow root (after `on` block, before `jobs`):
  - `permissions:`
  - `  contents: read`

This supports `actions/checkout` while preventing unnecessary write scopes. If future steps require write permissions, grant them narrowly at the specific job level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
