### PR TITLE
fix: Adds UIColor safety to MSR to resolve reported crash.

### DIFF
--- a/Agent/APrivateHeader.h
+++ b/Agent/APrivateHeader.h
@@ -11,6 +11,7 @@
 
 #import "NRMAMetric.h"
 #import "NRMATaskQueue.h"
+#import "NRMAExceptionHandler.h"
 #import "NRMAAssociate.h"
 #import "NRMAMethodSwizzling.h"
 #import "NRMASupportMetricHelper.h"

--- a/Agent/SessionReplay/NRMASessionReplay.swift
+++ b/Agent/SessionReplay/NRMASessionReplay.swift
@@ -193,9 +193,27 @@ public class NRMASessionReplay: NSObject {
                 NRLOG_AGENT_DEBUG("No key window found while trying to take a frame")
                 return
             }
-            
-            let frame = await sessionReplayCapture.recordFrom(rootView: window)
-            addFrame(frame)
+
+            // Backstop: a partially-deallocated view (rootViewController swap on
+            // sign-out, NR-566282) can raise an NSException deep inside UIKit /
+            // CoreGraphics that Swift can't catch. Wrap the capture so a single
+            // bad frame is dropped rather than taking the whole app down.
+            let captured: SessionReplayFrame? = await MainActor.run { () -> SessionReplayFrame? in
+                var result: SessionReplayFrame?
+                do {
+                    try NRMAExceptionHandler.safelyRun {
+                        result = self.sessionReplayCapture.recordFrom(rootView: window)
+                    }
+                } catch {
+                    NRLOG_AGENT_DEBUG("Session replay frame skipped after NSException: \(error.localizedDescription)")
+                    return nil
+                }
+                return result
+            }
+
+            if let frame = captured {
+                addFrame(frame)
+            }
         }
     }
     

