### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/productionDeploy.yml
+++ b/.github/workflows/productionDeploy.yml
@@ -6,6 +6,9 @@ on:
       version:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   # The deployS3Production job copies the existing build from staging download location to the production download location.
   # The job relies on the existence of the xcframework desired for production promotion at the staging download location url: https://download.newrelic.com/ios-v5/${{ env.version }}.zip
@@ -55,6 +58,9 @@ jobs:
     runs-on: macos-14
     needs: [deployS3Production]
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout Main repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/20](https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/20)

Add an explicit `permissions` block in `.github/workflows/productionDeploy.yml` to constrain `GITHUB_TOKEN` permissions.  
Best fix without changing functionality: set minimal workflow-level defaults (`contents: read`) and then override only the job that needs to create a PR (`deployProductionSpecs`) with `contents: write` and `pull-requests: write`. This preserves existing behavior while applying least privilege across jobs.

Edits needed:
- In `.github/workflows/productionDeploy.yml`, add a root-level `permissions` block right after the trigger section (`on:`...).
- In the `deployProductionSpecs` job, add a job-level `permissions` block under `if:` (or near other job keys) granting only required write scopes.

No imports/dependencies/methods are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
