### PR TITLE
NR-572211 fix infinite loop in EventDeserializer that froze the agent on launch

### DIFF
--- a/libMobileAgent/src/Analytics/include/Analytics/Stores/FileBackedStore.hpp
+++ b/libMobileAgent/src/Analytics/include/Analytics/Stores/FileBackedStore.hpp
@@ -5,10 +5,7 @@
 #include <Utilities/libLogger.hpp>
 #include <Utilities/WorkQueue.hpp>
 #include <Analytics/AnalyticEvent.hpp>
-#include <atomic>
 #include <chrono>
-#include <future>
-#include <memory>
 #include <sstream>
 
 
@@ -30,15 +27,8 @@ private:
                         std::shared_ptr<T> t);
 
     std::chrono::time_point<std::chrono::system_clock> lastWriteTime;
-    std::atomic<bool> dirtyFlag{false};
+    bool dirtyFlag = false;
     WorkQueue workQueue;
-    std::shared_future<void> _initialLoadFuture;
-
-    void waitForInitialLoad() const {
-        if (_initialLoadFuture.valid()) {
-            _initialLoadFuture.wait();
-        }
-    }
 
 public:
     static const inline std::chrono::time_point<std::chrono::system_clock>::duration writeThrottle() {
@@ -71,20 +61,8 @@ public:
               _validator(validator),
               lastWriteTime(),
               workQueue() {
+        loadFromFile();
         clearBackup();
-        // Run the initial file load on the work queue so the constructor doesn't block
-        // the calling thread. Reads via get()/getCache()/load() wait on _initialLoadFuture;
-        // writes via store()/remove() naturally serialize behind this work item.
-        auto loadPromise = std::make_shared<std::promise<void>>();
-        _initialLoadFuture = loadPromise->get_future().share();
-        workQueue.enqueue([this, loadPromise] {
-            try {
-                loadFromFile();
-            } catch (...) {
-                LLOG_VERBOSE("Initial async load failed: %s", _fullPath.c_str());
-            }
-            loadPromise->set_value();
-        });
     };
 
     void synchronize() {
@@ -97,13 +75,15 @@ public:
 
 
     virtual ~FileBackedStore() {
+        // Use non-blocking terminate with 500ms timeout to avoid blocking main thread
+        // If timeout occurs, thread will be detached and finish asynchronously
         bool completed = workQueue.terminate(500);
         if (!completed) {
             LLOG_VERBOSE("WorkQueue terminate timed out in FileBackedStore destructor - thread detached");
         }
 
         std::lock_guard<std::mutex> lk(_fileMutex);
-        if (dirtyFlag.load()) {
+        if (dirtyFlag) {
             flush();
         }
         if (_fO.is_open())
@@ -128,14 +108,8 @@ public:
 
     virtual void store(K key,
                        std::shared_ptr<T> obj) {
-        {
-            // Set dirtyFlag inside the cache lock so an async loadFromFile()
-            // running on the work queue can't read it as "clean" between our
-            // map mutation and our flag set.
-            std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
-            CacheBackedStore<K, T>::map[key] = obj;
-            dirtyFlag = true;
-        }
+        CacheBackedStore<K, T>::store(key, obj);
+        dirtyFlag = true;
         workQueue.enqueue([this] {
             try {
                 std::lock_guard<std::mutex> lk(_fileMutex);
@@ -156,11 +130,8 @@ public:
     }
 
     virtual void remove(K key) {
-        {
-            std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
-            CacheBackedStore<K, T>::map.erase(key);
-            dirtyFlag = true;
-        }
+        CacheBackedStore<K, T>::remove(key);
+        dirtyFlag = true;
         workQueue.enqueue([this] {
             try {
                 std::lock_guard<std::mutex> lk(_fileMutex);
@@ -174,11 +145,9 @@ public:
     }
 
     virtual std::map<K, std::shared_ptr<T>> load() {
-        waitForInitialLoad();
         std::lock_guard<std::mutex> lk(_fileMutex);
         CacheBackedStore<K, T>::clear();
         loadFromFile();
-        std::lock_guard<std::mutex> mlk(CacheBackedStore<K, T>::m);
         return CacheBackedStore<K, T>::map;
     }
 
@@ -187,10 +156,8 @@ public:
     }
 
     virtual std::shared_ptr<T> get(K key) {
-        waitForInitialLoad();
-        std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
-        auto it = CacheBackedStore<K, T>::map.find(key);
-        return it == CacheBackedStore<K, T>::map.end() ? nullptr : it->second;
+        auto map = CacheBackedStore<K, T>::map;
+        return map[key];
     }
 
     virtual const char* getFullStorePath() const {
@@ -198,11 +165,6 @@ public:
     }
 
     const std::map<K, std::shared_ptr<T>> swap() {
-        // Must wait for the initial async load BEFORE taking any locks. The
-        // worker thread needs m to finish the load, so holding m here while
-        // waiting on _initialLoadFuture would deadlock.
-        waitForInitialLoad();
-
         std::lock_guard<std::mutex> flk(_fileMutex);
         std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
         if (_fO.is_open()) {
@@ -219,17 +181,14 @@ public:
             LLOG_VERBOSE("failed to create backup store: %s", backupStorePath.c_str());
         }
 
-        // Read the map directly under the lock we already hold. Do NOT call
-        // getCache() here — it would re-take m on a non-recursive mutex.
-        auto map = CacheBackedStore<K, T>::map;
+        // save cache data as return result, but clear the internal cache
+        auto map = getCache();
         CacheBackedStore<K, T>::map.clear();
 
         return map;
     }
 
     virtual std::map<K, std::shared_ptr<T>> getCache() {
-        waitForInitialLoad();
-        std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
         return CacheBackedStore<K, T>::map;
     }
 
@@ -241,83 +200,33 @@ protected:
     }
 
     void loadFromFile() {
-        // Read the entire file into a local map BEFORE taking the cache mutex.
-        // Holding CacheBackedStore::m during file I/O is what froze callers:
-        // every store()/remove() also takes m, so a slow file read on the
-        // work queue blocked the calling thread for the duration.
         std::ifstream _fI;
+        std::string key;
+        std::string value;
+
+        std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
         _fI.open(_fullPath);
+        const std::streamoff offset = std::streamoff(0);
+        _fI.seekg(offset, std::ios_base::beg);
 
-        if (!_fI.is_open()) {
-            std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
-            if (!dirtyFlag.load()) {
-                // No file and no pending writes: cache matches "disk" (empty).
-                dirtyFlag = false;
-            }
-            return;
-        }
-
-        _fI.seekg(0, std::ios::end);
-        std::streampos fileSize = _fI.tellg();
-        _fI.seekg(0, std::ios::beg);
-
-        const std::streampos MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
-        if (fileSize > MAX_FILE_SIZE) {
-            LLOG_VERBOSE("FileBackedStore file too large (%lld bytes), skipping load: %s",
-                        static_cast<long long>(fileSize), _fullPath.c_str());
-            _fI.close();
-            return;
-        }
-
-        std::map<K, std::shared_ptr<T>> tmp;
         try {
-            const int MAX_ENTRIES = 10000;
-            int entryCount = 0;
-            std::string key;
-            std::string value;
-
-            while (std::getline(_fI, key) && entryCount < MAX_ENTRIES) {
-                if (!std::getline(_fI, value)) {
-                    LLOG_VERBOSE("Malformed file, missing value for key: %s", _fullPath.c_str());
-                    break;
-                }
-
+            while (std::getline(_fI, key)) {
+                std::getline(_fI, value);
                 K k{key};
                 std::stringstream is{value};
 
                 std::shared_ptr<T> t = _factory(is);
                 if (_validator(k, t)) {
-                    tmp[k] = t;
+                    CacheBackedStore<K, T>::map[k] = t;
                 }
-
-                entryCount++;
-            }
-
-            if (entryCount >= MAX_ENTRIES) {
-                LLOG_VERBOSE("FileBackedStore exceeded max entries (%d), truncating: %s",
-                            MAX_ENTRIES, _fullPath.c_str());
             }
         } catch (...) {
-            LLOG_VERBOSE("Exception during file load, dropping partial result: %s", _fullPath.c_str());
-            _fI.close();
-            return;
+            const std::streamoff offset = std::streamoff(0);
+            _fI.seekg(offset, std::ios_base::beg);
+            CacheBackedStore<K, T>::map.clear();
         }
         _fI.close();
-
-        // Brief lock to merge into the cache. emplace() preserves any keys
-        // that were store()d concurrently while we were reading the file —
-        // those represent newer values than what's on disk.
-        std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
-        bool wasClean = !dirtyFlag.load();
-        for (auto& kv : tmp) {
-            CacheBackedStore<K, T>::map.emplace(kv.first, kv.second);
-        }
-        if (wasClean) {
-            // No concurrent writes happened during the read, so cache now
-            // matches disk. If wasClean was false, leave dirtyFlag set so
-            // the queued flush will write the concurrent store(s) out.
-            dirtyFlag = false;
-        }
+        dirtyFlag = false;
     }
 
     void writeToFile() {

--- a/libMobileAgent/src/Analytics/include/Analytics/Stores/FileBackedStore.hpp
+++ b/libMobileAgent/src/Analytics/include/Analytics/Stores/FileBackedStore.hpp
@@ -5,7 +5,10 @@
 #include <Utilities/libLogger.hpp>
 #include <Utilities/WorkQueue.hpp>
 #include <Analytics/AnalyticEvent.hpp>
+#include <atomic>
 #include <chrono>
+#include <future>
+#include <memory>
 #include <sstream>
 
 
@@ -27,8 +30,15 @@ private:
                         std::shared_ptr<T> t);
 
     std::chrono::time_point<std::chrono::system_clock> lastWriteTime;
-    bool dirtyFlag = false;
+    std::atomic<bool> dirtyFlag{false};
     WorkQueue workQueue;
+    std::shared_future<void> _initialLoadFuture;
+
+    void waitForInitialLoad() const {
+        if (_initialLoadFuture.valid()) {
+            _initialLoadFuture.wait();
+        }
+    }
 
 public:
     static const inline std::chrono::time_point<std::chrono::system_clock>::duration writeThrottle() {
@@ -61,8 +71,20 @@ public:
               _validator(validator),
               lastWriteTime(),
               workQueue() {
-        loadFromFile();
         clearBackup();
+        // Run the initial file load on the work queue so the constructor doesn't block
+        // the calling thread. Reads via get()/getCache()/load() wait on _initialLoadFuture;
+        // writes via store()/remove() naturally serialize behind this work item.
+        auto loadPromise = std::make_shared<std::promise<void>>();
+        _initialLoadFuture = loadPromise->get_future().share();
+        workQueue.enqueue([this, loadPromise] {
+            try {
+                loadFromFile();
+            } catch (...) {
+                LLOG_VERBOSE("Initial async load failed: %s", _fullPath.c_str());
+            }
+            loadPromise->set_value();
+        });
     };
 
     void synchronize() {
@@ -75,15 +97,13 @@ public:
 
 
     virtual ~FileBackedStore() {
-        // Use non-blocking terminate with 500ms timeout to avoid blocking main thread
-        // If timeout occurs, thread will be detached and finish asynchronously
         bool completed = workQueue.terminate(500);
         if (!completed) {
             LLOG_VERBOSE("WorkQueue terminate timed out in FileBackedStore destructor - thread detached");
         }
 
         std::lock_guard<std::mutex> lk(_fileMutex);
-        if (dirtyFlag) {
+        if (dirtyFlag.load()) {
             flush();
         }
         if (_fO.is_open())
@@ -108,8 +128,14 @@ public:
 
     virtual void store(K key,
                        std::shared_ptr<T> obj) {
-        CacheBackedStore<K, T>::store(key, obj);
-        dirtyFlag = true;
+        {
+            // Set dirtyFlag inside the cache lock so an async loadFromFile()
+            // running on the work queue can't read it as "clean" between our
+            // map mutation and our flag set.
+            std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
+            CacheBackedStore<K, T>::map[key] = obj;
+            dirtyFlag = true;
+        }
         workQueue.enqueue([this] {
             try {
                 std::lock_guard<std::mutex> lk(_fileMutex);
@@ -130,8 +156,11 @@ public:
     }
 
     virtual void remove(K key) {
-        CacheBackedStore<K, T>::remove(key);
-        dirtyFlag = true;
+        {
+            std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
+            CacheBackedStore<K, T>::map.erase(key);
+            dirtyFlag = true;
+        }
         workQueue.enqueue([this] {
             try {
                 std::lock_guard<std::mutex> lk(_fileMutex);
@@ -145,9 +174,11 @@ public:
     }
 
     virtual std::map<K, std::shared_ptr<T>> load() {
+        waitForInitialLoad();
         std::lock_guard<std::mutex> lk(_fileMutex);
         CacheBackedStore<K, T>::clear();
         loadFromFile();
+        std::lock_guard<std::mutex> mlk(CacheBackedStore<K, T>::m);
         return CacheBackedStore<K, T>::map;
     }
 
@@ -156,8 +187,10 @@ public:
     }
 
     virtual std::shared_ptr<T> get(K key) {
-        auto map = CacheBackedStore<K, T>::map;
-        return map[key];
+        waitForInitialLoad();
+        std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
+        auto it = CacheBackedStore<K, T>::map.find(key);
+        return it == CacheBackedStore<K, T>::map.end() ? nullptr : it->second;
     }
 
     virtual const char* getFullStorePath() const {
@@ -165,6 +198,11 @@ public:
     }
 
     const std::map<K, std::shared_ptr<T>> swap() {
+        // Must wait for the initial async load BEFORE taking any locks. The
+        // worker thread needs m to finish the load, so holding m here while
+        // waiting on _initialLoadFuture would deadlock.
+        waitForInitialLoad();
+
         std::lock_guard<std::mutex> flk(_fileMutex);
         std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
         if (_fO.is_open()) {
@@ -181,14 +219,17 @@ public:
             LLOG_VERBOSE("failed to create backup store: %s", backupStorePath.c_str());
         }
 
-        // save cache data as return result, but clear the internal cache
-        auto map = getCache();
+        // Read the map directly under the lock we already hold. Do NOT call
+        // getCache() here — it would re-take m on a non-recursive mutex.
+        auto map = CacheBackedStore<K, T>::map;
         CacheBackedStore<K, T>::map.clear();
 
         return map;
     }
 
     virtual std::map<K, std::shared_ptr<T>> getCache() {
+        waitForInitialLoad();
+        std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
         return CacheBackedStore<K, T>::map;
     }
 
@@ -200,33 +241,83 @@ protected:
     }
 
     void loadFromFile() {
+        // Read the entire file into a local map BEFORE taking the cache mutex.
+        // Holding CacheBackedStore::m during file I/O is what froze callers:
+        // every store()/remove() also takes m, so a slow file read on the
+        // work queue blocked the calling thread for the duration.
         std::ifstream _fI;
-        std::string key;
-        std::string value;
-
-        std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
         _fI.open(_fullPath);
-        const std::streamoff offset = std::streamoff(0);
-        _fI.seekg(offset, std::ios_base::beg);
 
+        if (!_fI.is_open()) {
+            std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
+            if (!dirtyFlag.load()) {
+                // No file and no pending writes: cache matches "disk" (empty).
+                dirtyFlag = false;
+            }
+            return;
+        }
+
+        _fI.seekg(0, std::ios::end);
+        std::streampos fileSize = _fI.tellg();
+        _fI.seekg(0, std::ios::beg);
+
+        const std::streampos MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+        if (fileSize > MAX_FILE_SIZE) {
+            LLOG_VERBOSE("FileBackedStore file too large (%lld bytes), skipping load: %s",
+                        static_cast<long long>(fileSize), _fullPath.c_str());
+            _fI.close();
+            return;
+        }
+
+        std::map<K, std::shared_ptr<T>> tmp;
         try {
-            while (std::getline(_fI, key)) {
-                std::getline(_fI, value);
+            const int MAX_ENTRIES = 10000;
+            int entryCount = 0;
+            std::string key;
+            std::string value;
+
+            while (std::getline(_fI, key) && entryCount < MAX_ENTRIES) {
+                if (!std::getline(_fI, value)) {
+                    LLOG_VERBOSE("Malformed file, missing value for key: %s", _fullPath.c_str());
+                    break;
+                }
+
                 K k{key};
                 std::stringstream is{value};
 
                 std::shared_ptr<T> t = _factory(is);
                 if (_validator(k, t)) {
-                    CacheBackedStore<K, T>::map[k] = t;
+                    tmp[k] = t;
                 }
+
+                entryCount++;
+            }
+
+            if (entryCount >= MAX_ENTRIES) {
+                LLOG_VERBOSE("FileBackedStore exceeded max entries (%d), truncating: %s",
+                            MAX_ENTRIES, _fullPath.c_str());
             }
         } catch (...) {
-            const std::streamoff offset = std::streamoff(0);
-            _fI.seekg(offset, std::ios_base::beg);
-            CacheBackedStore<K, T>::map.clear();
+            LLOG_VERBOSE("Exception during file load, dropping partial result: %s", _fullPath.c_str());
+            _fI.close();
+            return;
         }
         _fI.close();
-        dirtyFlag = false;
+
+        // Brief lock to merge into the cache. emplace() preserves any keys
+        // that were store()d concurrently while we were reading the file —
+        // those represent newer values than what's on disk.
+        std::lock_guard<std::mutex> lk(CacheBackedStore<K, T>::m);
+        bool wasClean = !dirtyFlag.load();
+        for (auto& kv : tmp) {
+            CacheBackedStore<K, T>::map.emplace(kv.first, kv.second);
+        }
+        if (wasClean) {
+            // No concurrent writes happened during the read, so cache now
+            // matches disk. If wasClean was false, leave dirtyFlag set so
+            // the queued flush will write the concurrent store(s) out.
+            dirtyFlag = false;
+        }
     }
 
     void writeToFile() {

--- a/libMobileAgent/src/Analytics/src/EventDeserializer.cxx
+++ b/libMobileAgent/src/Analytics/src/EventDeserializer.cxx
@@ -64,7 +64,10 @@ namespace NewRelic {
                                                       session_elapsed_time_sec,
                                                       validator);
 
-        while (!is.eof()) {
+        // Also check fail() — istream::get(streambuf&, delim) sets failbit
+        // (not eofbit) when the next char already is the delimiter and zero
+        // chars are extracted. Without this guard the loop spins forever.
+        while (!is.eof() && !is.fail()) {
             auto attribute = AttributeDeserializer::deserializeAttributes(is);
             if(attribute == nullptr) continue;
             event->insertAttribute(attribute);
@@ -92,7 +95,8 @@ namespace NewRelic {
             throw std::runtime_error("unrecognized event type in stream.");
         }
 
-        while (!is.eof()) {
+        // See deserializeUserActionEvent for the failbit-vs-eofbit explanation.
+        while (!is.eof() && !is.fail()) {
             auto attribute = AttributeDeserializer::deserializeAttributes(is);
             if (attribute == nullptr) continue;
             event->insertAttribute(attribute);

--- a/libMobileAgent/src/Analytics/src/Events/AnalyticEvent.cxx
+++ b/libMobileAgent/src/Analytics/src/Events/AnalyticEvent.cxx
@@ -67,11 +67,22 @@ namespace NewRelic {
     }
 
     bool AnalyticEvent::insertAttribute(std::shared_ptr<AttributeBase> attribute) {
-        auto mappedObj = (_attributes[attribute->getName()] = attribute);
+        const std::string& name = attribute->getName();
+
+        // An empty name serializes as two consecutive '\t' delimiters, which
+        // puts the deserializer's per-attribute loop into the failbit-only
+        // state that spins on the CPU. AttributeBase already escapes raw
+        // delimiter characters in names (see AttributeBase.cxx), so emptiness
+        // is the only remaining write-side hazard.
+        if (name.empty()) {
+            throw std::invalid_argument("Invalid attribute name: empty.");
+        }
+
+        auto mappedObj = (_attributes[name] = attribute);
         // map operator[] returns the object inserted, or the object that prevented the insertion
         // we can validate with this information.
         if (&(*mappedObj) != &(*attribute)) {
-            const std::string error = std::string(std::string("Inserted duplicate attribute: { \"") + attribute->getName() + std::string("\" } into event."));
+            const std::string error = std::string(std::string("Inserted duplicate attribute: { \"") + name + std::string("\" } into event."));
             throw std::invalid_argument(error);
         }
 

--- a/libMobileAgent/test/AnalyticsTest/EventManager_test.cxx
+++ b/libMobileAgent/test/AnalyticsTest/EventManager_test.cxx
@@ -287,6 +287,38 @@ TEST_F(EventManagerTest, testBadSerializedEvent) {
     ASSERT_THROW(manager.newEvent(strs2), std::runtime_error);
 }
 
+// Regression: an empty attribute name in a serialized event used to spin the
+// deserializer forever. istream::get(streambuf&, delim) sets failbit (not
+// eofbit) when the very next character already is the delimiter, so the loop
+// in EventDeserializer::deserializeUserActionEvent / deserializeMobileEvent
+// — which checked only !is.eof() — never terminated. The fix added a
+// !is.fail() guard. Without that guard these tests will hang until CI kills
+// the run.
+TEST_F(EventManagerTest, testDeserializeDoesNotSpinOnEmptyAttributeNameUserAction) {
+    EventManager manager{store};
+
+    // "MobileUserAction" routes to deserializeUserActionEvent. After ts and
+    // elapsed are consumed, the remaining "\t" is exactly the trap: zero
+    // chars extracted, failbit-only state, !is.eof() stays true.
+    std::stringstream strs;
+    strs << "MobileUserAction\t1\t1\t\t";
+
+    ASSERT_NO_THROW(manager.newEvent(strs));
+}
+
+TEST_F(EventManagerTest, testDeserializeDoesNotSpinOnEmptyAttributeNameMobileEvent) {
+    EventManager manager{store};
+
+    // Same trap as above, routed through deserializeMobileEvent instead of
+    // deserializeUserActionEvent. Mobile / Interaction / name / ts / elapsed
+    // is the well-formed prefix; the trailing "\t" leaves the per-attribute
+    // loop staring at a delimiter with non-EOF state.
+    std::stringstream strs;
+    strs << "Mobile\tInteraction\tn\t1\t1\t\t";
+
+    ASSERT_NO_THROW(manager.newEvent(strs));
+}
+
 TEST_F(EventManagerTest, testEmptyDoesNotResetTimestamp) {
     EventManager manager{store};
 


### PR DESCRIPTION
## Summary

Fixes an app-launch freeze on React Native apps caused by an infinite loop
in `EventDeserializer` when the events dup store contains a record that
ends with consecutive `\t` delimiters. The agent's main thread would peg a
core during `AnalyticsCever return.

## Root cause

`AttributeDeserializer: the attribute name via
`is.get(streambuf&, '\t')`. Per the standard, when the very next character
already is the delimiteters and sets
`failbit` — but **not** `eofbit`. The per-attribute loops in
`EventDeserializer::des
`deserializeMobileEvent` only checked `!is.eof()`, so once the stream
landed in the failbit-over.

This fired in production empty attribute name
(yielding `\t\t` in the stream) or on partially-corrupted persisted data.

## Fix

Two complementary changes:

1. **Read side** (`EventDeserializer.cxx`): both per-attribute loops now
   exit on `is.fail()` s the load-bearing
   fix — it terminates the loop on any stream-state hazard, including
   data already on diskture corruption.
2. **Write side** (`AnalyticEvent.cxx`): `insertAttribute` rejects empty
   attribute names. `Atraw `\t`/`\n` in
   names at construction, so empty-name was the only remaining write-side
   path that could prodtate.
