### PR TITLE
NR-556426 fix for hasReplay getting added to errorMode before fullMode is started

### DIFF
--- a/Agent/Analytics/Constants.h
+++ b/Agent/Analytics/Constants.h
@@ -92,6 +92,7 @@ extern NSString *const kNRMA_Attrib_file_private;
 extern NSString *const  kNRMA_EventStoreFilename;
 
 extern NSString *const kNRMA_Offline_folder;
+extern NSString *const kNRMA_SessionReplayFrames_folder;
 
 extern NSString *const kNRMA_Collector_connect_url;
 extern NSString *const kNRMA_Collector_data_url;

--- a/Agent/Analytics/Constants.m
+++ b/Agent/Analytics/Constants.m
@@ -98,6 +98,7 @@ NSString * const kNRMA_Attrib_file_private    = @"privateAttributes.txt";
 NSString * const kNRMA_EventStoreFilename    = @"eventsStore.txt";
 
 NSString * const kNRMA_Offline_folder          = @"offlineStorage";
+NSString * const kNRMA_SessionReplayFrames_folder = @"SessionReplayFrames";
 
 NSString * const kNRMA_Collector_connect_url   = @"/mobile/v5/connect";
 NSString * const kNRMA_Collector_data_url      = @"/mobile/v3/data";

--- a/Agent/CrashHandler/NRMAExceptionHandlerManager.m
+++ b/Agent/CrashHandler/NRMAExceptionHandlerManager.m
@@ -26,6 +26,7 @@
 #import "NRMATaskQueue.h"
 #import "NRMAMetric.h"
 #import "NRMACrashReporterRecorder.h"
+#import "Constants.h"
 
 @interface NRMAExceptionHandlerManager  ()
 #if !TARGET_OS_WATCH
@@ -109,7 +110,16 @@ static const NSString* NRMAManagerAccessorLock = @"managerLock";
         if ([_crashReporter hasPendingCrashReport]) {
             // Here we process pending crash reports.
             // This would possibly mean the last session ended in a crash.
-            [_reportManager processReportsWithSessionAttributes:attributes
+
+            // Check if there are session replay frames for this crashed session
+            // If so, retroactively add the hasReplay attribute
+            NSMutableDictionary *modifiedAttributes = attributes ? [attributes mutableCopy] : [NSMutableDictionary new];
+            if ([self hasSessionReplayFrames]) {
+                NRLOG_AGENT_DEBUG(@"Found session replay frames for crashed session - adding hasReplay attribute");
+                modifiedAttributes[kNRMA_RA_hasReplay] = @YES;
+            }
+
+            [_reportManager processReportsWithSessionAttributes:modifiedAttributes
                                                 analyticsEvents:events];
 
             NRMAReachability* r = [NewRelicInternalUtils reachability];
@@ -237,11 +247,57 @@ static const NSString* __memoryUsageLock = @"Lock";
     }
 }
 
