### PR TITLE
NR-563752 Updating the JavaScript error attribute naming and structure

### DIFF
--- a/Agent/JSError/JSErrorController.swift
+++ b/Agent/JSError/JSErrorController.swift
@@ -330,12 +330,15 @@ public class JSErrorController: NSObject {
         }
 
         if let message = errorData["message"] as? String {
-            event["description"] = message
+            event["errorMessage"] = message
         }
 
         if let name = errorData["name"] as? String {
-            event["errorType"] = name
+            event["errorName"] = name
         }
+
+        // High-level error classification
+        event["errorType"] = "JavascriptError"
 
         if let isFatal = errorData["isFatal"] as? Bool {
             event["isFatalError"] = isFatal ? "true" : "false"
@@ -510,5 +513,12 @@ public class JSErrorController: NSObject {
     /// Internal method for testing: clears persisted errors from disk
     @objc public func clearPersistedErrorsForTesting() {
         clearPersistedErrors()
+    }
+
+    /// Internal method for testing: formats an error as it would appear in the wire format
+    /// - Parameter errorData: The raw error data from the queue
+    /// - Returns: The formatted event as it would be sent over the wire
+    @objc public func formatErrorAsEventForTesting(_ errorData: [String: Any]) -> [String: Any] {
+        return formatErrorAsEvent(errorData)
     }
 }

--- a/Test Harness/NRTestApp/NRTestApp/ViewModels/UtilViewModel.swift
+++ b/Test Harness/NRTestApp/NRTestApp/ViewModels/UtilViewModel.swift
@@ -68,6 +68,7 @@ class UtilViewModel {
         options.append(UtilOption(title: "Make 100 Special Character Logs", handler: { [self] in make100SpecialCharacterLogs()}))
 
         options.append(UtilOption(title: "URLSession dataTask", handler: { [self] in doDataTask()}))
+        options.append(UtilOption(title: "Record JavaScript Error", handler: { [self] in recordJavascriptError()}))
         options.append(UtilOption(title: "Shut down New Relic Agent", handler: { [self] in shutDown()}))
     }
 
@@ -259,6 +260,19 @@ class UtilViewModel {
         let dataTask = urlSession.dataTask(with: request)
 
         dataTask.resume()
+    }
+
+    func recordJavascriptError() {
+        NewRelic.recordJavascriptError(
+            "TypeError",
+            message: "Cannot read property 'foo' of undefined",
+            stackTrace: "at myFunction (app.js:42:15)\nat anotherFunction (app.js:30:5)\nat main (app.js:10:3)",
+            isFatal: false,
+            additionalAttributes: [
+                "component": "TestComponent",
+                "cause": "Felt like it."
+            ]
+        )
     }
 
     @objc func make100SpecialCharacterLogs() {

--- a/Tests/Unit-Tests/NewRelicAgentTests/JS-Error-Tests/JSErrorControllerTests.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/JS-Error-Tests/JSErrorControllerTests.m
@@ -355,6 +355,134 @@
     XCTAssertEqual(errors.count, 0, @"Should not record error with empty message");
 }
 
+// MARK: - Wire Format Tests
+
+- (void)testWireFormatContainsErrorMessage {
+    JSErrorController* controller = [self createTestController];
+    XCTAssertNotNil(controller);
+
+    NSString* testMessage = @"Cannot read property 'foo' of undefined";
+    [controller recordJSError:@"TypeError"
+                      message:testMessage
+                   stackTrace:@"at testFunction (app.js:123:45)"
+                      isFatal:NO
+         additionalAttributes:nil];
+
+    NSArray* errors = [controller getErrorQueueForTesting];
+    NSDictionary* error = errors.firstObject;
+    NSDictionary* wireFormat = [controller formatErrorAsEventForTesting:error];
+
+    // errorMessage should be present and contain the message
+    XCTAssertNotNil(wireFormat[@"errorMessage"], @"errorMessage should be present in wire format");
+    XCTAssertEqualObjects(wireFormat[@"errorMessage"], testMessage, @"errorMessage should contain the error message");
+
+    // description should NOT be present (deprecated)
+    XCTAssertNil(wireFormat[@"description"], @"description attribute should no longer be present");
+}
+
+- (void)testWireFormatContainsErrorName {
+    JSErrorController* controller = [self createTestController];
+    XCTAssertNotNil(controller);
+
+    NSString* testName = @"TypeError";
+    [controller recordJSError:testName
+                      message:@"Test error message"
+                   stackTrace:@"at testFunction (app.js:123:45)"
+                      isFatal:NO
+         additionalAttributes:nil];
+
+    NSArray* errors = [controller getErrorQueueForTesting];
+    NSDictionary* error = errors.firstObject;
+    NSDictionary* wireFormat = [controller formatErrorAsEventForTesting:error];
+
+    // errorName should be present and contain the error name
+    XCTAssertNotNil(wireFormat[@"errorName"], @"errorName should be present in wire format");
+    XCTAssertEqualObjects(wireFormat[@"errorName"], testName, @"errorName should contain the JS error name");
+}
+
+- (void)testWireFormatErrorTypeIsHighLevelClassification {
+    JSErrorController* controller = [self createTestController];
+    XCTAssertNotNil(controller);
+
+    // Test with various specific error types
+    NSArray* errorNames = @[@"TypeError", @"ReferenceError", @"SyntaxError", @"RangeError"];
+
+    for (NSString* errorName in errorNames) {
+        [controller clearErrorQueueForTesting];
+
+        [controller recordJSError:errorName
+                          message:@"Test message"
+                       stackTrace:@"test stack"
+                          isFatal:NO
+             additionalAttributes:nil];
+
+        NSArray* errors = [controller getErrorQueueForTesting];
+        NSDictionary* error = errors.firstObject;
+        NSDictionary* wireFormat = [controller formatErrorAsEventForTesting:error];
+
+        // errorType should always be "JavascriptError" regardless of specific error name
+        XCTAssertNotNil(wireFormat[@"errorType"], @"errorType should be present in wire format");
+        XCTAssertEqualObjects(wireFormat[@"errorType"], @"JavascriptError",
+                             @"errorType should be 'JavascriptError' for %@", errorName);
+    }
+}
+
+- (void)testWireFormatErrorIdRemainsCamelCase {
+    JSErrorController* controller = [self createTestController];
+    XCTAssertNotNil(controller);
+
+    [controller recordJSError:@"TestError"
+                      message:@"Test message"
+                   stackTrace:@"test stack"
+                      isFatal:NO
+         additionalAttributes:nil];
+
+    NSArray* errors = [controller getErrorQueueForTesting];
+    NSDictionary* error = errors.firstObject;
+    NSDictionary* wireFormat = [controller formatErrorAsEventForTesting:error];
+
+    // errorId should be present and in camelCase format
+    XCTAssertNotNil(wireFormat[@"errorId"], @"errorId should be present in wire format");
+    XCTAssertTrue([wireFormat[@"errorId"] isKindOfClass:[NSString class]], @"errorId should be a string");
+
+    // Verify it's NOT in other formats (snake_case, kebab-case, etc.)
+    XCTAssertNil(wireFormat[@"error_id"], @"error_id (snake_case) should not be present");
+    XCTAssertNil(wireFormat[@"error-id"], @"error-id (kebab-case) should not be present");
+    XCTAssertNil(wireFormat[@"ErrorId"], @"ErrorId (PascalCase) should not be present");
+}
+
+- (void)testWireFormatCompleteStructure {
+    JSErrorController* controller = [self createTestController];
+    XCTAssertNotNil(controller);
+
+    [controller recordJSError:@"TypeError"
+                      message:@"Cannot read property 'x' of null"
+                   stackTrace:@"at function (file.js:10:5)"
+                      isFatal:YES
+         additionalAttributes:@{@"screen": @"HomeScreen", @"userId": @"12345"}];
+
+    NSArray* errors = [controller getErrorQueueForTesting];
+    NSDictionary* error = errors.firstObject;
+    NSDictionary* wireFormat = [controller formatErrorAsEventForTesting:error];
+
+    // Verify all expected attributes are present with correct names
+    XCTAssertEqualObjects(wireFormat[@"eventType"], @"MobileJSError", @"eventType should be MobileJSError");
+    XCTAssertNotNil(wireFormat[@"errorId"], @"errorId should be present");
+    XCTAssertEqualObjects(wireFormat[@"errorMessage"], @"Cannot read property 'x' of null", @"errorMessage should contain message");
+    XCTAssertEqualObjects(wireFormat[@"errorName"], @"TypeError", @"errorName should contain error name");
+    XCTAssertEqualObjects(wireFormat[@"errorType"], @"JavascriptError", @"errorType should be JavascriptError");
+    XCTAssertEqualObjects(wireFormat[@"isFatalError"], @"true", @"isFatalError should be true");
+    XCTAssertNotNil(wireFormat[@"timestamp"], @"timestamp should be present");
+    XCTAssertNotNil(wireFormat[@"threads"], @"threads should be present");
+
+    // Verify additional attributes are merged
+    XCTAssertEqualObjects(wireFormat[@"screen"], @"HomeScreen", @"Custom attributes should be merged");
+    XCTAssertEqualObjects(wireFormat[@"userId"], @"12345", @"Custom attributes should be merged");
+
+    // Verify deprecated attributes are NOT present
+    XCTAssertNil(wireFormat[@"description"], @"description should not be present");
+}
+
 // MARK: - Helper Methods
 
 // MARK: - Persistence and Duplicate Prevention Tests


### PR DESCRIPTION
## Changes

### Attribute Renaming & Additions
- **Removed:** `description` attribute (deprecated)
- **Added:** `errorMessage` attribute - Contains the JavaScript error message text
- **Added:** `errorName` attribute - Contains the specific JavaScript error name (e.g., "TypeError", "ReferenceError", "SyntaxError")
- **Updated:** `errorType` - Now contains high-level classification "JavascriptError" instead of the specific error name
- **Unchanged:** `errorId` - Remains in camelCase format (no changes needed)