--- a/Agent/SessionReplay/SessionReplayCapture.swift
+++ b/Agent/SessionReplay/SessionReplayCapture.swift
@@ -18,26 +18,31 @@ class SessionReplayCapture {
     
     @MainActor
     public func recordFrom(rootView:UIView) -> SessionReplayFrame {
-        let effectiveViewController = findRootViewController(rootView: rootView)
-        var rootViewControllerID:String?
-        if let rootViewController = effectiveViewController {
-            rootViewControllerID = String(describing: type(of: rootViewController))
+        // Bound the lifetime of every autoreleased UIKit / CF object touched
+        // during the walk to a single frame so we don't drag stale references
+        // across view-controller tear-downs. NR-566282.
+        return autoreleasepool {
+            let effectiveViewController = findRootViewController(rootView: rootView)
+            var rootViewControllerID:String?
+            if let rootViewController = effectiveViewController {
+                rootViewControllerID = String(describing: type(of: rootViewController))
+            }
+
+            var rootSwiftUIViewID: Int? = nil
+            var rootThingy = findRecorderForView(view: rootView)
+
+            // Reset counters for this frame capture
+            layoutContainerViewCount = 0
+            navigationStackDepth = 0
+
+            // Build tree using recursive approach to properly handle value semantics
+            buildViewTree(for: rootView, into: &rootThingy, rootSwiftUIViewID: &rootSwiftUIViewID)
+
+            // Set nextId for all views after tree is built
+            setNextIdRecursively(for: &rootThingy)
+
+            return SessionReplayFrame(date: Date(), views: rootThingy, rootViewControllerId: rootViewControllerID, rootSwiftUIViewId: rootSwiftUIViewID, size: rootView.frame.size, layoutContainerViewCount: layoutContainerViewCount, navigationStackDepth: navigationStackDepth)
         }
-        
-        var rootSwiftUIViewID: Int? = nil
-        var rootThingy = findRecorderForView(view: rootView)
-        
-        // Reset counters for this frame capture
-        layoutContainerViewCount = 0
-        navigationStackDepth = 0
-        
-        // Build tree using recursive approach to properly handle value semantics
-        buildViewTree(for: rootView, into: &rootThingy, rootSwiftUIViewID: &rootSwiftUIViewID)
-        
-        // Set nextId for all views after tree is built
-        setNextIdRecursively(for: &rootThingy)
-        
-        return SessionReplayFrame(date: Date(), views: rootThingy, rootViewControllerId: rootViewControllerID, rootSwiftUIViewId: rootSwiftUIViewID, size: rootView.frame.size, layoutContainerViewCount: layoutContainerViewCount, navigationStackDepth: navigationStackDepth)
     }
     
     private func buildViewTree(for currentView: UIView, into parentThingy: inout any SessionReplayViewThingy, rootSwiftUIViewID: inout Int?) {
@@ -72,10 +77,12 @@ class SessionReplayCapture {
                 }
             }
             
+            // Validate CGColor pointers up front — they can dangle during view
+            // tear-down (e.g. rootViewController swap on sign-out). NR-566282.
             let viewAttributes = SwiftUIViewAttributes(frame: parentThingy.viewDetails.frame,
                                                        clip: parentThingy.viewDetails.clip,
-                                                       backgroundColor: currentView.backgroundColor?.cgColor,
-                                                       layerBorderColor: currentView.layer.borderColor,
+                                                       backgroundColor: currentView.backgroundColor?.cgColor.safeColor,
+                                                       layerBorderColor: currentView.layer.borderColor?.safeColor,
                                                        layerBorderWidth: currentView.layer.borderWidth,
                                                        layerCornerRadius: currentView.layer.cornerRadius,
                                                        alpha: currentView.alpha,

--- a/Agent/SessionReplay/SwiftUI/Helpers/MakeCFTypeSafe.swift
+++ b/Agent/SessionReplay/SwiftUI/Helpers/MakeCFTypeSafe.swift
@@ -1,15 +1,2 @@
-#if os(iOS)
-import CoreGraphics
-
-private func makeSafe<T: CFTypeRef>(value: T?, expectedTypeID: CFTypeID) -> T? {
-    guard let value = value, CFGetTypeID(value)
-                                            == expectedTypeID else {
-        return nil
-    }
-    return value
-}
-
-internal extension CGColor {
-    var safeColor: CGColor? { makeSafe(value: self, expectedTypeID: CGColor.typeID) }
-}
-#endif
+// CGColor.safeColor moved to Agent/SessionReplay/UIColor+HexString.swift so it
+// is available on all Session Replay targets (iOS + tvOS). NR-566282.

--- a/Agent/SessionReplay/SwiftUI/UIHostingViewRecordOrchestrator.swift
+++ b/Agent/SessionReplay/SwiftUI/UIHostingViewRecordOrchestrator.swift
@@ -247,17 +247,26 @@ final class UIHostingViewRecordOrchestrator {
                                                y: frame.origin.y,
                                                width: frame.size.width + widthOffset,
                                                height: frame.size.height)
-                    
+
+                    // safeColor-validated bridges from CGColor → UIColor. If validation
+                    // fails the underlying CGColor was a dangling pointer (e.g. a
+                    // hosting view being torn down on sign-out) — fall back to .clear /
+                    // nil instead of crashing in CGColorSpaceGetModel. NR-566282.
+                    let bgUIColor: UIColor = (viewAttributes.backgroundColor?.safeColor)
+                        .map(UIColor.init(cgColor:)) ?? .clear
+                    let borderUIColor: UIColor? = (viewAttributes.layerBorderColor?.safeColor)
+                        .map(UIColor.init(cgColor:))
+
                     return ViewDetails(frame: adjustedFrame,
                                 clip: viewAttributes.clip,
-                                backgroundColor: UIColor(cgColor: viewAttributes.backgroundColor ?? UIColor.clear.cgColor),
+                                backgroundColor: bgUIColor,
                                 alpha: viewAttributes.alpha,
                                 isHidden: viewAttributes.isHidden,
                                 viewName: viewName,
                                 parentId: parentId,
                                 cornerRadius: viewAttributes.layerCornerRadius,
                                 borderWidth: viewAttributes.layerBorderWidth,
-                                borderColor: UIColor(cgColor:viewAttributes.layerBorderColor ?? UIColor.clear.cgColor),
+                                borderColor: borderUIColor,
                                 viewId: contentId,
                                 view: originalView,
                                 maskApplicationText: viewAttributes.maskApplicationText,

--- a/Agent/SessionReplay/UIColor+HexString.swift
+++ b/Agent/SessionReplay/UIColor+HexString.swift
@@ -8,6 +8,17 @@
 
 import Foundation
 import UIKit
+import CoreGraphics
+
+/// Returns the same CGColor only if its CFTypeID is actually CGColor's. A bridge
+/// against dangling pointers we may receive from a layer that's mid-deallocation
+/// (e.g. Session Replay walking the view tree during a rootViewController swap
+/// on sign-out — NR-566282).
+internal extension CGColor {
+    var safeColor: CGColor? {
+        CFGetTypeID(self) == CGColor.typeID ? self : nil
+    }
+}
 
 internal extension UIColor {
     func toHexString(includingAlpha: Bool) -> String {

--- a/Agent/SessionReplay/ViewCaptors/ViewDetails.swift
+++ b/Agent/SessionReplay/ViewCaptors/ViewDetails.swift
@@ -107,15 +107,21 @@ struct ViewDetails {
             self.frame = view.frame
             self.clip = view.bounds
         }
-        backgroundColor = view.backgroundColor
+        // Validate the backing CGColor before holding the UIColor — when a layer
+        // is being torn down (e.g. rootViewController swap during sign-out), its
+        // CGColor can be a dangling pointer. NR-566282.
+        if let bg = view.backgroundColor, bg.cgColor.safeColor != nil {
+            backgroundColor = bg
+        } else {
+            backgroundColor = nil
+        }
         alpha = view.alpha
         isHidden = view.isHidden
         cornerRadius = view.layer.cornerRadius
         borderWidth = view.layer.borderWidth
 
-        // Checking if we have a border, because asking for the layer's
-        // border color will always give us something
-        if view.layer.borderWidth > 0, let borderColor = view.layer.borderColor {
+        if view.layer.borderWidth > 0,
+           let borderColor = view.layer.borderColor?.safeColor {
             self.borderColor = UIColor(cgColor: borderColor)
         }
         else {

--- a/Agent/Utilities/NRMAExceptionHandler.h
+++ b/Agent/Utilities/NRMAExceptionHandler.h
@@ -12,4 +12,14 @@
 + (void) logException:(NSException*)exception
                 class:(NSString*)cls
              selector:(NSString*)sel;
+
+/**
+ Runs @c block inside an Obj-C @@try/@@catch. If @c block raises an NSException
+ the method returns NO and writes a description into @c error (if non-null);
+ otherwise returns YES. Used as a hard backstop for code paths that touch
+ partially-deallocated UIKit / CoreGraphics state (e.g. Session Replay's
+ view-hierarchy walk during a rootViewController swap — NR-566282).
+ */
++ (BOOL) safelyRun:(NS_NOESCAPE void(^)(void))block
+             error:(NSError * _Nullable * _Nullable)error;
 @end

--- a/Agent/Utilities/NRMAExceptionHandler.m
+++ b/Agent/Utilities/NRMAExceptionHandler.m
@@ -49,4 +49,24 @@
     }
 }
 
++ (BOOL) safelyRun:(NS_NOESCAPE void(^)(void))block
+             error:(NSError * _Nullable * _Nullable)error
+{
+    if (block == nil) { return YES; }
+    @try {
+        block();
+        return YES;
+    } @catch (NSException *ex) {
+        if (error != NULL) {
+            NSMutableDictionary *info = [NSMutableDictionary dictionary];
+            if (ex.name)   info[@"NSExceptionName"]   = ex.name;
+            if (ex.reason) info[NSLocalizedDescriptionKey] = ex.reason;
+            *error = [NSError errorWithDomain:@"com.newrelic.sessionreplay"
+                                         code:-1
+                                     userInfo:info];
+        }
+        return NO;
+    }
+}
+
 @end

--- a/Test Harness/NRTestApp/NRTestApp/Navigation/MainCoordinator.swift
+++ b/Test Harness/NRTestApp/NRTestApp/Navigation/MainCoordinator.swift
@@ -159,6 +159,13 @@ class MainCoordinator: Coordinator {
 #endif
     }
 
+    func showSignOutCrashReproViewController() {
+#if os(iOS)
+        let signOutVC = ViewControllerProvider.signOutCrashReproViewController
+        navigationController.pushViewController(signOutVC, animated: true)
+#endif
+    }
+
     func showSwitchTestViewController() {
 #if os(iOS)
         let switchTestViewController = ViewControllerProvider.switchTestViewController

--- a/Test Harness/NRTestApp/NRTestApp/Navigation/ViewControllerProvider.swift
+++ b/Test Harness/NRTestApp/NRTestApp/Navigation/ViewControllerProvider.swift
@@ -77,5 +77,11 @@ enum ViewControllerProvider {
         return viewController
     }
 #endif
+
+#if os(iOS)
+    static var signOutCrashReproViewController: SignOutCrashReproViewController {
+        return SignOutCrashReproViewController()
+    }
+#endif
 }
 

--- a/Test Harness/NRTestApp/NRTestApp/ViewControllers/BlockViewExamples.swift
+++ b/Test Harness/NRTestApp/NRTestApp/ViewControllers/BlockViewExamples.swift
@@ -505,3 +505,188 @@ class BlockViewPropagationTestController: UIViewController {
         }
     }
 }
+
+// MARK: - Sign-Out Crash Repro (NR-566282)
+//
+// Reproduces the customer flow that previously crashed Session Replay:
+//   1. A "logged-in" screen builds a dense view tree where every UIView has an
+//      explicit borderColor + backgroundColor on its CALayer.
+//   2. The user taps Sign Out, which swaps the window's rootViewController in a
+//      tight loop. Each swap deallocates the entire previous tree, including
+//      every layer's backing CGColor.
+//   3. Session Replay's once-per-second capture pass walks the tree on the
+//      main thread and tries to read those same colors. Before NR-566282 this
+//      resulted in EXC_BAD_ACCESS inside CGColorSpaceGetModel /
+//      UIColor.init(cgColor:). With the safeColor guards, autoreleasepool,
+//      and NRMAExceptionHandler.safelyRun backstop in place the capture either
+//      sees the new tree or drops a single frame — no crash.
+//
+// To exercise the fix:
+//   1. Run NRTestApp with Session Replay enabled (see AppDelegate config).
+//   2. Open this VC from the main menu ("Sign-Out Crash Repro").
+//   3. Tap "Sign Out (Repro)" and watch the device log: no EXC_BAD_ACCESS.
+//      You may see "Session replay frame skipped after NSException: ..."
+//      lines from NRMASessionReplay.takeFrame() — those are the backstop
+//      doing its job.
+
+#if os(iOS)
+final class SignOutCrashReproViewController: UIViewController {
+
+    private let statusLabel = UILabel()
+    private let signOutButton = UIButton(type: .system)
+
+    /// How many times the rootViewController is swapped per Sign-Out tap.
+    /// Tuned to a value that reliably overlapped with at least one Session
+    /// Replay capture pass during local testing.
+    private let swapCount = 30
+    /// Delay between swaps. Short enough to land inside one SR tick, long
+    /// enough to allow the runloop to fire layout / deallocation.
+    private let swapInterval: TimeInterval = 0.05
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Sign-Out Crash Repro"
+        view.backgroundColor = .systemBackground
+
+        buildDenseColoredTree()
+        installSignOutButton()
+        installStatusLabel()
+    }
+
+    // MARK: Tree of layered, colored views
+
+    /// Builds 4 levels × 5 children per level of nested UIViews, each with a
+    /// distinct random borderColor + backgroundColor set directly on the
+    /// CALayer. The customer crash signature is specifically a CGColor read
+    /// off a deallocating layer, so the more layers-with-colors the better.
+    private func buildDenseColoredTree() {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.backgroundColor = .systemGray6
+        view.addSubview(container)
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+            container.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            container.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            container.heightAnchor.constraint(equalToConstant: 360)
+        ])
+
+        addColoredChildren(into: container, depth: 4, fanOut: 5)
+    }
+
+    private func addColoredChildren(into parent: UIView, depth: Int, fanOut: Int) {
+        guard depth > 0 else { return }
+        for i in 0..<fanOut {
+            let child = UIView()
+            child.translatesAutoresizingMaskIntoConstraints = false
+            child.backgroundColor = UIColor(
+                red: .random(in: 0...1),
+                green: .random(in: 0...1),
+                blue: .random(in: 0...1),
+                alpha: 1.0
+            )
+            // Set borderColor directly on the layer — this is the exact path
+            // ViewDetails.init(view:) reads from.
+            child.layer.borderWidth = 1.0
+            child.layer.borderColor = UIColor(
+                red: .random(in: 0...1),
+                green: .random(in: 0...1),
+                blue: .random(in: 0...1),
+                alpha: 1.0
+            ).cgColor
+            child.layer.cornerRadius = 4
+
+            parent.addSubview(child)
+            NSLayoutConstraint.activate([
+                child.topAnchor.constraint(equalTo: parent.topAnchor, constant: CGFloat(i) * 4 + 8),
+                child.leadingAnchor.constraint(equalTo: parent.leadingAnchor, constant: CGFloat(i) * 4 + 8),
+                child.trailingAnchor.constraint(equalTo: parent.trailingAnchor, constant: -(CGFloat(i) * 4 + 8)),
+                child.bottomAnchor.constraint(equalTo: parent.bottomAnchor, constant: -(CGFloat(i) * 4 + 8))
+            ])
+
+            addColoredChildren(into: child, depth: depth - 1, fanOut: fanOut)
+        }
+    }
+
+    // MARK: Sign-out flow that triggers the race
+
+    private func installSignOutButton() {
+        signOutButton.translatesAutoresizingMaskIntoConstraints = false
+        signOutButton.setTitle("Sign Out (Repro)", for: .normal)
+        signOutButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+        signOutButton.accessibilityIdentifier = "sign_out_repro_button"
+        signOutButton.addTarget(self, action: #selector(didTapSignOut), for: .touchUpInside)
+        view.addSubview(signOutButton)
+        NSLayoutConstraint.activate([
+            signOutButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            signOutButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -32)
+        ])
+    }
+
+    private func installStatusLabel() {
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        statusLabel.numberOfLines = 0
+        statusLabel.textAlignment = .center
+        statusLabel.font = .preferredFont(forTextStyle: .footnote)
+        statusLabel.text = "Tap Sign Out to swap the rootViewController \(swapCount)× in \(Int(Double(swapCount) * swapInterval * 1000)) ms while Session Replay is recording."
+        view.addSubview(statusLabel)
+        NSLayoutConstraint.activate([
+            statusLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            statusLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+            statusLabel.bottomAnchor.constraint(equalTo: signOutButton.topAnchor, constant: -16)
+        ])
+    }
+
+    @objc private func didTapSignOut() {
+        guard let window = view.window else { return }
+        signOutButton.isEnabled = false
+        cycleSignOut(window: window, remaining: swapCount)
+    }
+
+    /// Replaces the window's rootViewController repeatedly. Each replacement
+    /// deallocates the previous controller's entire view tree (and every
+    /// layer's CGColor along with it) on the main thread — exactly the
+    /// situation that produced the customer's EXC_BAD_ACCESS.
+    private func cycleSignOut(window: UIWindow, remaining: Int) {
+        guard remaining > 0 else {
+            // Final state: a fresh, simple "logged out" screen so the test app
+            // is in a recognisable state when the loop ends.
+            let final = SignedOutPlaceholderViewController()
+            window.rootViewController = UINavigationController(rootViewController: final)
+            return
+        }
+
+        let next = SignOutCrashReproViewController()
+        window.rootViewController = UINavigationController(rootViewController: next)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + swapInterval) { [weak self, weak window] in
+            guard let self = self, let window = window else { return }
+            self.cycleSignOut(window: window, remaining: remaining - 1)
+        }
+    }
+}
+
+/// Tiny placeholder shown when the swap loop finishes. Gives the user a clear
+/// "we made it through without crashing" indicator.
+final class SignedOutPlaceholderViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Signed Out"
+        view.backgroundColor = .systemBackground
+
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "Sign-out repro completed without crashing."
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.font = .preferredFont(forTextStyle: .body)
+        view.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24)
+        ])
+    }
+}
+#endif

