### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,10 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   repolint:
     name: Run Repolinter


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/12](https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/12)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is scoped to least privilege.  
Best single fix: define permissions at the workflow root so all jobs inherit them consistently. For this workflow, `contents: read` is needed (repo read/checkout), and because `repolinter-action` is configured with `output_type: issue`, add `issues: write` so issue creation/updating continues to work.

Edit only `.github/workflows/repolinter.yml`, inserting a root-level `permissions` section between `on:` and `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
