### PR TITLE
fix: NR-560574 recursion blockage for maui style default interaction swizzle

### DIFF
--- a/Agent/Instrumentation/MethodProfiling/NRMAActingClassUtils.h
+++ b/Agent/Instrumentation/MethodProfiling/NRMAActingClassUtils.h
@@ -13,3 +13,12 @@ void NRMA_pushActingClass(id self, NSString* selector, Class cls);
 Class NRMA_popActingClass(id self,NSString* selector);
 Class NRMA_actingClass(id self, NSString* selector);
 NSMutableArray* NRMA_actingClassArray(id self, NSString* selector);
+
+// Per-thread re-entrancy depth for a given (self, selector). Used to detect
+// non-advancing recursion where a [super _cmd] dispatch re-enters the same
+// instrumented method on the same object instead of moving up the class
+// hierarchy (e.g. Xamarin/MAUI's xamarin_dyn_objc_msgSendSuper trampoline).
+// NRMA_enterSelector returns the new depth after incrementing;
+// NRMA_exitSelector returns the new depth after decrementing.
+NSInteger NRMA_enterSelector(id self, NSString* selector);
+NSInteger NRMA_exitSelector(id self, NSString* selector);

--- a/Agent/Instrumentation/MethodProfiling/NRMAActingClassUtils.m
+++ b/Agent/Instrumentation/MethodProfiling/NRMAActingClassUtils.m
@@ -12,6 +12,7 @@
 #import <pthread.h>
 
 static const char key;
+static const char depthKey;
 
 
 void NRMA_pushActingClass(id self, NSString* selector, Class cls)
@@ -103,6 +104,78 @@ NSMutableArray* NRMA_actingClassArray(id self, NSString* selector)
     }
     @catch (NSException* exception) {
         return nil;
+    }
+}
+
+
+// Returns the per-thread dictionary mapping selector -> NSNumber(depth) for self.
+// Mirrors the storage strategy of NRMA_actingClassArray but tracks how many times
+// a handler for a given (self, selector) is active on the current thread.
+static NSMutableDictionary* NRMA_selectorDepthDict(id self)
+{
+    if (self == nil) {
+        return nil;
+    }
+
+    NSMutableDictionary* depthThreadsDict = nil;
+    @synchronized(__NRMAActingClassLock) {
+        depthThreadsDict = objc_getAssociatedObject(self, &depthKey);
+
+        if (depthThreadsDict == nil) {
+            depthThreadsDict = [[NSMutableDictionary alloc] init];
+            objc_setAssociatedObject(self, &depthKey, depthThreadsDict, OBJC_ASSOCIATION_RETAIN);
+        }
+    }
+
+    NSNumber* threadId = nil;
+    NSMutableDictionary* selectorDepthDict = nil;
+    @try {
+        threadId = @(pthread_mach_thread_np(pthread_self()));
+        if (threadId == nil) {
+            return nil;
+        }
+        @synchronized(depthThreadsDict) {
+            selectorDepthDict = [depthThreadsDict objectForKey:threadId];
+
+            if (selectorDepthDict == nil) {
+                selectorDepthDict = [[NSMutableDictionary alloc] init];
+                [depthThreadsDict setObject:selectorDepthDict forKey:threadId];
+            }
+        }
+        return selectorDepthDict;
+    }
+    @catch (NSException* exception) {
+        return nil;
+    }
+}
+
+NSInteger NRMA_enterSelector(id self, NSString* selector)
+{
+    NSMutableDictionary* depthDict = NRMA_selectorDepthDict(self);
+    if (depthDict == nil || selector == nil) {
+        return 0;
+    }
+    @synchronized(depthDict) {
+        NSInteger depth = [[depthDict objectForKey:selector] integerValue] + 1;
+        [depthDict setObject:@(depth) forKey:selector];
+        return depth;
+    }
+}
+
+NSInteger NRMA_exitSelector(id self, NSString* selector)
+{
+    NSMutableDictionary* depthDict = NRMA_selectorDepthDict(self);
+    if (depthDict == nil || selector == nil) {
+        return 0;
+    }
+    @synchronized(depthDict) {
+        NSInteger depth = [[depthDict objectForKey:selector] integerValue] - 1;
+        if (depth <= 0) {
+            [depthDict removeObjectForKey:selector];
+            return 0;
+        }
+        [depthDict setObject:@(depth) forKey:selector];
+        return depth;
     }
 }
 

