### PR TITLE
NR-568934 fix: replace timestamp-seeded LCG in IGuidGenerator with arc4random_buf

### DIFF
--- a/Agent.xcodeproj/project.pbxproj
+++ b/Agent.xcodeproj/project.pbxproj
@@ -1589,6 +1589,9 @@
 		D48D551A2F4E46B2003BE3AB /* JSErrorController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48D55172F4E46B2003BE3AB /* JSErrorController.swift */; };
 		D48D551D2F4E63B9003BE3AB /* NRMAJSErrorHarvestAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = D48D551C2F4E63B9003BE3AB /* NRMAJSErrorHarvestAdapter.m */; };
 		D48D551E2F4E63B9003BE3AB /* NRMAJSErrorHarvestAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = D48D551B2F4E63B9003BE3AB /* NRMAJSErrorHarvestAdapter.h */; };
+		D4C36C962FC902B7001DD597 /* TestGuidUniqueness.mm in Sources */ = {isa = PBXBuildFile; fileRef = D4C36C952FC902B7001DD597 /* TestGuidUniqueness.mm */; };
+		D4C36C972FC902B7001DD597 /* TestGuidUniqueness.mm in Sources */ = {isa = PBXBuildFile; fileRef = D4C36C952FC902B7001DD597 /* TestGuidUniqueness.mm */; };
+		D4C36C982FC902B7001DD597 /* TestGuidUniqueness.mm in Sources */ = {isa = PBXBuildFile; fileRef = D4C36C952FC902B7001DD597 /* TestGuidUniqueness.mm */; };
 		F6E79C7325A65347006277FB /* W3CTraceState.mm in Sources */ = {isa = PBXBuildFile; fileRef = F6E79C6D25A65346006277FB /* W3CTraceState.mm */; };
 		F6E79C7425A65347006277FB /* W3CTraceState.mm in Sources */ = {isa = PBXBuildFile; fileRef = F6E79C6D25A65346006277FB /* W3CTraceState.mm */; };
 		F6E79C7525A65347006277FB /* W3CTraceState.h in Headers */ = {isa = PBXBuildFile; fileRef = F6E79C6E25A65346006277FB /* W3CTraceState.h */; };
