### PR TITLE
Potential fix for code scanning alert no. 36: Artifact poisoning

### DIFF
--- a/.github/workflows/wdio.yml
+++ b/.github/workflows/wdio.yml
@@ -27,8 +27,8 @@ jobs:
   ios-data:
     name: Generate iOS data
     runs-on: ubuntu-latest
-    # Only run if manually triggered or if uploadApp workflow succeeded
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    # Only run if manually triggered from main, or if trusted uploadApp workflow_run succeeded from main
+    if: ${{ (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.event == 'push') }}
     env:
       LT_USERNAME: ${{ secrets.LAMBDA_USERNAME }}
       LT_ACCESSKEY: ${{ secrets.LAMBDA_ACCESS_KEY }}


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/36](https://github.com/newrelic/newrelic-ios-agent/security/code-scanning/36)

To fix this without changing intended functionality, gate the `ios-data` job so it only runs when:
- manually dispatched from a trusted branch (e.g., `main`), or
- triggered by `workflow_run` **and** the upstream run succeeded **and** came from the trusted branch/event.

This reduces artifact poisoning risk by preventing untrusted workflow runs from feeding artifacts into a privileged job.  
Concretely, edit `.github/workflows/wdio.yml` at the job-level `if:` (line 31 region) to add strict conditions on `github.ref` for manual dispatch and on `github.event.workflow_run.head_branch` plus `github.event.workflow_run.event` for workflow_run-triggered executions.

No new actions, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
