### PR TITLE
chore add: Auto release note template

### DIFF
--- a/ios-agent-next.mdx
+++ b/ios-agent-next.mdx
@@ -1,0 +1,10 @@
+---
+subject: iOS agent
+releaseDate: '{RELEASE-DATE}'
+version: {VERSION-STRING}
+downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_{VERSION-STRING}.zip'
+---
+
+### New in this release
+
+### Fixed in this release


### PR DESCRIPTION
Missed adding this template file to the repo that bootstraps our release PR on docs-website. This commit adds it.