### PR TITLE
Potential fix for code scanning alert no. 36: Artifact poisoning

### DIFF
--- a/.github/workflows/wdio.yml
+++ b/.github/workflows/wdio.yml
@@ -58,14 +58,18 @@ jobs:
                 archive_format: 'zip',
               });
               const fs = require('fs');
-              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/app-id.zip`, Buffer.from(download.data));
+              const path = require('path');
+              const artifactDir = path.join(process.env.RUNNER_TEMP, 'artifacts');
+              fs.mkdirSync(artifactDir, { recursive: true });
+              fs.writeFileSync(path.join(artifactDir, 'app-id.zip'), Buffer.from(download.data));
             }
 
       - name: Extract app ID (from workflow_run)
         if: github.event_name == 'workflow_run'
         run: |
-          if [ -f app-id.zip ]; then
-            unzip -q app-id.zip -d LambdaTest/
+          if [ -f "${{ runner.temp }}/artifacts/app-id.zip" ]; then
+            mkdir -p "${{ runner.temp }}/artifacts/LambdaTest"
+            unzip -q "${{ runner.temp }}/artifacts/app-id.zip" -d "${{ runner.temp }}/artifacts/LambdaTest"
             echo "Extracted app ID from workflow_run artifact"
           fi
         continue-on-error: true
@@ -75,14 +79,20 @@ jobs:
         uses: actions/download-artifact@v6
         with:
           name: lambdatest-app-id
-          path: ${{ github.workspace }}/LambdaTest
+          path: ${{ runner.temp }}/artifacts/LambdaTest
         continue-on-error: true
 
       - name: Set LT_APP_ID environment variable
         run: |
-          if [ -f LambdaTest/last-app-id ]; then
-            echo "LT_APP_ID=$(tr -d '\n' < LambdaTest/last-app-id)" >> $GITHUB_ENV
-            echo "Using app ID: $(tr -d '\n' < LambdaTest/last-app-id)"
+          APP_ID_FILE="${{ runner.temp }}/artifacts/LambdaTest/last-app-id"
+          if [ -f "$APP_ID_FILE" ]; then
+            APP_ID="$(tr -d '\n' < "$APP_ID_FILE")"
+            if echo "$APP_ID" | grep -Eq '^[A-Za-z0-9._:-]{1,200}$'; then
+              echo "LT_APP_ID=$APP_ID" >> $GITHUB_ENV
+              echo "Using app ID: $APP_ID"
+            else
+              echo "Artifact app ID is invalid; tests will use default app ID from config"
+            fi
           else
             echo "No app ID artifact found, tests will use default app ID from config"
           fi


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/36](https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/36)

General fix approach:
- Treat all artifacts as untrusted.
- Download/extract artifacts only into an isolated temporary directory (`${{ runner.temp }}`), never directly into the repository workspace.
- Validate artifact content strictly before use (for app ID, enforce expected format and single-line value).

Best fix for this file:
1. In `.github/workflows/wdio.yml`, update the `workflow_run` artifact download step to write `app-id.zip` into `${{ runner.temp }}/artifacts`.
2. Update extraction step to unzip into `${{ runner.temp }}/artifacts/LambdaTest`.
3. Update manual `download-artifact` step path to `${{ runner.temp }}/artifacts/LambdaTest`.
4. Update `Set LT_APP_ID environment variable` step to read from `${{ runner.temp }}/artifacts/LambdaTest/last-app-id` and validate content with a strict regex before exporting to `GITHUB_ENV`.
5. Keep behavior unchanged otherwise: if artifact missing/invalid, fall back to default config.

No new imports or dependencies are needed (shell and existing actions suffice).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
