### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wdio.yml
+++ b/.github/workflows/wdio.yml
@@ -6,6 +6,9 @@
 
 name: "WDIO: automate iOS tests"
 
+permissions:
+  contents: read
+
 on:
   # enables option for workflow to be manually executed in Github UI
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/33](https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/33)

Add an explicit `permissions` block at the workflow root (best here since there is one job and all steps share the same minimal need).  
For this workflow, `contents: read` is the right minimal baseline and aligns with checkout and artifact-read behavior. No write scopes are needed by the shown steps.

**File to edit:** `.github/workflows/wdio.yml`  
**Change location:** after `name:` and before `on:` (workflow-level permissions).

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
