### PR TITLE
fix: Added a fix for crash in NRMAHarvester transitionToConnected:] (NRMAHarvester transitionToConnected:] (NRMAHarvester.mm:549)

### DIFF
--- a/Agent/Harvester/NRMAHarvester.mm
+++ b/Agent/Harvester/NRMAHarvester.mm
@@ -192,14 +192,73 @@
 
 - (void) configureHarvester:(NRMAHarvesterConfiguration*)harvestConfiguration
 {
-    NewRelic::Application::getInstance().setContext(NewRelic::ApplicationContext([[NSString stringWithFormat:@"%lld", harvestConfiguration.account_id] cStringUsingEncoding:NSUTF8StringEncoding],
-                                                                                 [[NSString stringWithFormat:@"%lld", harvestConfiguration.application_id] cStringUsingEncoding:NSUTF8StringEncoding],
-                                                                                 [[NSString stringWithFormat:@"%@", harvestConfiguration.trusted_account_key] cStringUsingEncoding:NSUTF8StringEncoding]));
+    if (![harvestConfiguration isKindOfClass:[NRMAHarvesterConfiguration class]]) {
+        NRLOG_AGENT_ERROR(@"configureHarvester: invalid configuration; skipping.");
+        return;
+    }
 
-    self.harvestData.dataToken = harvestConfiguration.data_token;
-    connection.serverTimestamp = harvestConfiguration.server_timestamp;
-    connection.crossProcessID  = harvestConfiguration.cross_process_id;
-    connection.requestHeadersMap = harvestConfiguration.request_header_map;
+#ifndef  DISABLE_NRMA_EXCEPTION_WRAPPER
+    @try {
+#endif
+        // Snapshot values into strong locals up front. Several object-typed properties on
+        // NRMAHarvesterConfiguration are declared 'assign' (e.g. request_header_map), so the
+        // backing object can be deallocated while the property still holds the pointer. Pulling
+        // values once and copying object types up front contains that risk to one wrapped block.
+        long long accountId = harvestConfiguration.account_id;
+        long long applicationId = harvestConfiguration.application_id;
+        NSString* trustedAccountKey = harvestConfiguration.trusted_account_key;
+        NRMADataToken* dataToken = harvestConfiguration.data_token;
+        long long serverTimestamp = harvestConfiguration.server_timestamp;
+        NSString* crossProcessID = harvestConfiguration.cross_process_id;
+
+        NSDictionary* requestHeaders = nil;
+        @try {
+            id rawHeaders = harvestConfiguration.request_header_map;
+            if ([rawHeaders isKindOfClass:[NSDictionary class]]) {
+                requestHeaders = [(NSDictionary*)rawHeaders copy];
+            }
+        } @catch (NSException* exception) {
+            NRLOG_AGENT_ERROR(@"configureHarvester: invalid request_header_map; ignoring.");
+            requestHeaders = nil;
+        }
+
+        // Keep the NSStrings alive for the lifetime of the setContext call so the C string
+        // pointers we hand to ApplicationContext remain valid.
+        NSString* accountIdString = [NSString stringWithFormat:@"%lld", accountId];
+        NSString* applicationIdString = [NSString stringWithFormat:@"%lld", applicationId];
+        NSString* trustedAccountKeyString = [NSString stringWithFormat:@"%@", trustedAccountKey ?: @""];
+
+        const char* accountIdCStr = [accountIdString cStringUsingEncoding:NSUTF8StringEncoding] ?: "";
+        const char* applicationIdCStr = [applicationIdString cStringUsingEncoding:NSUTF8StringEncoding] ?: "";
+        const char* trustedAccountKeyCStr = [trustedAccountKeyString cStringUsingEncoding:NSUTF8StringEncoding] ?: "";
+
+        NewRelic::Application::getInstance().setContext(NewRelic::ApplicationContext(accountIdCStr,
+                                                                                     applicationIdCStr,
+                                                                                     trustedAccountKeyCStr));
+
+        NRMAHarvestData* localHarvestData = self.harvestData;
+        if (localHarvestData != nil) {
+            localHarvestData.dataToken = dataToken;
+        } else {
+            NRLOG_AGENT_ERROR(@"configureHarvester: harvestData is nil; skipping data_token assignment.");
+        }
+
+        NRMAHarvesterConnection* localConnection = connection;
+        if (localConnection != nil) {
+            localConnection.serverTimestamp = serverTimestamp;
+            localConnection.crossProcessID  = crossProcessID ?: @"";
+            localConnection.requestHeadersMap = requestHeaders;
+        } else {
+            NRLOG_AGENT_ERROR(@"configureHarvester: connection is nil; skipping connection updates.");
+        }
+#ifndef  DISABLE_NRMA_EXCEPTION_WRAPPER
+    } @catch (NSException* exception) {
+        NRLOG_AGENT_ERROR(@"configureHarvester: caught exception %@: %@", exception.name, exception.reason);
+        [NRMAExceptionHandler logException:exception
+                                     class:NSStringFromClass([self class])
+                                  selector:NSStringFromSelector(_cmd)];
+    }
+#endif
 }
 
 - (NSString *) applicationIdentifierAsString