@@ -2701,6 +2704,7 @@
 		D48D55182F4E46B2003BE3AB /* MobileErrorsUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileErrorsUploader.swift; sourceTree = "<group>"; };
 		D48D551B2F4E63B9003BE3AB /* NRMAJSErrorHarvestAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NRMAJSErrorHarvestAdapter.h; sourceTree = "<group>"; };
 		D48D551C2F4E63B9003BE3AB /* NRMAJSErrorHarvestAdapter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRMAJSErrorHarvestAdapter.m; sourceTree = "<group>"; };
+		D4C36C952FC902B7001DD597 /* TestGuidUniqueness.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TestGuidUniqueness.mm; sourceTree = "<group>"; };
 		F6E79C6D25A65346006277FB /* W3CTraceState.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = W3CTraceState.mm; sourceTree = "<group>"; };
 		F6E79C6E25A65346006277FB /* W3CTraceState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = W3CTraceState.h; sourceTree = "<group>"; };
 		F6E79C7025A65346006277FB /* W3CTraceParent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = W3CTraceParent.mm; sourceTree = "<group>"; };
@@ -4296,6 +4300,7 @@
 		F6E79CFA25A7590B006277FB /* DistributedTesting-Tests */ = {
 			isa = PBXGroup;
 			children = (
+				D4C36C952FC902B7001DD597 /* TestGuidUniqueness.mm */,
 				F6E79D0225A75E6E006277FB /* TestNRMATraceContext.mm */,
 				F6E79D1A25A78689006277FB /* TestW3CTraceParent.mm */,
 				F6E79D2A25A788AB006277FB /* TestW3CTraceState.mm */,
@@ -5649,6 +5654,7 @@
 				0209ACA224E7393300E45C90 /* NRThreadInfoTest.m in Sources */,
 				F8FBFA5F2A78336200CDC8C5 /* TestNRMAPayload.m in Sources */,
 				0209ABF524E706FA00E45C90 /* NRGCDOverrideTest.m in Sources */,
+				D4C36C962FC902B7001DD597 /* TestGuidUniqueness.mm in Sources */,
 				D46F91C22F69CD5600FD2EBE /* UISwitchThingy.swift in Sources */,
 				0209ABC324E7057900E45C90 /* NRAgentTestBase.m in Sources */,
 				0209ACA124E7393300E45C90 /* NRUncaughtExceptionhandlerTests.m in Sources */,
@@ -6094,6 +6100,7 @@
 				0256584B24EB19BF00FE3125 /* NRMethodProfilerTests.m in Sources */,
 				0256584C24EB19BF00FE3125 /* MachineMeasurementsTest.m in Sources */,
 				0256584D24EB19BF00FE3125 /* NRThreadInfoTests.m in Sources */,
+				D4C36C982FC902B7001DD597 /* TestGuidUniqueness.mm in Sources */,
 				3431DD922BED4C9B00FF145F /* TestCustomEvents.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -6393,6 +6400,7 @@
 				3431DD9A2BED8E5B00FF145F /* APINetworkNoticeTest.m in Sources */,
 				3431DD372BED383C00FF145F /* NRMAInternalTests.m in Sources */,
 				3431DD3E2BED385D00FF145F /* NRCPUVitalsTest.m in Sources */,
+				D4C36C972FC902B7001DD597 /* TestGuidUniqueness.mm in Sources */,
 				3431DD362BED381600FF145F /* TestW3CTraceState.mm in Sources */,
 				3431DD3C2BED384D00FF145F /* ZZZCodeCoverageTest.m in Sources */,
 				3431DD3A2BED384700FF145F /* NRMAUUIDStoreTests.m in Sources */,

--- a/Tests/Unit-Tests/NewRelicAgentTests/DistributedTesting-Tests/TestGuidUniqueness.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/DistributedTesting-Tests/TestGuidUniqueness.mm
@@ -1,0 +1,196 @@
+//
+//  TestGuidUniqueness.mm
+//  Agent_Tests
+//
+//  Regression coverage for NR-516417 / NR-XXXXXX (mCDP cross-region span ID
+//  collisions). The previous IGuidGenerator reseeded a default_random_engine
+//  with a 32-bit-truncated wall-clock value on every call, so two devices that
+//  hit the generator in the same clock tick produced identical trace and span
+//  IDs. These tests assert that high-volume single-threaded and concurrent use
+//  of the production payload-generation path does not produce duplicates.
+//
+//  Copyright © 2026 New Relic. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <vector>
+
+#include <Connectivity/Facade.hpp>
+#include <Utilities/Application.hpp>
+#include <Utilities/ApplicationContext.hpp>
+
+@interface TestGuidUniqueness : XCTestCase
+@end
+
+@implementation TestGuidUniqueness
+
+- (void)setUp {
+    NewRelic::Application::getInstance().setContext(
+        NewRelic::ApplicationContext("accountId", "applicationId", "1"));
+}
+
+- (void)tearDown {
+    NewRelic::Application::getInstance().setContext(
+        NewRelic::ApplicationContext("", "", ""));
+}
+
+- (void)testFacadeNewPayloadTightLoopProducesNoDuplicates {
+    // newPayload is the cheapest production code path (one generateGuid call,
+    // no trace-id regeneration, no string formatting beyond the 16-char id).
+    // Tight loop maximises same-clock-tick density to surface the LCG bug.
+    NewRelic::Application::getInstance().setContext(
+        NewRelic::ApplicationContext("accountId", "applicationId", "1"));
+    (void)NewRelic::Connectivity::Facade::getInstance().startTrip();   // seed _currentTraceId
+
+    const NSUInteger iterations = 100000;
+    NSMutableSet<NSString*> *seen = [NSMutableSet setWithCapacity:iterations];
+    NSUInteger duplicates = 0;
+    NSString *firstDup = nil;
+    NSUInteger firstDupIter = 0;
+
+    for (NSUInteger i = 0; i < iterations; i++) {
+        auto payload = NewRelic::Connectivity::Facade::getInstance().newPayload();
+        if (!payload) continue;
+        NSString *spanId = @(payload->getId().c_str());
+        if ([seen containsObject:spanId]) {
+            if (duplicates == 0) { firstDup = spanId; firstDupIter = i; }
+            duplicates++;
+        } else {
+            [seen addObject:spanId];
+        }
+    }
+
+    XCTAssertEqual(duplicates, 0u,
+                   @"%lu duplicate span IDs across %lu newPayload calls; first was %@ at iter %lu",
+                   (unsigned long)duplicates, (unsigned long)iterations,
+                   firstDup, (unsigned long)firstDupIter);
+}
+
+- (void)testFacadeNewPayloadTightLoopUnderConcurrencyProducesNoDuplicates {
+    NewRelic::Application::getInstance().setContext(
+        NewRelic::ApplicationContext("accountId", "applicationId", "1"));
+    (void)NewRelic::Connectivity::Facade::getInstance().startTrip();
+
+    const NSUInteger threadCount = 64;
+    const NSUInteger perThread   = 5000;
+
+    NSLock *lock = [[NSLock alloc] init];
+    NSMutableSet<NSString*> *seen = [NSMutableSet setWithCapacity:threadCount * perThread];
+    __block NSUInteger duplicates = 0;
+
+    dispatch_apply(threadCount, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^(size_t) {
+        @autoreleasepool {
+            std::vector<std::string> local;
+            local.reserve(perThread);
+            for (NSUInteger i = 0; i < perThread; i++) {
+                auto payload = NewRelic::Connectivity::Facade::getInstance().newPayload();
+                if (payload) local.push_back(payload->getId());
+            }
+
+            [lock lock];
+            for (auto& s : local) {
+                NSString *n = @(s.c_str());
+                if ([seen containsObject:n]) duplicates++;
+                else [seen addObject:n];
+            }
+            [lock unlock];
+        }
+    });
+
+    XCTAssertEqual(duplicates, 0u,
+                   @"%lu duplicate span IDs across %lu concurrent newPayload calls",
+                   (unsigned long)duplicates,
+                   (unsigned long)(threadCount * perThread));
+}
+
+- (void)testFacadeStartTripProducesUniqueIdsAtVolume {
+    const NSUInteger iterations = 20000;
+    NSMutableSet<NSString*> *traceIds = [NSMutableSet setWithCapacity:iterations];
+    NSMutableSet<NSString*> *spanIds  = [NSMutableSet setWithCapacity:iterations];
+    NSUInteger traceDupes = 0;
+    NSUInteger spanDupes  = 0;
+
+    for (NSUInteger i = 0; i < iterations; i++) {
+        auto payload = NewRelic::Connectivity::Facade::getInstance().startTrip();
+        XCTAssertTrue(payload != nullptr);
+        NSString *traceId = @(payload->getTraceId().c_str());
+        NSString *spanId  = @(payload->getId().c_str());
+
+        XCTAssertEqual(traceId.length, 32u, @"trace id must be 32 hex chars");
+        XCTAssertEqual(spanId.length,  16u, @"span id must be 16 hex chars");
+
+        if ([traceIds containsObject:traceId]) traceDupes++; else [traceIds addObject:traceId];
+        if ([spanIds containsObject:spanId])   spanDupes++;  else [spanIds addObject:spanId];
+    }
+    XCTAssertEqual(traceDupes, 0u, @"%lu trace-id duplicates across %lu startTrip calls", (unsigned long)traceDupes, (unsigned long)iterations);
+    XCTAssertEqual(spanDupes,  0u, @"%lu span-id duplicates across %lu startTrip calls",  (unsigned long)spanDupes,  (unsigned long)iterations);
+}
+
+- (void)testGeneratePayloadProducesUniqueIdsUnderConcurrency {
+    NewRelic::Application::getInstance().setContext(
+        NewRelic::ApplicationContext("accountId", "applicationId", "1"));
+
+    const NSUInteger threadCount = 32;
+    const NSUInteger perThread   = 2000;
+
+    NSLock *lock = [[NSLock alloc] init];
+    NSMutableSet<NSString*> *traceIds = [NSMutableSet setWithCapacity:threadCount * perThread];
+    NSMutableSet<NSString*> *spanIds  = [NSMutableSet setWithCapacity:threadCount * perThread];
+    __block NSUInteger traceCollisions = 0;
+    __block NSUInteger spanCollisions  = 0;
+    __block NSUInteger nullPayloads    = 0;
+
+    dispatch_apply(threadCount, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^(size_t) {
+        @autoreleasepool {
+            NSMutableArray<NSString*> *localTrace = [NSMutableArray arrayWithCapacity:perThread];
+            NSMutableArray<NSString*> *localSpan  = [NSMutableArray arrayWithCapacity:perThread];
+
+            for (NSUInteger i = 0; i < perThread; i++) {
+                auto payload = NewRelic::Connectivity::Facade::getInstance().startTrip();
+                if (payload == nullptr) {
+                    nullPayloads++;
+                    continue;
+                }
+                [localTrace addObject:@(payload->getTraceId().c_str())];
+                [localSpan  addObject:@(payload->getId().c_str())];
+            }
+
+            [lock lock];
+            for (NSString *t in localTrace) {
+                if ([traceIds containsObject:t]) traceCollisions++;
+                else [traceIds addObject:t];
+            }
+            for (NSString *s in localSpan) {
+                if ([spanIds containsObject:s]) spanCollisions++;
+                else [spanIds addObject:s];
+            }
+            [lock unlock];
+        }
+    });
+
+    XCTAssertEqual(nullPayloads, 0u, @"Facade::startTrip returned nullptr %lu times — Application context lost?", (unsigned long)nullPayloads);
+    XCTAssertEqual(traceCollisions, 0u,
+                   @"trace id collisions across %lu concurrent generators",
+                   (unsigned long)(threadCount * perThread));
+    XCTAssertEqual(spanCollisions, 0u,
+                   @"span id collisions across %lu concurrent generators",
+                   (unsigned long)(threadCount * perThread));
+}
+
+- (void)testGeneratedIdsAreLowercaseHex {
+    auto payload = NewRelic::Connectivity::Facade::getInstance().startTrip();
+    XCTAssertTrue(payload != nullptr);
+    NSCharacterSet *allowed = [NSCharacterSet characterSetWithCharactersInString:@"0123456789abcdef"];
+    NSString *traceId = @(payload->getTraceId().c_str());
+    NSString *spanId  = @(payload->getId().c_str());
+    for (NSUInteger i = 0; i < traceId.length; i++) {
+        XCTAssertTrue([allowed characterIsMember:[traceId characterAtIndex:i]],
+                      @"non-hex char in trace id %@", traceId);
+    }
+    for (NSUInteger i = 0; i < spanId.length; i++) {
+        XCTAssertTrue([allowed characterIsMember:[spanId characterAtIndex:i]],
+                      @"non-hex char in span id %@", spanId);
+    }
+}
+
+@end

--- a/libMobileAgent/src/Connectivity/include/Connectivity/IGuidGenerator.hpp
+++ b/libMobileAgent/src/Connectivity/include/Connectivity/IGuidGenerator.hpp
@@ -2,17 +2,19 @@
 
 #ifndef LIBMOBILEAGENT_IGUIDGENERATOR_HPP
 #define LIBMOBILEAGENT_IGUIDGENERATOR_HPP
-#include <random>
+#include <stdlib.h>
 namespace NewRelic {
 namespace Connectivity {
 template<typename T>
 class IGuidGenerator {
 public:
+    // Uses arc4random_buf (CSPRNG) instead of an LCG seeded by a 32-bit-truncated
+    // timestamp, which produced colliding trace/span IDs across processes that
+    // generated GUIDs in the same clock tick.
     static T generateGuid() {
-        unsigned seed = static_cast<unsigned int>(std::chrono::system_clock::now().time_since_epoch().count());
-        std::default_random_engine generator{seed};
-        std::uniform_int_distribution<T> distribution{}; //default constructor does 0 - type_max
-        return distribution(generator);
+        T value = 0;
+        arc4random_buf(&value, sizeof(value));
+        return value;
     }
 };
 }


### PR DESCRIPTION
 ## Summary
  - Fixes NR-568934 — iOS agent emits identical trace/span IDs across regional apps, producing fake cross-region
  service edges in Mobile → Dependencies. Reproduces against 7.6.3 and 7.7.1.
  - Root cause: `IGuidGenerator::generateGuid` reseeded `std::default_random_engine` per call from
  `system_clock::now()` truncated to 32 bits — same-tick calls produce identical seeds and identical output.
  - Fix: use `arc4random_buf` (kernel CSPRNG) for each ID. No shared seed, no same-tick collision class.

  ## Test plan
  - [x] `TestGuidUniqueness.mm` added; all 5 tests pass on the patched code.
  - [x] Pre-fix verification: with the LCG restored, `testFacadeNewPayloadTightLoopProducesNoDuplicates` reports
  26,454 duplicate span IDs in 100k calls (first duplicate at iter 20); concurrent variant reports 42,530 in 320k
  calls.
  - [ ] Reviewer: verify post-fix run shows 0 duplicates across all 5 tests.
  - [ ] Reviewer (independent collision repro): temporarily revert `IGuidGenerator.hpp` to the pre-PR LCG version on a
   scratch branch, ⇧⌘K (clean build), re-run `TestGuidUniqueness` — expect
  `testFacadeNewPayloadTightLoopProducesNoDuplicates` and
  `testFacadeNewPayloadTightLoopUnderConcurrencyProducesNoDuplicates` to fail with tens of thousands of duplicates.
  This independently confirms the test is exercising the right code path *and* that the fix is what's keeping it
  green.

  ## Customer comms
  Customer needs to upgrade to whichever release ships this fix or set the use the New Event System Feature Flag. Existing colliding spans in the backend will age out
  as the 75-min span TTL elapses, but only once *all* regional apps are on the patched build — mixing patched and
  unpatched apps in the fleet leaves the collision class active.