### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/branchBuild.yml
+++ b/.github/workflows/branchBuild.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   deployS3:
     name: DeployS3


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/15](https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/15)

Add an explicit `permissions` block at the workflow root so all jobs inherit minimal token access unless overridden. For this workflow, the best non-breaking fix is:

- Add:
  - `permissions:`
  - `  contents: read`

Place this near the top-level keys (e.g., after `concurrency` and before `jobs`). This preserves existing behavior while enforcing least privilege and satisfying CodeQL. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