@@ -544,15 +603,32 @@
 
 - (void) transitionToConnected:(NRMAHarvesterConfiguration*)_configuration
 {
-     NRLOG_AGENT_VERBOSE(@"config: transitionToConnected");
+    NRLOG_AGENT_VERBOSE(@"config: transitionToConnected");
 
-    // Called from disconnected.
-    [self configureHarvester:_configuration];
-    
-    [self transition:NRMA_HARVEST_CONNECTED];
-    // Function will immediately send data.
-    [self execute];
-    return;
+    // Validate the inbound configuration before touching it. Sending messages to a
+    // freed/corrupt object here is the suspected root cause of crashes seen at this site.
+    if (![_configuration isKindOfClass:[NRMAHarvesterConfiguration class]]) {
+        NRLOG_AGENT_ERROR(@"transitionToConnected: invalid configuration; aborting transition.");
+        return;
+    }
+
+#ifndef  DISABLE_NRMA_EXCEPTION_WRAPPER
+    @try {
+#endif
+        // Called from disconnected.
+        [self configureHarvester:_configuration];
+
+        [self transition:NRMA_HARVEST_CONNECTED];
+        // Function will immediately send data.
+        [self execute];
+#ifndef  DISABLE_NRMA_EXCEPTION_WRAPPER
+    } @catch (NSException* exception) {
+        NRLOG_AGENT_ERROR(@"transitionToConnected: caught exception %@: %@", exception.name, exception.reason);
+        [NRMAExceptionHandler logException:exception
+                                     class:NSStringFromClass([self class])
+                                  selector:NSStringFromSelector(_cmd)];
+    }
+#endif
 }
 
 - (NRMAHarvesterConfiguration*) configureFromCollector:(NRMAHarvestResponse*)response


### PR DESCRIPTION
1. […NRMAHarvester.mm:549](fix: Added a fix for crash in NRMAHarvester transitionToConnected:] (NRMAHarvester transitionToConnected:] (NRMAHarvester.mm:549))

Hardened Agent/Harvester/NRMAHarvester.mm:

  transitionToConnected: (NRMAHarvester.mm:604)
  - isKindOfClass: guard on _configuration — bails cleanly instead of objc_msgSend-ing into a freed/corrupt object (the suspected root cause).
  - Wrapped body in the file's @try/NRMAExceptionHandler pattern as a last-line defense.

  configureHarvester: (NRMAHarvester.mm:193)
  - isKindOfClass: guard on the inbound config.
  - Snapshots all property reads into strong locals up front, so a single transient failure can't corrupt mid-flow state.
  - Defensively copys request_header_map inside an inner @try — that property is declared assign for NSDictionary* in the header (likely the actual smoking gun),
  which lets the backing dict be freed while the pointer lives. The copy neutralizes any dangling reference.
  - Holds the NSStrings feeding cStringUsingEncoding: in named locals so the C-string pointers handed to the C++ ApplicationContext stay valid for the call.
  - Nil-checks self.harvestData and connection before assigning.
  - Whole body wrapped in @try/NRMAExceptionHandler.


2. All eight misdeclared properties are fixed. Final state in Agent/Harvester/DataStore/NRMAHarvesterConfiguration.h:
                                  
  NRMAHarvesterConfiguration (lines 94, 102, 107, 116):                                                                                                            
  - encoding_key — assign → copy                                                                                                                                   
  - request_header_map — assign → copy                                                                                                                             
  - log_reporting_level — assign → copy                                                                                                                            
  - session_replay_mode — assign → copy                                                                                                                            
                                                                                                                                                                   
  SessionReplayCustomMaskingRule (lines 157–160):                                                                                                                  
  - identifier, name, operatorName, type — all assign → copy                                                                                                       
                                                                                                                                                                   
  Why copy over strong:                                     
  - For NSString/NSArray/NSDictionary, copy is the standard idiom — defensive against an NSMutable* being passed in and later mutated out from under us.           
  - For immutable inputs (the common case here, since values come from JSON-decoded dictionaries), the runtime optimization makes [NSString/NSArray/NSDictionary   
  copy] equivalent to retain — so no perf hit and no behavior change.                                                                                            
  - session_replay_mode == SessionReplayMaskingModeDefault pointer compare on .m:254 keeps working: copying an immutable NSString constant returns the same        
  instance, so the constant pointer is preserved.                                                                                                          
                                                                                                                                                                   
  Compatibility check from the .m: every consumer of these properties only reads or assigns; nobody mutates through the property reference (e.g. no
  [self.request_header_map setObject:…]), so switching to copy is safe.                                                                                            
                                                            
  Net effect: the dangling-pointer-into-objc_msgSend failure mode at the harvester crash site is now closed at the source. The defensive snapshot/@try work in     
  NRMAHarvester.mm from the previous turn becomes belt-and-suspenders rather than load-bearing.