--- a/Test Harness/NRTestApp/NRTestApp/ViewControllers/ViewController.swift
+++ b/Test Harness/NRTestApp/NRTestApp/ViewControllers/ViewController.swift
@@ -287,6 +287,13 @@ class ViewController: UIViewController {
         // In setupButtonsTable(), add these options:
         options.append(UtilOption(title: "Add Hello World Label", handler: { [self] in addHelloWorldLabel() }))
         options.append(UtilOption(title: "Remove Hello World Label", handler: { [self] in removeHelloWorldLabel() }))
+
+        // NR-566282 — exercises the Session Replay sign-out / rootViewController-swap crash repro.
+        options.append(UtilOption(title: "Sign-Out Crash Repro", handler: { [self] in signOutCrashReproAction() }))
+    }
+
+    func signOutCrashReproAction() {
+        coordinator?.showSignOutCrashReproViewController()
     }
     
     func utilitiesAction() {


### PR DESCRIPTION
Fix:


  Files changed:
  - Agent/SessionReplay/ViewCaptors/ViewDetails.swift — init(view:) now validates both view.backgroundColor.cgColor
  - Agent/SessionReplay/ViewCaptors/ViewDetails.swift — init(view:) now validates both view.backgroundColor.cgColor
  and view.layer.borderColor through safeColor before touching them.
  - Agent/SessionReplay/SessionReplayCapture.swift — recordFrom(rootView:) body wrapped in autoreleasepool;
  SwiftUIViewAttributes initializer feeds safeColor-validated CGColors.
  - Agent/SessionReplay/SwiftUI/UIHostingViewRecordOrchestrator.swift — makeDetails() only constructs
  UIColor(cgColor:) after a safeColor check; falls back to .clear / nil.
  - Agent/SessionReplay/UIColor+HexString.swift — moved the CGColor.safeColor extension here so it's available on
  both iOS and tvOS targets.
  - Agent/SessionReplay/SwiftUI/Helpers/MakeCFTypeSafe.swift — emptied (kept as a placeholder note pointing to the
  new home).
  - Agent/Utilities/NRMAExceptionHandler.h/.m — added +safelyRun:error: (Obj-C @try/@catch bridge,
  Swift-throws-bridged).
  - Agent/APrivateHeader.h — exposed NRMAExceptionHandler.h to Swift via the NewRelicPrivate umbrella.
  - Agent/SessionReplay/NRMASessionReplay.swift — takeFrame() now runs recordFrom inside try
  NRMAExceptionHandler.safelyRun {…}; on NSException the frame is dropped with a debug log.

New UI Testcase added to NRTestApp                 
                                                         
  Files added/changed in Test Harness/NRTestApp/:                                                                                                                  
  - ViewControllers/BlockViewExamples.swift (appended) — two new classes:                                                                                          
    - SignOutCrashReproViewController — builds a 4-deep × 5-wide nested tree of UIViews, each with explicit layer.borderColor and layer.backgroundColor. A "Sign   
  Out (Repro)" button calls cycleSignOut, which swaps window.rootViewController 30× at 50 ms intervals (1.5 s window). Each swap deallocates the previous tree's   
  layers + their CGColors — exactly the customer's pattern.                                                                                                        
    - SignedOutPlaceholderViewController — final state shown when the loop finishes, so the operator knows it survived.                                            
  - Navigation/ViewControllerProvider.swift — added signOutCrashReproViewController factory.                                                                       
  - Navigation/MainCoordinator.swift — added showSignOutCrashReproViewController().                                                                                
  - ViewControllers/ViewController.swift — added "Sign-Out Crash Repro" entry to the main menu's button list.                                                      
                                                                                                                                                                   
  (All edits are inside existing files in the pbxproj — no project-file edits required.)                                                                           
                                                                                                                                                                   
  How to run the repro:                                                                                                                                            
  1. Boot a simulator and run NRTestApp with Session Replay enabled.                                                                                               
  2. From the home screen tap Sign-Out Crash Repro.                                                                                                                
  3. On the new screen tap Sign Out (Repro).                
  4. Watch the device console:                                                                                                                                     
    - Pre-fix (7.7.0/7.7.1): EXC_BAD_ACCESS inside UIColor.init(cgColor:) → CGColorSpaceGetModel.                                                                  
    - Post-fix: no crash. Occasional Session replay frame skipped after NSException: … lines may appear from the NRMASessionReplay.takeFrame() backstop — that's   
  the safety net working. The "Signed Out" screen appears after the loop completes.  