+- (BOOL) hasSessionReplayFrames
+{
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *documentsDirectory = [paths objectAtIndex:0];
+    NSString *framesDirectory = [documentsDirectory stringByAppendingPathComponent:kNRMA_SessionReplayFrames_folder];
+
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    BOOL isDirectory = NO;
+
+    // Check if SessionReplayFrames directory exists
+    if (![fileManager fileExistsAtPath:framesDirectory isDirectory:&isDirectory] || !isDirectory) {
+        return NO;
+    }
+
+    // Check if there are any session directories with frames
+    NSError *error = nil;
+    NSArray *contents = [fileManager contentsOfDirectoryAtPath:framesDirectory error:&error];
+    if (error) {
+        NRLOG_AGENT_DEBUG(@"Error reading SessionReplayFrames directory: %@", error.localizedDescription);
+        return NO;
+    }
+
+    // Look for session directories (UUIDs) or upload URL files
+    for (NSString *item in contents) {
+        NSString *itemPath = [framesDirectory stringByAppendingPathComponent:item];
+        BOOL itemIsDirectory = NO;
+        [fileManager fileExistsAtPath:itemPath isDirectory:&itemIsDirectory];
+
+        // Check for session directories or upload URL files
+        if (itemIsDirectory) {
+            // Check if this session directory has any frame files
+            NSArray *sessionContents = [fileManager contentsOfDirectoryAtPath:itemPath error:nil];
+            for (NSString *file in sessionContents) {
+                if ([file hasPrefix:@"frame_"] && [file hasSuffix:@".json"]) {
+                    return YES;
+                }
+            }
+        } else if ([item hasSuffix:@"_upload_url.txt"]) {
+            // Found an upload URL file, indicating there was session replay data
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
 - (void) clearSessionReplayFrames
 {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *documentsDirectory = [paths objectAtIndex:0];
-    NSString *framesDirectory = [documentsDirectory stringByAppendingPathComponent:@"SessionReplayFrames"];
+    NSString *framesDirectory = [documentsDirectory stringByAppendingPathComponent:kNRMA_SessionReplayFrames_folder];
 
     NSFileManager *fileManager = [NSFileManager defaultManager];
     if ([fileManager fileExistsAtPath:framesDirectory]) {

--- a/Agent/General/NewRelicAgentInternal.m
+++ b/Agent/General/NewRelicAgentInternal.m
@@ -703,8 +703,13 @@ static NSString* kNRMAAnalyticsInitializationLock = @"AnalyticsInitializationLoc
         if (m != SessionReplayRecordingModeOff) {
             
             [_sessionReplay startFromManual:FALSE with:m];
-            @synchronized(kNRMAAnalyticsInitializationLock) {
-                [self.analyticsController setNRSessionAttribute:kNRMA_RA_hasReplay value:[[NRMABool alloc] initWithBOOL:YES]];
+
+            // Only add hasReplay attribute if starting in full mode
+            // For error mode, the attribute will be added when an error occurs
+            if (m == SessionReplayRecordingModeFull) {
+                @synchronized(kNRMAAnalyticsInitializationLock) {
+                    [self.analyticsController setNRSessionAttribute:kNRMA_RA_hasReplay value:[[NRMABool alloc] initWithBOOL:YES]];
+                }
             }
         }
     }
@@ -865,14 +870,6 @@ static const NSString *kNRMA_APPLICATION_WILL_TERMINATE =
     // Update session duration manager with new session start time for 4-hour session timeout
     [[NRMASessionDurationManager shared] updateSessionStartTime:self.appSessionStartDate];
     [self onSessionStart];
-    
-#if !TARGET_OS_TV && !TARGET_OS_WATCH
-    if (@available(iOS 13.0, *)) {
-        if ([self isSessionReplaySampled] && [self isSessionReplayEnabled]) {
-            [self.analyticsController setNRSessionAttribute:kNRMA_RA_hasReplay value:[[NRMABool alloc] initWithBOOL:YES]]; // Add the hasReplay attribute here incase the analytics controller wasn't created at the start of the session replay.
-        }
-    }
-#endif
 }
 
 - (void) handle4HourSessionRestart {

--- a/Agent/SessionReplay/NRMASessionReplay.swift
+++ b/Agent/SessionReplay/NRMASessionReplay.swift
@@ -73,7 +73,7 @@ public class NRMASessionReplay: NSObject {
         // sessionReplayFrameProcessor.useIncrementalDiffs = false // Only take full snapshots, not incremental diffs
         
         let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-        self.framesDirectory = documentsPath.appendingPathComponent("SessionReplayFrames")
+        self.framesDirectory = documentsPath.appendingPathComponent(kNRMA_SessionReplayFrames_folder)
         
         super.init()
         

--- a/Agent/SessionReplay/SessionReplayManager.swift
+++ b/Agent/SessionReplay/SessionReplayManager.swift
@@ -500,7 +500,7 @@ public class SessionReplayManager: NSObject {
         guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
             return nil
         }
-        return documentsDirectory.appendingPathComponent("SessionReplayFrames")
+        return documentsDirectory.appendingPathComponent(kNRMA_SessionReplayFrames_folder)
     }
     
 #endif

--- a/Agent/SessionReplay/SessionReplayReporter.swift
+++ b/Agent/SessionReplay/SessionReplayReporter.swift
@@ -161,6 +161,7 @@ public class SessionReplayReporter: NSObject {
             "rrweb.version": "^2.0.0-alpha.17",
             "payload.type": "standard",
             "hasMeta": String(true),
+            "hasReplay": String(true),
             "decompressedBytes": String(uncompressedDataSize),
             "replay.firstTimestamp": String(Int(firstTimestamp)),
             "replay.lastTimestamp": String(Int(lastTimestamp)),

--- a/Agent/Vendor/NRMAReachability.m
+++ b/Agent/Vendor/NRMAReachability.m
@@ -47,7 +47,6 @@
 
 #import <sys/socket.h>
 #import <netinet/in.h>
-#import <netinet6/in6.h>
 #import <arpa/inet.h>
 #import <ifaddrs.h>
 #import <netdb.h>


### PR DESCRIPTION
- Not adding the hasReplay attribute in error mode before full mode is activated.
- Retroactively adding the hasReplay attribute to crashes when there is replay data.