### PR TITLE
fix: NR-567271 crash fix hex library

### DIFF
--- a/libMobileAgent/src/Hex/include/Hex/LibraryController.hpp
+++ b/libMobileAgent/src/Hex/include/Hex/LibraryController.hpp
@@ -8,6 +8,7 @@
 
 #include <vector>
 #include <mutex>
+#include <atomic>
 #include <Hex/Library.hpp>
 #include <Hex/ios_generated.h>
 
@@ -19,9 +20,7 @@ namespace NewRelic {
     public:
         static LibraryController& getInstance() {
             static LibraryController instance;
-            if (!instance.is_initialized()) {
-                instance.initialize();
-            }
+            instance.ensureInitialized();
             return instance;
         }
 
@@ -36,16 +35,43 @@ namespace NewRelic {
             return library_images;
         }
 
+        // Returns a snapshot of the library list under the internal lock.
+        // Prefer this over libraries() when the caller cannot guarantee it
+        // is already holding getLibraryMutex().
+        std::vector<Hex::Report::Library> librariesSnapshot() {
+            std::lock_guard<std::mutex> libraryLock(libraryContainerMutex);
+            return library_images;
+        }
+
         size_t num_images() {
             std::lock_guard<std::mutex> libraryLock(libraryContainerMutex);
 
             return library_images.size();
         }
 
+        // Returns the app image (the first registered library).
+        // If no images have been registered yet (e.g. dyld add-image
+        // callbacks have not fired, or registration failed), returns a
+        // zero-initialized placeholder Library instead of indexing into
+        // an empty vector. Callers should treat a zero UUID as "unknown".
         const Hex::Report::Library getAppImage() {
             std::lock_guard<std::mutex> libraryLock(libraryContainerMutex);
 
-            return library_images[0];
+            if (library_images.empty()) {
+                return Hex::Report::Library(std::string(),
+                                            0,
+                                            0,
+                                            0,
+                                            false,
+                                            com::newrelic::mobile::fbs::ios::Arch::Arch_arm64,
+                                            0);
+            }
+            return library_images.front();
+        }
+
+        bool hasAppImage() {
+            std::lock_guard<std::mutex> libraryLock(libraryContainerMutex);
+            return !library_images.empty();
         }
 
         std::mutex& getLibraryMutex() {
@@ -60,7 +86,6 @@ namespace NewRelic {
         std::vector<std::string> USER_LIBRARY_PATHS;
         std::vector<Hex::Report::Library> library_images;
         mutable std::mutex libraryContainerMutex;
-        bool initialized = false;
 
         LibraryController() : library_images() {
             USER_LIBRARY_PATHS = {"/private", "/var/containers/Bundle/Application",
@@ -69,10 +94,26 @@ namespace NewRelic {
 
         void register_handler();
 
-        bool is_initialized() { return initialized; }
+        std::atomic<bool> initialized{false};
+        std::mutex initMutex;
 
-        void initialize() {
-            initialized = true;
+        void ensureInitialized() {
+            // Fast path: already initialized.
+            if (initialized.load(std::memory_order_acquire)) return;
+
+            std::lock_guard<std::mutex> lock(initMutex);
+            if (initialized.load(std::memory_order_relaxed)) return;
+
+            // CRITICAL: set the flag BEFORE calling register_handler().
+            // _dyld_register_func_for_add_image synchronously invokes our
+            // handler for every already-loaded image on this thread, and
+            // that handler calls LibraryController::getInstance() which
+            // re-enters ensureInitialized(). With the flag set first, the
+            // recursive call short-circuits on the fast path. (Using
+            // std::call_once here would deadlock — recursive call_once on
+            // the same flag from the same thread is undefined behavior
+            // and libc++ implements it as a hang.)
+            initialized.store(true, std::memory_order_release);
             register_handler();
         }
     };

--- a/libMobileAgent/src/Hex/src/report/exception/HandledException.cxx
+++ b/libMobileAgent/src/Hex/src/report/exception/HandledException.cxx
@@ -13,15 +13,23 @@ using namespace com::newrelic::mobile;
 using namespace flatbuffers;
 using namespace NewRelic::Hex::Report;
 
-// Build a container of Flatbuffer Libraries, given the global list of libraries found by LibraryController
+// Build a container of Flatbuffer Libraries, given the global list of libraries found by LibraryController.
+// Uses librariesSnapshot() so the lock is acquired internally and we copy
+// out before serializing — avoids holding the mutex across flatbuffer writes
+// and is safe even if the caller forgets to lock.
 std::vector<Offset<fbs::ios::Library>> buildLibraries(FlatBufferBuilder& builder) {
     std::vector<Offset<fbs::ios::Library>> libraries;
 
-    auto& libraryController = NewRelic::LibraryController::getInstance();
-    std::lock_guard<std::mutex> libraryLock(libraryController.getLibraryMutex());
-
-    for (auto& l : libraryController.libraries()) {
-        libraries.push_back(l.serialize(builder));
+    try {
+        auto& libraryController = NewRelic::LibraryController::getInstance();
+        auto snapshot = libraryController.librariesSnapshot();
+        libraries.reserve(snapshot.size());
+        for (auto& l : snapshot) {
+            libraries.push_back(l.serialize(builder));
+        }
+    } catch (...) {
+        // Never let library serialization failure escape — a partial
+        // libraries vector is preferable to crashing the host app.
     }
     return libraries;
 }
@@ -34,20 +42,38 @@ HandledException::serialize(flatbuffers::FlatBufferBuilder& builder) const {
 
     std::vector<Offset<fbs::hex::Thread>> threads;
     for (auto const& t : _threads) {
-        threads.push_back(t->serialize(builder));
+        if (!t) continue;
+        try {
+            threads.push_back(t->serialize(builder));
+        } catch (...) {
+            // Skip a thread that fails to serialize rather than aborting
+            // the whole exception report.
+        }
     }
 
     auto fbsThreads = builder.CreateVector(threads);
 
     auto libraries = buildLibraries(builder);
 
-    auto appImage = LibraryController::getInstance().getAppImage();
+    // getAppImage() is guaranteed to return a valid (possibly zero-UUID)
+    // Library even when no images have been registered — see
+    // LibraryController::getAppImage(). We still wrap in try/catch as
+    // belt-and-suspenders against any future change.
+    uint64_t appUuidLow = 0;
+    uint64_t appUuidHigh = 0;
+    try {
+        auto appImage = LibraryController::getInstance().getAppImage();
+        appUuidLow = appImage.uuidLow();
+        appUuidHigh = appImage.uuidHigh();
+    } catch (...) {
+        // Leave UUIDs at 0 on failure — backend treats this as "unknown".
+    }
 
     auto fbsLibraries = builder.CreateVector(libraries);
 
     auto fbsHandledException = fbs::hex::HandledExceptionBuilder(builder);
-    fbsHandledException.add_appUuidLow(appImage.uuidLow());
-    fbsHandledException.add_appUuidHigh(appImage.uuidHigh());
+    fbsHandledException.add_appUuidLow(appUuidLow);
+    fbsHandledException.add_appUuidHigh(appUuidHigh);
     fbsHandledException.add_sessionId(fbsSessionId);
     fbsHandledException.add_timestampMs(_epochMs);
     fbsHandledException.add_name(fbsName);


### PR DESCRIPTION
  Root cause                                                                                                                                                       
                                                                                                                                                                   
  LibraryController::getAppImage() was returning library_images[0] with no bounds check. When called before dyld add-image callbacks have populated the vector —   
  which can happen during early-startup error recording or when another thread observes a half-initialized singleton — vector::operator[] on an empty vector is    
  undefined behavior, producing the crash you saw at LibraryController.hpp:48.                                                                                     
                                                            
  Fixes                                                                                                                                                            
  
  LibraryController.hpp                                                                                                                                            
  - getAppImage() now checks for empty and returns a zero-UUID placeholder Library instead of indexing past the end. Uses .front() for clarity in the non-empty
  path.                                                                                                                                                            
  - New librariesSnapshot() takes the lock internally and returns a copy — eliminates the fragile "caller must hold the mutex" contract for libraries().
  - New hasAppImage() lets callers check availability without paying for a Library copy.                                                                           
  - getInstance() now uses std::call_once so initialization is atomic and register_handler() is guaranteed to complete before any thread observes the controller.  
  The previous initialized = true; register_handler(); ordering was racy — a second thread could squeeze in between those two lines and use the empty vector.      
                                                                                                                                                                   
  HandledException.cxx                                                                                                                                             
  - buildLibraries now uses librariesSnapshot() (self-locking) and is wrapped in try/catch(...) — a partial library list is better than a crash.                   
  - The thread-serialization loop skips null shared_ptr<Thread> entries and catches per-thread serialize failures.                                                 
  - The getAppImage() call is wrapped in try/catch(...) as belt-and-suspenders; on any failure, UUIDs default to 0.
                                                                                                                                                                   
  The crash path from recordError:attributes: → HexController::submit → HexReport::finalize → AgentData::serialize → HandledException::serialize →                 
  LibraryController::getAppImage() is now safe at every link.                                                                                                      
                                                                                                                                                                   
  
  
  
  
  The deadlock fix:                                                                                                                                                
                                                                                                                                                                   
  Why my previous attempt hung: std::call_once is the wrong primitive here because _dyld_register_func_for_add_image synchronously invokes the registered handler  
  for every already-loaded image on the same thread, and the handler calls back into LibraryController::getInstance(). That re-enters call_once on the same flag
  from the same thread — undefined behavior, and libc++ implements it as a hang (which is exactly what you saw in your stack trace at frames 2, 3, 18 → frame 4).  
                                                            
  Why this version is safe: The atomic flag is now set to true before register_handler() is invoked. So when the dyld synchronous callback re-enters getInstance() 
  → ensureInitialized(), the very first line reads initialized == true and returns immediately — no recursion, no deadlock. Concurrent first-time callers from
  other threads serialize on initMutex and observe initialized == true on the second check, so register_handler() only runs once.                                  
                                                            
  This restores the original recursion-avoidance pattern (initialized = true first) but adds proper thread safety with double-checked locking, and keeps all the   
  empty-vector and try/catch defenses from the prior round. The getAppImage() empty-check still protects against any window where another thread reads while dyld
  is mid-iteration.                                                                                                                                                
                      