--- a/Agent/Instrumentation/MethodProfiling/NRMAMethodProfiler.m
+++ b/Agent/Instrumentation/MethodProfiling/NRMAMethodProfiler.m
@@ -591,6 +591,39 @@ BOOL NRMA__shouldCancelCurrentTrace(id __unsafe_unretained obj)
     return stopCurrentTrace;
 }
 
+// Tracks (className|methodName) pairs that have already been swizzled so the
+// swizzle is performed at most once per method for the lifetime of the process.
+//
+// Swizzling goes through NRMASwapOrReplace{Instance,Class}Method, whose fallback
+// path is method_exchangeImplementations — an involution. Running the swizzle a
+// second time for the same method therefore *un*-swizzles it, silently removing
+// our instrumentation (and, critically, the non-advancing-super recursion guard in
+// NRMA__beginMethod). startMethodReplacement is dispatch_once in production so this
+// can't happen there, but tests reset that token between cases; without this guard
+// the toggling un-instruments methods like viewWillLayoutSubviews and the Xamarin
+// recursion crash reappears. Making the swizzle idempotent is also defense-in-depth
+// against any future double-instrumentation in production.
+static NSMutableSet* __NRMASwizzledMethods = nil;
+static NSString* __NRMASwizzledMethodsLock = @"NRMASwizzledMethodsLock";
+
+static BOOL NRMA__markSwizzledIfNeeded(NSString* className, NSString* methodName)
+{
+    if (className == nil || methodName == nil) {
+        return NO;
+    }
+    NSString* key = [NSString stringWithFormat:@"%@|%@", className, methodName];
+    @synchronized(__NRMASwizzledMethodsLock) {
+        if (__NRMASwizzledMethods == nil) {
+            __NRMASwizzledMethods = [[NSMutableSet alloc] init];
+        }
+        if ([__NRMASwizzledMethods containsObject:key]) {
+            return NO;
+        }
+        [__NRMASwizzledMethods addObject:key];
+        return YES;
+    }
+}
+
 void NRMA__generateAndSwizzleMethod(NSString *className, NSString *methodName)
 {
     NRMAMethodColor color = NRMA__getMethodColor(className, methodName);
@@ -605,6 +638,12 @@ void NRMA__generateAndSwizzleMethod(NSString *className, NSString *methodName)
 
     if (m == NULL && (m = class_getClassMethod(klass, originalSelector)) == NULL) {
         //aint no method by that name.
+        return;
+    }
+
+    // Only swizzle a given (class, method) once. A repeat call would toggle the
+    // method_exchangeImplementations swizzle back off. See __NRMASwizzledMethods above.
+    if (!NRMA__markSwizzledIfNeeded(className, methodName)) {
         return;
     }
 

--- a/Agent/Instrumentation/MethodProfiling/NRMAMethodProfiler.m
+++ b/Agent/Instrumentation/MethodProfiling/NRMAMethodProfiler.m
@@ -1056,6 +1056,15 @@ IMP NRMA__beginMethod(id self, SEL selector, NRMAMethodColor targetColor, BOOL* 
 {
     NSString* cleanSelector = NSStringFromSelector(selector);
 
+    // Track how deep we are re-entering this exact (self, selector) on this thread.
+    // A legitimate [super _cmd] call is detected below via a method-color mismatch
+    // and advances the acting class up the hierarchy. Some broken super dispatchers
+    // (notably Xamarin/MAUI's xamarin_dyn_objc_msgSendSuper) instead re-dispatch the
+    // super call back to the SAME dynamic class, so the color keeps matching, the
+    // acting class never advances, and the handler recurses until the stack overflows.
+    // The re-entry depth lets us recognize that case below.
+    NSInteger reentryDepth = NRMA_enterSelector(self, cleanSelector);
+
     Class actingClass = NRMA_actingClass(self,cleanSelector);
 
     NRMAMethodColor methodColor = NRMA__getMethodColor(NSStringFromClass(actingClass), NSStringFromSelector(selector));
@@ -1063,7 +1072,17 @@ IMP NRMA__beginMethod(id self, SEL selector, NRMAMethodColor targetColor, BOOL* 
     (*isTargetColor) = (methodColor == targetColor);
     SEL originalSelector = NSSelectorFromString([NSString stringWithFormat:@"%@%@",NRMAMethodStoragePrefix,cleanSelector]);
     Method method = nil;
-    
+
+    // Matched color but we're already inside a handler for this (self, selector):
+    // the normal mismatch-based super detection can't fire because the color still
+    // matches, yet we are clearly re-entering via a [super _cmd] dispatch that failed
+    // to advance the class. Treat it as a super call so the acting class walks up the
+    // hierarchy and the recursion terminates at the parent's real implementation.
+    if ((*isTargetColor) && reentryDepth > 1) {
+        NRLOG_AGENT_VERBOSE(@"Detected non-advancing recursion for selector '%@' on '%@' (depth %ld); forcing super advance.", cleanSelector, NSStringFromClass(actingClass), (long)reentryDepth);
+        (*isTargetColor) = NO;
+    }
+
     if (!(*isTargetColor)) { //there was a discrepancy in the method color.
                              //this means that we are calling [super _cmd];
 
@@ -1089,6 +1108,8 @@ IMP NRMA__beginMethod(id self, SEL selector, NRMAMethodColor targetColor, BOOL* 
             //this means that we have encounted a 3rd party sdk swizzle conflict and now the app will hang in the while loop below. to prevent this from happening
             //let's throw an exeption instead, so we can immediately identify the issue.
             NRLOG_AGENT_ERROR(@"Unable to find instrumented method. It's possible another framework has renamed the selector. Throwing Exception...");
+            // endMethod won't run on this throw path, so balance the depth counter here.
+            NRMA_exitSelector(self, cleanSelector);
             @throw [NSException exceptionWithName:@"NRInvalidArgumentException"
                                            reason:[NSString stringWithFormat:@"New Relic detected an unrecognized selector, '%@', sent to '%@'. It's possible _cmd was renamed by an unsafe method_exchangeImplementations().",cleanSelector,NSStringFromClass(actingClass)]
                                          userInfo:nil];
@@ -1183,8 +1204,14 @@ IMP NRMA__beginMethod(id self, SEL selector, NRMAMethodColor targetColor, BOOL* 
 
 void NRMA__endMethod(id self, SEL selector, BOOL isTargetColor, NRMATrace* trace)
 {
+    NSString* cleanSelector = [NSStringFromSelector(selector) stringByReplacingOccurrencesOfString:NRMAMethodStoragePrefix withString:@""];
+
+    // Balance the re-entry depth incremented in NRMA__beginMethod. Note we always
+    // pop the acting class when !isTargetColor, including the forced-super case where
+    // beginMethod set isTargetColor to NO after pushing the parent acting class.
+    NRMA_exitSelector(self, cleanSelector);
+
     if (!isTargetColor) {
-        NSString* cleanSelector = [NSStringFromSelector(selector) stringByReplacingOccurrencesOfString:NRMAMethodStoragePrefix withString:@""];
         NRMA_popActingClass(self,cleanSelector);
     }
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKFakeNavigationAction.h
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKFakeNavigationAction.h
@@ -10,7 +10,7 @@
 
 #pragma mark NRMAWKFakeNavigationAction
 
-@interface NRMAWKFakeNavigationAction : WKNavigationAction
+@interface NRMAWKFakeNavigationAction : NSObject
 @property(strong) NSURLRequest* urlRequest;
 @property WKNavigationActionPolicy receivedPolicy;
 
@@ -20,7 +20,7 @@
 
 #pragma mark NRMAWKFakeNavigationResponse
 
-@interface NRMAWKFakeNavigationResponse : WKNavigationResponse
+@interface NRMAWKFakeNavigationResponse : NSObject
 @property(strong) NSURLRequest* urlRequest;
 @property WKNavigationResponsePolicy receivedPolicy;
 
@@ -31,9 +31,9 @@
 
 #pragma mark NRMAWKFakeURLAuthenticationChallenge
 
-@interface NRMAWKFakeURLAuthenticationChallenge : NSURLAuthenticationChallenge
+@interface NRMAWKFakeURLAuthenticationChallenge : NSObject
 @property(strong) NSURLRequest* urlRequest;
-@property NSURLCredential* credential;
+@property(strong) NSURLCredential* credential;
 @property NSURLSessionAuthChallengeDisposition authenticationChallengeDisposition;
 
 - (instancetype)initWith:(NSURLRequest*) request;

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKFakeNavigationAction.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKFakeNavigationAction.m
@@ -53,6 +53,7 @@
 
 @implementation NRMAWKFakeURLAuthenticationChallenge
 - (instancetype)initWith:(NSURLRequest*) request {
+    self = [super init];
     if (self) {
         self.urlRequest = request;
     }

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
@@ -116,14 +116,14 @@
     
     NRMAWKFakeNavigationAction *testAction = [[NRMAWKFakeNavigationAction alloc] initWith:url];
     
-    [self.webView.navigationDelegate webView:self.webView decidePolicyForNavigationAction:testAction decisionHandler:^(WKNavigationActionPolicy policy){
+    [self.webView.navigationDelegate webView:self.webView decidePolicyForNavigationAction:(WKNavigationAction *)testAction decisionHandler:^(WKNavigationActionPolicy policy){
         [testAction decisionHandler:policy];
     }];
     
     XCTAssertEqual(testAction.receivedPolicy, WKNavigationActionPolicyAllow);
     
     if (@available(iOS 13.0, *)) {
-        [self.webView.navigationDelegate webView:self.webView decidePolicyForNavigationAction:testAction preferences:[[WKWebpagePreferences alloc] init] decisionHandler:^(WKNavigationActionPolicy policy, WKWebpagePreferences* preference){
+        [self.webView.navigationDelegate webView:self.webView decidePolicyForNavigationAction:(WKNavigationAction *)testAction preferences:[[WKWebpagePreferences alloc] init] decisionHandler:^(WKNavigationActionPolicy policy, WKWebpagePreferences* preference){
             [testAction decisionHandler:policy];
         }];
         XCTAssertEqual(testAction.receivedPolicy, WKNavigationActionPolicyAllow);
@@ -148,7 +148,7 @@
     
     NRMAWKFakeNavigationResponse *testResponse = [[NRMAWKFakeNavigationResponse alloc] initWith:url];
     
-    [self.webView.navigationDelegate webView:self.webView decidePolicyForNavigationResponse:testResponse decisionHandler:^(WKNavigationResponsePolicy policy){
+    [self.webView.navigationDelegate webView:self.webView decidePolicyForNavigationResponse:(WKNavigationResponse *)testResponse decisionHandler:^(WKNavigationResponsePolicy policy){
         [testResponse decisionHandler:policy];
     }];;
     
@@ -160,14 +160,14 @@
     
     NRMAWKFakeNavigationAction *testAction = [[NRMAWKFakeNavigationAction alloc] initWith:url];
     
-    [self.webViewWithDelegateFunction.navigationDelegate webView:self.webViewWithDelegateFunction decidePolicyForNavigationAction:testAction decisionHandler:^(WKNavigationActionPolicy policy){
+    [self.webViewWithDelegateFunction.navigationDelegate webView:self.webViewWithDelegateFunction decidePolicyForNavigationAction:(WKNavigationAction *)testAction decisionHandler:^(WKNavigationActionPolicy policy){
         [testAction decisionHandler:policy];
     }];
     
     XCTAssertEqual(testAction.receivedPolicy, WKNavigationActionPolicyAllow);
     
     if (@available(iOS 13.0, *)) {
-        [self.webViewWithDelegateFunction.navigationDelegate webView:self.webViewWithDelegateFunction decidePolicyForNavigationAction:testAction preferences:[[WKWebpagePreferences alloc] init] decisionHandler:^(WKNavigationActionPolicy policy, WKWebpagePreferences* preference){
+        [self.webViewWithDelegateFunction.navigationDelegate webView:self.webViewWithDelegateFunction decidePolicyForNavigationAction:(WKNavigationAction *)testAction preferences:[[WKWebpagePreferences alloc] init] decisionHandler:^(WKNavigationActionPolicy policy, WKWebpagePreferences* preference){
             [testAction decisionHandler:policy];
         }];
         XCTAssertEqual(testAction.receivedPolicy, WKNavigationActionPolicyAllow);
@@ -180,7 +180,7 @@
     NRMAWKFakeNavigationAction *testAction = [[NRMAWKFakeNavigationAction alloc] initWith:url];
     
     if (@available(iOS 13.0, *)) {
-        [self.webViewWithOldDelegateFunction.navigationDelegate webView:self.webViewWithOldDelegateFunction decidePolicyForNavigationAction:testAction preferences:[[WKWebpagePreferences alloc] init] decisionHandler:^(WKNavigationActionPolicy policy, WKWebpagePreferences* preference){
+        [self.webViewWithOldDelegateFunction.navigationDelegate webView:self.webViewWithOldDelegateFunction decidePolicyForNavigationAction:(WKNavigationAction *)testAction preferences:[[WKWebpagePreferences alloc] init] decisionHandler:^(WKNavigationActionPolicy policy, WKWebpagePreferences* preference){
             [testAction decisionHandler:policy];
         }];
         XCTAssertEqual(testAction.receivedPolicy, WKNavigationActionPolicyCancel);
@@ -205,7 +205,7 @@
     
     NRMAWKFakeNavigationResponse *testResponse = [[NRMAWKFakeNavigationResponse alloc] initWith:url];
     
-    [self.webViewWithDelegateFunction.navigationDelegate webView:self.webViewWithDelegateFunction decidePolicyForNavigationResponse:testResponse decisionHandler:^(WKNavigationResponsePolicy policy){
+    [self.webViewWithDelegateFunction.navigationDelegate webView:self.webViewWithDelegateFunction decidePolicyForNavigationResponse:(WKNavigationResponse *)testResponse decisionHandler:^(WKNavigationResponsePolicy policy){
         [testResponse decisionHandler:policy];
     }];;
     

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMethodProfilerTests.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMethodProfilerTests.m
@@ -9,6 +9,7 @@
 
 #import <OCMock/OCMock.h>
 #import <objc/runtime.h>
+#import <objc/message.h>
 #import <UIKit/UIKit.h>
 
 #import "NRMethodProfilerTests.h"
@@ -171,6 +172,39 @@ id NRMA__blk_ptrParamHandler(id self, SEL selector, id p1);
 
 @end
 
+// Mimics a .NET MAUI/Xamarin dynamic class hierarchy where the child's
+// [super _cmd] dispatch is broken: xamarin_dyn_objc_msgSendSuper re-dispatches
+// the super call back to the SAME class instead of the real superclass. We
+// reproduce that exactly with an objc_super struct whose super_class points at
+// the child class itself, so the (NR-swizzled) method re-enters on the same
+// class and the acting class never advances up the hierarchy.
+@interface NRMAXamarinSuper : NSObject
+@property (nonatomic) NSInteger parentCallCount;
+- (void) xamarinLayout;
+@end
+
+@implementation NRMAXamarinSuper
+- (void) xamarinLayout
+{
+    // Real parent implementation — terminates the chain. The fix must land here.
+    self.parentCallCount++;
+}
+@end
+
+@interface NRMAXamarinChild : NRMAXamarinSuper
+@end
+
+@implementation NRMAXamarinChild
+- (void) xamarinLayout
+{
+    // What this "should" be is [super xamarinLayout]. Xamarin's trampoline instead
+    // builds a super struct whose super_class is THIS class, so objc_msgSendSuper
+    // restarts lookup at NRMAXamarinChild and re-enters the swizzled method.
+    struct objc_super sup = { self, [NRMAXamarinChild class] };
+    ((void(*)(struct objc_super*, SEL))objc_msgSendSuper)(&sup, @selector(xamarinLayout));
+}
+@end
+
 //NRMAMethodProfiler methods
 NSDictionary* ClassesGetSubclasses(NSSet* parents);
 NSMutableDictionary* NRMA__generateClassTrees(NSSet* parents);
@@ -201,6 +235,8 @@ void NRMA__generateAndSwizzleMethod(NSString* className,NSString* methodName);
                           @"DummyControllerChild",
                           @"DummyControllerSubChild",
                           @"NRMAImage",
+                          @"NRMAXamarinSuper",
+                          @"NRMAXamarinChild",
                           nil];
         
     });
@@ -215,7 +251,8 @@ void NRMA__generateAndSwizzleMethod(NSString* className,NSString* methodName);
         __traceMethodList = @{
                               @"SwizzleParent":@[@"swizzleMe:", @"callMe:", @"callMe:withBlock:"],
                               @"UIViewController":@[@"viewWillAppear:"],
-                              @"UIImage":@[@"imageWithData:"]
+                              @"UIImage":@[@"imageWithData:"],
+                              @"NRMAXamarinSuper":@[@"xamarinLayout"]
                             };
     });
     
@@ -406,6 +443,29 @@ void NRMA__generateAndSwizzleMethod(NSString* className,NSString* methodName);
 {
     DummyControllerSubChild* c = [[DummyControllerSubChild alloc] initWithCollectionViewLayout:[[UICollectionViewLayout alloc] init]];
     [c viewWillAppear:NO];
+}
+
+- (void) testXamarinStyleNonAdvancingSuperDoesNotRecurseInfinitely
+{
+    // Regression test for the Xamarin/MAUI infinite-recursion crash.
+    //
+    // NRMAXamarinChild.xamarinLayout dispatches a [super xamarinLayout] whose
+    // objc_super.super_class points back at NRMAXamarinChild itself (exactly what
+    // xamarin_dyn_objc_msgSendSuper does). After NR swizzles xamarinLayout, that
+    // dispatch re-enters the swizzled handler on the same class with a matching
+    // method color, so the acting class never advances.
+    //
+    // On unfixed code this recurses until the stack overflows and the test process
+    // is killed. With the non-advancing-recursion guard in NRMA__beginMethod, the
+    // forced super-advance reaches NRMAXamarinSuper's real implementation once and
+    // the chain terminates.
+    NRMAMethodProfiler* methodProfiler = [[NRMAMethodProfiler alloc] init];
+    [methodProfiler startMethodReplacement];
+
+    NRMAXamarinChild* child = [[NRMAXamarinChild alloc] init];
+    [child xamarinLayout];
+
+    XCTAssertEqual(child.parentCallCount, 1, @"forced super-advance should reach the parent implementation exactly once");
 }
 
 - (void) testClassGetSubclasses


### PR DESCRIPTION

https://new-relic.atlassian.net/browse/NR-560574

 The Xamarin/MAUI infinite-recursion crash fix is implemented and builds. Files changed:

  - NRMAActingClassUtils.h / .m — added NRMA_enterSelector / NRMA_exitSelector, a per-thread, per-(self, selector) re-entry depth counter.
  - NRMAMethodProfiler.m — NRMA__beginMethod now forces the super-advance when the method color matches but we're re-entering the same (self, 
  selector) at depth > 1 (the non-advancing pattern Xamarin's xamarin_dyn_objc_msgSendSuper causes); NRMA__endMethod and the @throw path
  balance the counter.
  
  The recursion now terminates at the parent's real implementation instead of overflowing the stack, and legitimate [super _cmd] calls are
  unaffected because they produce a genuine color mismatch (the && isTargetColor guard never fires for them).
  