### PR TITLE
Distributed Tracing: seed the guid generator once for full-entropy trace ids (#772)

### DIFF
--- a/libMobileAgent/src/Connectivity/include/Connectivity/IGuidGenerator.hpp
+++ b/libMobileAgent/src/Connectivity/include/Connectivity/IGuidGenerator.hpp
@@ -9,8 +9,14 @@ template<typename T>
 class IGuidGenerator {
 public:
     static T generateGuid() {
-        unsigned seed = static_cast<unsigned int>(std::chrono::system_clock::now().time_since_epoch().count());
-        std::default_random_engine generator{seed};
+        // Use a single persistent engine, seeded once from a non-deterministic
+        // source. The previous implementation re-seeded a fresh engine with a
+        // truncated `unsigned int` timestamp on EVERY call, so two calls within
+        // the same clock tick returned identical values. newGUID32() concatenates
+        // two generateGuid() calls, so that produced 128-bit trace ids whose two
+        // 64-bit halves were identical (e.g. "7b2961adf3fdf1cd" twice) and made
+        // trace ids collide across unrelated requests (newrelic/newrelic-ios-agent#772).
+        static thread_local std::mt19937_64 generator{std::random_device{}()};
         std::uniform_int_distribution<T> distribution{}; //default constructor does 0 - type_max
         return distribution(generator);
     }


### PR DESCRIPTION
Split out of #773 at the maintainer's request.

## Summary

`IGuidGenerator::generateGuid()` re-seeded a fresh `std::default_random_engine` with a `static_cast<unsigned int>` of the current timestamp on **every call**. `GuidGenerator::newGUID32()` calls it twice back-to-back to build a 128-bit id, so two calls within the same clock tick got the same seed and returned **identical 64-bit halves** (e.g. `7b2961adf3fdf1cd` repeated). Besides looking malformed, this is low-entropy and collision-prone across unrelated requests.

Fix: seed a single persistent `thread_local std::mt19937_64` from `std::random_device` once, so successive calls are independent.

## Already addressed upstream

New Relic noted on #772 that this is **already fixed on `develop` (PR #754) and will ship in 7.7.3**. Opening this only so the fix is tracked against #772 and the change is visible against `main` - **feel free to close in favour of #754** if you would rather not carry a duplicate.

Refs newrelic/newrelic-ios-agent#772