### PR TITLE
Distributed Tracing: align injected traceparent with recorded span trace.id on the setState path (#772)

### DIFF
--- a/Agent/Instrumentation/NSURLSession/NRMAURLSessionTaskOverride.m
+++ b/Agent/Instrumentation/NSURLSession/NRMAURLSessionTaskOverride.m
@@ -134,19 +134,26 @@ void NRMAOverride__urlSessionTask_SetState(NSURLSessionTask* task, SEL _cmd, NSU
                 NSURL *url = [currentRequest URL];
                 if (url != nil) {
 
-                    // Added this section to add Distributed Tracing traceId\trace.id, guid,id and payload.
-                    //1
-                    NSMutableURLRequest* mutableRequest = [NRMAHTTPUtilities addCrossProcessIdentifier:currentRequest];
-                    mutableRequest = [NRMAHTTPUtilities addConnectivityHeaderAndPayload:mutableRequest];
-                    // 2
-                    if([NRMAFlags shouldEnableNewEventSystem]){
-                        NRMAPayload* payload = [NRMAHTTPUtilities addConnectivityHeaderNRMAPayload:mutableRequest];
-                        [NRMAHTTPUtilities attachNRMAPayload:payload
-                                                      to:task.originalRequest];
-                    } else {
-                        NRMAPayloadContainer* payload = [NRMAHTTPUtilities addConnectivityHeader:mutableRequest];
-                        [NRMAHTTPUtilities attachPayload:payload
-                                                      to:task.originalRequest];
+                    // Attach a distributed tracing payload for the recorded span ONLY if an
+                    // earlier instrumentation point (e.g. the NSURLSession-level override at
+                    // task creation) has not already attached one. Regenerating here used to
+                    // overwrite that payload - whose traceparent was already injected onto the
+                    // wire - so the recorded span's trace.id no longer matched the header the
+                    // backend continues, breaking mobile -> backend trace linking
+                    // (newrelic/newrelic-ios-agent#772). This also drops the redundant second
+                    // payload generation (addConnectivityHeaderAndPayload created a payload on a
+                    // throwaway request that was immediately discarded).
+                    if (![NRMAHTTPUtilities hasAttachedPayload:task.originalRequest]) {
+                        NSMutableURLRequest* mutableRequest = [NRMAHTTPUtilities addCrossProcessIdentifier:currentRequest];
+                        if([NRMAFlags shouldEnableNewEventSystem]){
+                            NRMAPayload* payload = [NRMAHTTPUtilities addConnectivityHeaderNRMAPayload:mutableRequest];
+                            [NRMAHTTPUtilities attachNRMAPayload:payload
+                                                          to:task.originalRequest];
+                        } else {
+                            NRMAPayloadContainer* payload = [NRMAHTTPUtilities addConnectivityHeader:mutableRequest];
+                            [NRMAHTTPUtilities attachPayload:payload
+                                                          to:task.originalRequest];
+                        }
                     }
 
 

--- a/Agent/Network/NRMAHTTPUtilities.h
+++ b/Agent/Network/NRMAHTTPUtilities.h
@@ -33,5 +33,11 @@ NS_ASSUME_NONNULL_BEGIN
 + (void) addTrackedHeaders:(NSDictionary *)headers to:(NRMANetworkRequestData*)requestData;
 + (void) attachPayload:(NRMAPayloadContainer*)payload to:(id)object;
 + (NRMAPayloadContainer*) addConnectivityHeader:(NSMutableURLRequest*)request;
+// Non-destructive check (does not remove the association) for whether a
+// distributed tracing payload has already been attached to `object`. Used to
+// avoid regenerating/overwriting a payload an earlier instrumentation point
+// already attached (newrelic/newrelic-ios-agent#772). Covers both event systems
+// (NRMAPayload and NRMAPayloadContainer share the association key).
++ (BOOL) hasAttachedPayload:(id)object;
 @end
 NS_ASSUME_NONNULL_END

--- a/Agent/Network/NRMAHTTPUtilities.mm
+++ b/Agent/Network/NRMAHTTPUtilities.mm
@@ -245,6 +245,13 @@ NSString* currentParentId = @"";
     [NRMAAssociate attach:payload to:object with:kNRMA_ASSOCIATED_PAYLOAD_KEY];
 }
 
++ (BOOL) hasAttachedPayload:(id)object {
+    // Peek without removing the association. Both event systems attach under the
+    // same key (NRMAPayload for the new system, NRMAPayloadContainer for the old),
+    // so a non-nil result means a payload is already present (newrelic/newrelic-ios-agent#772).
+    return [NRMAAssociate retrieveFrom:object with:kNRMA_ASSOCIATED_PAYLOAD_KEY] != nil;
+}
+
 + (NRMAPayload*) retrieveNRMAPayload:(id)object {
     id associatedObject = [NRMAAssociate retrieveFrom:object
                                     with:kNRMA_ASSOCIATED_PAYLOAD_KEY];


### PR DESCRIPTION
Fixes the distributed-tracing payload-overwrite defect analyzed in #772 on the `NSURLSession` task `setState` path. This is the path instrumented when the `SwiftAsyncURLSessionSupport` feature flag is enabled.

> The trace-id entropy fix (`IGuidGenerator`) that was originally part of this PR has been split out into #775 at the maintainer's request, since it is already addressed on `develop` (PR #754, shipping in 7.7.3).

## The defect

`NRMAOverride__urlSessionTask_SetState` regenerated a DT payload and re-attached it to `task.originalRequest`, **overwriting** the payload attached at task creation (`NRMAURLSessionOverride`) whose `traceparent` was already injected onto the wire. The recording path (`NRMAURLSessionTaskDelegateBase` -> `retrieveNRMAPayload` -> `addNetworkRequestEvent`) then read the newer payload, so the recorded span's `trace.id` differed from the header the backend continues. It also generated two payloads (`addConnectivityHeaderAndPayload` + `addConnectivityHeaderNRMAPayload`), the first on a throwaway request that was discarded.

Fix: only generate/attach a payload here when one is **not already attached** (new non-destructive `+[NRMAHTTPUtilities hasAttachedPayload:]`, covering both event systems), and drop the redundant second generation.

## Scope note

This override is only swizzled in when `SwiftAsyncURLSessionSupport` is enabled (`NRMAURLSessionTaskOverride.m`: `if (![NRMAFlags shouldEnableSwiftAsyncURLSessionSupport]) return;`), and it early-returns for tasks the session-level swizzle already handled (`NRMAHandledRequestKey`). So this change only affects callers running with that flag on, on the Swift async / non-handled task path.

## Testing notes

- Minimal, targeted change. I was **not able to run the agent's full Xcode test harness locally**, so please validate against the `NSURLSession` instrumentation tests - in particular the delegate vs completion-handler task paths and the `isHandled` early-return interaction.
- Happy to adjust the approach - e.g. if you'd prefer the dedupe to live in the recording path (`NRMANetworkFacade`) rather than the task override.

Refs newrelic/newrelic-ios-agent#772