### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   testIOS:
     name: TestIOS
@@ -198,6 +201,8 @@ jobs:
   deployStagingSpecs:
     name: DeployStagingSpecs
     runs-on: macos-15
+    permissions:
+      contents: write
     needs: [deployS3]
     if: github.ref == 'refs/heads/staging'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/18](https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/18)

Add explicit `permissions` in `.github/workflows/main.yml`:

1. Set a restrictive default at workflow root:
   - `permissions:`
   - `contents: read`
2. Override only the write-required job (`deployStagingSpecs`) with job-level permissions:
   - `permissions:`
   - `contents: write`

This preserves functionality:
- Read-only token for most jobs (checkout, test/build steps).
- Write permission only where commit/tag push occurs.

Edit locations:
- Near top-level keys (after `concurrency` is a clean place) to add root `permissions`.
- Inside `jobs.deployStagingSpecs` (after `runs-on` is fine) to add job-level override.

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
