### PR TITLE
NR-570504 Rename appVersionId to appVersion in RN source map upload

### DIFF
--- a/dsym-upload-tools/README_REACT_NATIVE_SOURCEMAP.md
+++ b/dsym-upload-tools/README_REACT_NATIVE_SOURCEMAP.md
@@ -147,12 +147,12 @@ The following data is sent with each source map upload:
 |-------|-------------|---------|
 | `sourcemap` | The source map file | `main.jsbundle.map` |
 | `jsBundleId` | Unique identifier for this build (CFBundleShortVersionString) | `1.2.3` |
-| `appVersionId` | App marketing version (CFBundleShortVersionString) | `1.2.3` |
+| `appVersion` | App marketing version (CFBundleShortVersionString) | `1.2.3` |
 | `sourcemapName` | Name of the source map | `main.jsbundle.map` |
 
 ### JS Bundle ID
 
-The `jsBundleId` and `appVersionId` are both set to your app's `CFBundleShortVersionString` from `Info.plist`. This ensures that source maps are correctly matched to error reports from your React Native app.
+The `jsBundleId` and `appVersion` are both set to your app's `CFBundleShortVersionString` from `Info.plist`. This ensures that source maps are correctly matched to error reports from your React Native app.
 
 **Important:** When recording JavaScript errors in your React Native app, pass the same version string as the `jsAppVersion` parameter to `NewRelic.recordJavascriptError()`.
 
@@ -167,7 +167,7 @@ The upload script provides detailed error messages for all API responses:
 
 **Common causes:**
 - Source map version must be 3 (not version 1 or 2)
-- Missing required fields (`jsBundleId`, `appVersionId`, `sourcemapName`)
+- Missing required fields (`jsBundleId`, `appVersion`, `sourcemapName`)
 - Invalid JSON format in the source map file
 - ZIP file contains no valid files or multiple files
 - Invalid file extension (must be `.map`, `.js.map`, `.json`, or `.zip`)

--- a/dsym-upload-tools/upload-react-native-sourcemap.swift
+++ b/dsym-upload-tools/upload-react-native-sourcemap.swift
@@ -183,7 +183,7 @@ func start() {
         exit(1)
     }
 
-    // jsBundleId is the same as appVersionId (CFBundleShortVersionString)
+    // jsBundleId is the same as appVersion (CFBundleShortVersionString)
     let jsBundleId = appVersion
 
     let sourcemapName = "main.jsbundle.map"
@@ -207,7 +207,7 @@ func start() {
             url: uploadURL,
             sourcemapPath: sourcemapPath,
             jsBundleId: jsBundleId,
-            appVersionId: appVersion,
+            appVersion: appVersion,
             sourcemapName: sourcemapName
         )
         print("New Relic: ✓ Source map uploaded successfully!")
@@ -226,7 +226,7 @@ func uploadSourceMap(
     url: String,
     sourcemapPath: String,
     jsBundleId: String,
-    appVersionId: String,
+    appVersion: String,
     sourcemapName: String
 ) throws {
 
@@ -247,7 +247,7 @@ func uploadSourceMap(
     // Add text fields
     let textFields = [
         "jsBundleId": jsBundleId,
-        "appVersionId": appVersionId,
+        "appVersion": appVersion,
         "sourcemapName": sourcemapName
     ]
 
@@ -392,7 +392,7 @@ func uploadSourceMap(
                 }
                 print("Common causes:")
                 print("  • Source map version must be 3")
-                print("  • Missing required fields (jsBundleId, appVersionId, sourcemapName)")
+                print("  • Missing required fields (jsBundleId, appVersion, sourcemapName)")
                 print("  • Invalid JSON format")
                 print("  • ZIP file issues (no valid files, multiple files, or invalid extension)")
 
@@ -472,7 +472,7 @@ func uploadSourceMap(
             if let jsBundleId = metadata["JSBundleId"] as? String {
                 print("  JS Bundle ID: \(jsBundleId)")
             }
-            if let appVersion = metadata["appVersionId"] as? String {
+            if let appVersion = metadata["appVersion"] as? String {
                 print("  App Version: \(appVersion)")
             }
             if let createdAt = metadata["createdAt"] as? String {


### PR DESCRIPTION
Rename the multipart form field key sent to the Symbol Ingest API from appVersionId to appVersion in the React Native source map upload script, matching the Android counterpart and the API field rename.

- Wire field key appVersionId -> appVersion (straight rename)
- Rename internal function parameter for consistency
- Parse appVersion from the response metadata success print
- Update 400-error help text and README docs