### PR TITLE
NR-577731: Handle 429 / rate-limit responses with backoff

### DIFF
--- a/Agent/Harvester/DataStore/NRMAHarvestResponse.h
+++ b/Agent/Harvester/DataStore/NRMAHarvestResponse.h
@@ -19,6 +19,7 @@
 #define URL_TOO_LARGE          414
 #define INVALID_AGENT_ID       450
 #define UNSUPPORTED_MEDIA_TYPE 415
+#define TOO_MANY_REQUESTS      429
 #define UNKNOWN                 -1
 #define ZERO_STATUS_CODE         0
 
@@ -29,10 +30,16 @@
 @property(assign) int statusCode;
 @property(strong) NSString* responseBody;
 @property(strong) NSError* error;
+// Parsed value of the Retry-After response header in seconds; 0 when absent or unparseable.
+@property(assign) NSTimeInterval retryAfterSeconds;
 
 - (int) getResponseCode;
 - (BOOL) isDisableCommand;
 - (BOOL) isError;
 - (BOOL) isOK;
+- (BOOL) isRateLimited;
+
+// Parses the Retry-After header (delta-seconds or HTTP-date) into retryAfterSeconds.
+- (void) parseRetryAfterFromHeaders:(NSDictionary*)headers;
 
 @end

--- a/Agent/Harvester/DataStore/NRMAHarvestResponse.m
+++ b/Agent/Harvester/DataStore/NRMAHarvestResponse.m
@@ -25,6 +25,7 @@ static const NSString* kDISABLE_STRING = @"DISABLE_NEW_RELIC";
         case INVALID_AGENT_ID:
         case UNSUPPORTED_MEDIA_TYPE:
         case CONFIGURATION_UPDATE:
+        case TOO_MANY_REQUESTS:
             return self.statusCode;
             break;
         default:
@@ -48,5 +49,58 @@ static const NSString* kDISABLE_STRING = @"DISABLE_NEW_RELIC";
     return ![self isError];
 }
 
+- (BOOL) isRateLimited
+{
+    return self.statusCode == TOO_MANY_REQUESTS;
+}
+
+- (void) parseRetryAfterFromHeaders:(NSDictionary*)headers
+{
+    self.retryAfterSeconds = 0;
+    if (![headers isKindOfClass:[NSDictionary class]]) {
+        return;
+    }
+
+    // Header field names are case-insensitive, but allHeaderFields preserves the
+    // server's casing, so search for the value rather than assuming a key.
+    NSString* value = nil;
+    for (id key in headers) {
+        if ([key isKindOfClass:[NSString class]] && [(NSString*)key caseInsensitiveCompare:@"Retry-After"] == NSOrderedSame) {
+            id rawValue = headers[key];
+            if ([rawValue isKindOfClass:[NSString class]]) {
+                value = rawValue;
+            }
+            break;
+        }
+    }
+
+    value = [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    if (value.length == 0) {
+        return;
+    }
+
+    // Retry-After is either delta-seconds (a non-negative integer) or an HTTP-date.
+    NSScanner* scanner = [NSScanner scannerWithString:value];
+    NSInteger seconds = 0;
+    if ([scanner scanInteger:&seconds] && [scanner isAtEnd]) {
+        self.retryAfterSeconds = seconds > 0 ? (NSTimeInterval)seconds : 0;
+        return;
+    }
+
+    static NSDateFormatter* httpDateFormatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        httpDateFormatter = [[NSDateFormatter alloc] init];
+        httpDateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+        httpDateFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+        httpDateFormatter.dateFormat = @"EEE, dd MMM yyyy HH:mm:ss 'GMT'";
+    });
+
+    NSDate* retryDate = [httpDateFormatter dateFromString:value];
+    if (retryDate != nil) {
+        NSTimeInterval delta = [retryDate timeIntervalSinceNow];
+        self.retryAfterSeconds = delta > 0 ? delta : 0;
+    }
+}
 
 @end

--- a/Agent/Harvester/NRMAHarvester.h
+++ b/Agent/Harvester/NRMAHarvester.h
@@ -48,6 +48,12 @@ typedef enum {
 
 @property(readonly) NRMAHarvesterState currentState;
 @property(nonatomic,strong) NRMAHarvestData* harvestData;
+
+// Rate-limit (HTTP 429) backoff state. rateLimitBackoffUntil is an absolute
+// reference-date timestamp before which harvest uploads are paused;
+// rateLimitBackoffCount is the number of consecutive 429s driving exponential escalation.
+@property(atomic, assign) NSTimeInterval rateLimitBackoffUntil;
+@property(atomic, assign) NSInteger rateLimitBackoffCount;
 - (void) execute;
 - (void) setAgentConfiguration:(NRMAAgentConfiguration*)agentConfiguration;
 - (void) configureHarvester:(NRMAHarvesterConfiguration*)harvestConfiguration;

--- a/Agent/Harvester/NRMAHarvester.mm
+++ b/Agent/Harvester/NRMAHarvester.mm
@@ -7,6 +7,7 @@
 //
 
 #import "NRMAHarvester.h"
+#import <math.h>
 #import "NRLogger.h"
 #import "NRMAMeasurements.h"
 #import "NRTimer.h"
@@ -26,6 +27,11 @@
 #import "NRAutoLogCollector.h"
 
 #define kNRSupportabilityResponseCode kNRSupportabilityPrefix @"/Collector/ResponseStatusCodes"
+
+// Rate-limit (HTTP 429) backoff bounds. When the collector does not provide a
+// Retry-After header we escalate exponentially from the base, capped at the max.
+static const NSTimeInterval kNRMARateLimitBaseBackoffSeconds = 60.0;
+static const NSTimeInterval kNRMARateLimitMaxBackoffSeconds  = 600.0;
 
 @interface NRMAHarvester (privateMethods)
 
@@ -366,6 +372,16 @@
     }
     
     NRLOG_AGENT_VERBOSE(@"Harvester: connected");
+
+    // If we are inside a rate-limit (429) backoff window, pause harvest uploads:
+    // skip the upload entirely and retain the buffered data for after the window,
+    // rather than blindly resending payloads the collector just rejected.
+    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+    if (self.rateLimitBackoffUntil > now) {
+        NRLOG_AGENT_VERBOSE(@"Harvester: rate-limit backoff active, skipping upload for %.0f more seconds.", self.rateLimitBackoffUntil - now);
+        return;
+    }
+
     NRMAHarvestResponse* response = nil;
 #ifndef  DISABLE_NRMA_EXCEPTION_WRAPPER
     @try {
@@ -407,7 +423,12 @@
 
             // Send Supportability metric when received 409 to indicate that a config update should happen or send it when actual /connect call finishes which refreshes the data.
             [NRMASupportMetricHelper enqueueConfigurationUpdateMetric];
-            
+
+            break;
+        case TOO_MANY_REQUESTS:
+            // The collector is rate-limiting us. Arm a backoff window so the next
+            // harvest cycles pause instead of resending the just-rejected payload.
+            [self handleRateLimitResponse:response];
             break;
         default:
             break;
@@ -419,10 +440,14 @@
             // If the harvest was persisted for offline storage clear the harvest.
             [self.harvestData clear];
         } else {
+            // On a 429 we deliberately retain the buffer so it can be sent after
+            // the backoff window; the backoff guard above prevents an immediate resend.
             [self fireOnHarvestFailure];
         }
     } else {
         // success
+        // A successful (2xx) harvest clears any active rate-limit backoff.
+        [self resetRateLimitBackoff];
         [self.harvestData clear];
         // If there was a successful harvest upload send the persisted offline payloads.
         [connection sendOfflineStorage];
@@ -457,6 +482,33 @@
     }
 #endif
     [self fireOnHarvestComplete];
+}
+
+- (void) handleRateLimitResponse:(NRMAHarvestResponse*)response {
+    NSTimeInterval backoff;
+    if (response.retryAfterSeconds > 0) {
+        // Honor the server-provided Retry-After interval, bounded by our cap.
+        backoff = MIN(response.retryAfterSeconds, kNRMARateLimitMaxBackoffSeconds);
+    } else {
+        // No Retry-After: escalate exponentially from the base, capped at the max.
+        backoff = kNRMARateLimitBaseBackoffSeconds * pow(2.0, (double)self.rateLimitBackoffCount);
+        backoff = MIN(backoff, kNRMARateLimitMaxBackoffSeconds);
+    }
+
+    self.rateLimitBackoffUntil = [NSDate timeIntervalSinceReferenceDate] + backoff;
+    self.rateLimitBackoffCount += 1;
+
+    NRLOG_AGENT_WARNING(@"Harvester: received 429 rate-limit response; pausing harvest uploads for %.0f seconds (attempt %ld).", backoff, (long)self.rateLimitBackoffCount);
+
+    [NRMASupportMetricHelper enqueueRateLimitBackoffMetric:backoff];
+}
+
+- (void) resetRateLimitBackoff {
+    if (self.rateLimitBackoffUntil != 0 || self.rateLimitBackoffCount != 0) {
+        NRLOG_AGENT_VERBOSE(@"Harvester: successful harvest, clearing rate-limit backoff.");
+    }
+    self.rateLimitBackoffUntil = 0;
+    self.rateLimitBackoffCount = 0;
 }
 
 - (BOOL) checkOfflineAndPersist:(NRMAHarvestResponse*) response {

--- a/Agent/Harvester/NRMAHarvesterConnection.m
+++ b/Agent/Harvester/NRMAHarvesterConnection.m
@@ -167,6 +167,7 @@
 
     harvestResponse.statusCode = (int)response.statusCode;
     harvestResponse.responseBody = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    [harvestResponse parseRetryAfterFromHeaders:response.allHeaderFields];
     NRLOG_AGENT_VERBOSE(@"NEWRELIC CONNECT - RESPONSE DATA: %@", harvestResponse.responseBody);
     return harvestResponse;
 }

--- a/Agent/Measurements/NRMASupportMetricHelper.h
+++ b/Agent/Measurements/NRMASupportMetricHelper.h
@@ -19,6 +19,7 @@ static NSMutableArray *deferredMetrics;
 + (void) enqueueUpgradeMetric;
 + (void) enqueueStopAgentMetric;
 + (void) enqueueConfigurationUpdateMetric;
++ (void) enqueueRateLimitBackoffMetric:(NSTimeInterval)backoffSeconds;
 + (void) enqueueBufferPoolSizeConfiguration:(unsigned int)size;
 + (void) enqueueMaxBufferTimeConfiguration:(unsigned int)seconds;
 + (void) enqueue4HourSessionRestartMetric;

--- a/Agent/Measurements/NRMASupportMetricHelper.m
+++ b/Agent/Measurements/NRMASupportMetricHelper.m
@@ -108,6 +108,17 @@ static NSMutableArray<NRMAMetric *> *deferredMetrics;
     }
 }
 
++ (void) enqueueRateLimitBackoffMetric:(NSTimeInterval)backoffSeconds {
+    NSString* metricString = [NSString stringWithFormat:kNRMARateLimitBackoffMetricFormatString, [NewRelicInternalUtils osName], kPlatformPlaceholder];
+    @synchronized (deferredMetrics) {
+        [deferredMetrics addObject:[[NRMAMetric alloc] initWithName:metricString
+                                                              value:[NSNumber numberWithDouble:backoffSeconds]
+                                                              scope:@""
+                                                    produceUnscoped:YES
+                                                    additionalValue:nil]];
+    }
+}
+
 + (void) enqueueMaxBufferTimeConfiguration:(unsigned int)seconds {
     NSString* nativePlatform = [NewRelicInternalUtils osName];
 

--- a/Agent/Public/NRConstants.h
+++ b/Agent/Public/NRConstants.h
@@ -150,6 +150,9 @@ typedef NSString NRMetricUnit;
 
 #define kNRMAConfigurationUpdated        @"Supportability/Mobile/%@/%@/Configuration/Updated"
 
+// NativePlatform, Platform — emitted when a 429/rate-limit response triggers harvest upload backoff.
+#define kNRMARateLimitBackoffMetricFormatString @"Supportability/Mobile/%@/%@/Collector/RateLimit/Backoff"
+
 //Network info cache constants
 #define kNRCarrierNameCacheLifetime     50 // milliseconds
 #define kNRWanTypeCacheLifetime         25 // milliseconds

--- a/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRHarvesterTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRHarvesterTest.m
@@ -812,6 +812,204 @@
 
 // TODO: LogReporting Add test for entity_guid: and log_reporting: { enabled: , level: }
 
+#pragma mark - Rate limit (429) backoff
+
+- (void) testRetryAfterParsingSeconds {
+    NRMAHarvestResponse* response = [[NRMAHarvestResponse alloc] init];
+    [response parseRetryAfterFromHeaders:@{@"Retry-After": @"120"}];
+    XCTAssertEqual(response.retryAfterSeconds, 120, @"Retry-After integer seconds should parse to 120");
+}
+
+- (void) testRetryAfterParsingCaseInsensitiveHeader {
+    NRMAHarvestResponse* response = [[NRMAHarvestResponse alloc] init];
+    [response parseRetryAfterFromHeaders:@{@"retry-after": @"45"}];
+    XCTAssertEqual(response.retryAfterSeconds, 45, @"Retry-After header lookup should be case-insensitive");
+}
+
+- (void) testRetryAfterParsingHTTPDate {
+    NRMAHarvestResponse* response = [[NRMAHarvestResponse alloc] init];
+    NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
+    formatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+    formatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+    formatter.dateFormat = @"EEE, dd MMM yyyy HH:mm:ss 'GMT'";
+    NSString* future = [formatter stringFromDate:[NSDate dateWithTimeIntervalSinceNow:300]];
+
+    [response parseRetryAfterFromHeaders:@{@"Retry-After": future}];
+    // Allow slack for the second boundary / parsing.
+    XCTAssertTrue(response.retryAfterSeconds > 250 && response.retryAfterSeconds <= 301,
+                  @"Retry-After HTTP-date should parse to ~300s from now, was %f", response.retryAfterSeconds);
+}
+
+- (void) testRetryAfterAbsent {
+    NRMAHarvestResponse* response = [[NRMAHarvestResponse alloc] init];
+    [response parseRetryAfterFromHeaders:@{@"Content-Type": @"application/json"}];
+    XCTAssertEqual(response.retryAfterSeconds, 0, @"Missing Retry-After should leave retryAfterSeconds at 0");
+}
+
+- (void) testRateLimitResponseSetsBackoffWithRetryAfter {
+    id mockHarvester = [OCMockObject partialMockForObject:harvester];
+    id mockConnection = [OCMockObject partialMockForObject:[mockHarvester connection]];
+    [[[mockHarvester stub] andReturn:[NRMAHarvesterConfiguration new]] harvesterConfiguration];
+
+    [[[mockConnection stub] andDo:^(NSInvocation *invocation) {
+        @throw [NSException exceptionWithName:@"" reason:@"" userInfo:nil];
+    }] sendConnect];
+
+    NRMAHarvestResponse* response = [[NRMAHarvestResponse alloc] init];
+    response.statusCode = TOO_MANY_REQUESTS;
+    response.retryAfterSeconds = 120;
+    [[[mockConnection stub] andReturn:response] sendData:OCMOCK_ANY];
+
+    NSTimeInterval before = [NSDate timeIntervalSinceReferenceDate];
+    [mockHarvester connected];
+
+    XCTAssertEqual([mockHarvester rateLimitBackoffCount], 1, @"First 429 should set backoff count to 1");
+    NSTimeInterval remaining = [mockHarvester rateLimitBackoffUntil] - before;
+    XCTAssertTrue(remaining > 110 && remaining <= 121,
+                  @"Backoff window should honor the 120s Retry-After, was %f", remaining);
+
+    [mockHarvester stopMocking];
+    [mockConnection stopMocking];
+}
+
+- (void) testRateLimitBackoffEscalatesWithoutRetryAfter {
+    id mockHarvester = [OCMockObject partialMockForObject:harvester];
+    id mockConnection = [OCMockObject partialMockForObject:[mockHarvester connection]];
+    [[[mockHarvester stub] andReturn:[NRMAHarvesterConfiguration new]] harvesterConfiguration];
+
+    [[[mockConnection stub] andDo:^(NSInvocation *invocation) {
+        @throw [NSException exceptionWithName:@"" reason:@"" userInfo:nil];
+    }] sendConnect];
+
+    NRMAHarvestResponse* response = [[NRMAHarvestResponse alloc] init];
+    response.statusCode = TOO_MANY_REQUESTS; // no Retry-After -> exponential backoff
+    [[[mockConnection stub] andReturn:response] sendData:OCMOCK_ANY];
+
+    NSTimeInterval before1 = [NSDate timeIntervalSinceReferenceDate];
+    [mockHarvester connected];
+    NSTimeInterval firstWindow = [mockHarvester rateLimitBackoffUntil] - before1;
+    XCTAssertEqual([mockHarvester rateLimitBackoffCount], 1);
+
+    // Simulate the first backoff window elapsing so the next cycle actually
+    // reaches the collector and receives a second 429 (the pause guard would
+    // otherwise correctly skip the upload while the window is still active).
+    [mockHarvester setRateLimitBackoffUntil:[NSDate timeIntervalSinceReferenceDate] - 1];
+
+    NSTimeInterval before2 = [NSDate timeIntervalSinceReferenceDate];
+    [mockHarvester connected];
+    NSTimeInterval secondWindow = [mockHarvester rateLimitBackoffUntil] - before2;
+    XCTAssertEqual([mockHarvester rateLimitBackoffCount], 2);
+
+    XCTAssertTrue(secondWindow > firstWindow,
+                  @"Consecutive 429s should escalate the backoff window (%f -> %f)", firstWindow, secondWindow);
+
+    [mockHarvester stopMocking];
+    [mockConnection stopMocking];
+}
+
+- (void) testRateLimitBackoffCapsRetryAfterAtMax {
+    id mockHarvester = [OCMockObject partialMockForObject:harvester];
+    id mockConnection = [OCMockObject partialMockForObject:[mockHarvester connection]];
+    [[[mockHarvester stub] andReturn:[NRMAHarvesterConfiguration new]] harvesterConfiguration];
+
+    [[[mockConnection stub] andDo:^(NSInvocation *invocation) {
+        @throw [NSException exceptionWithName:@"" reason:@"" userInfo:nil];
+    }] sendConnect];
+
+    // A server-provided Retry-After far larger than our cap must be clamped to
+    // kNRMARateLimitMaxBackoffSeconds (600s) so a misbehaving collector can't pause us indefinitely.
+    NRMAHarvestResponse* response = [[NRMAHarvestResponse alloc] init];
+    response.statusCode = TOO_MANY_REQUESTS;
+    response.retryAfterSeconds = 100000;
+    [[[mockConnection stub] andReturn:response] sendData:OCMOCK_ANY];
+
+    NSTimeInterval before = [NSDate timeIntervalSinceReferenceDate];
+    [mockHarvester connected];
+
+    NSTimeInterval remaining = [mockHarvester rateLimitBackoffUntil] - before;
+    XCTAssertTrue(remaining > 590 && remaining <= 601,
+                  @"An oversized Retry-After should be clamped to the 600s cap, was %f", remaining);
+
+    [mockHarvester stopMocking];
+    [mockConnection stopMocking];
+}
+
+- (void) testRateLimitBackoffExponentialPlateausAtMax {
+    id mockHarvester = [OCMockObject partialMockForObject:harvester];
+    id mockConnection = [OCMockObject partialMockForObject:[mockHarvester connection]];
+    [[[mockHarvester stub] andReturn:[NRMAHarvesterConfiguration new]] harvesterConfiguration];
+
+    [[[mockConnection stub] andDo:^(NSInvocation *invocation) {
+        @throw [NSException exceptionWithName:@"" reason:@"" userInfo:nil];
+    }] sendConnect];
+
+    // After many consecutive 429s with no Retry-After the exponential window (base * 2^count)
+    // would explode; it must plateau at kNRMARateLimitMaxBackoffSeconds (600s). Seed a high count
+    // so the next 429 lands well past the cap.
+    [mockHarvester setRateLimitBackoffCount:10];
+
+    NRMAHarvestResponse* response = [[NRMAHarvestResponse alloc] init];
+    response.statusCode = TOO_MANY_REQUESTS; // no Retry-After -> exponential branch
+    [[[mockConnection stub] andReturn:response] sendData:OCMOCK_ANY];
+
+    NSTimeInterval before = [NSDate timeIntervalSinceReferenceDate];
+    [mockHarvester connected];
+
+    NSTimeInterval remaining = [mockHarvester rateLimitBackoffUntil] - before;
+    XCTAssertTrue(remaining > 590 && remaining <= 601,
+                  @"Exponential backoff should plateau at the 600s cap, was %f", remaining);
+
+    [mockHarvester stopMocking];
+    [mockConnection stopMocking];
+}
+
+- (void) testRateLimitBackoffSkipsUploadDuringWindow {
+    id mockHarvester = [OCMockObject partialMockForObject:harvester];
+    id mockConnection = [OCMockObject partialMockForObject:[mockHarvester connection]];
+    [[[mockHarvester stub] andReturn:[NRMAHarvesterConfiguration new]] harvesterConfiguration];
+
+    [[[mockConnection stub] andDo:^(NSInvocation *invocation) {
+        @throw [NSException exceptionWithName:@"" reason:@"" userInfo:nil];
+    }] sendConnect];
+
+    // Arm an active backoff window 5 minutes into the future.
+    [mockHarvester setRateLimitBackoffUntil:[NSDate timeIntervalSinceReferenceDate] + 300];
+
+    // sendData must NOT be called while paused.
+    [[mockConnection reject] sendData:OCMOCK_ANY];
+
+    XCTAssertNoThrow([mockHarvester connected], @"Harvest upload should be skipped during backoff window");
+
+    [mockHarvester stopMocking];
+    [mockConnection stopMocking];
+}
+
+- (void) testRateLimitBackoffResetsOnSuccess {
+    id mockHarvester = [OCMockObject partialMockForObject:harvester];
+    id mockConnection = [OCMockObject partialMockForObject:[mockHarvester connection]];
+    [[[mockHarvester stub] andReturn:[NRMAHarvesterConfiguration new]] harvesterConfiguration];
+
+    [[[mockConnection stub] andDo:^(NSInvocation *invocation) {
+        @throw [NSException exceptionWithName:@"" reason:@"" userInfo:nil];
+    }] sendConnect];
+
+    // Pretend we were previously in backoff (but the window has already elapsed).
+    [mockHarvester setRateLimitBackoffUntil:[NSDate timeIntervalSinceReferenceDate] - 1];
+    [mockHarvester setRateLimitBackoffCount:3];
+
+    NRMAHarvestResponse* response = [[NRMAHarvestResponse alloc] init];
+    response.statusCode = OK;
+    [[[mockConnection stub] andReturn:response] sendData:OCMOCK_ANY];
+
+    [mockHarvester connected];
+
+    XCTAssertEqual([mockHarvester rateLimitBackoffUntil], 0, @"A successful harvest should clear the backoff window");
+    XCTAssertEqual([mockHarvester rateLimitBackoffCount], 0, @"A successful harvest should reset the backoff count");
+
+    [mockHarvester stopMocking];
+    [mockConnection stopMocking];
+}
+
 - (void) testConnectedv5Apps{
     id mockHarvester = [OCMockObject partialMockForObject:harvester];
     id mockConnection = [OCMockObject partialMockForObject:[mockHarvester connection]];


### PR DESCRIPTION
Isolated 429 rate-limit handling extracted for NR-577731

Implementation:
- NRMAHarvestResponse: TOO_MANY_REQUESTS (429), isRateLimited, and parseRetryAfterFromHeaders (delta-seconds and HTTP-date forms).
- NRMAHarvester: arm/clear an exponential backoff window on 429, honoring Retry-After (capped) and skipping harvest uploads while the window is active.
- NRMAHarvesterConnection: parse Retry-After from response headers.
- NRMASupportMetricHelper + NRConstants: RateLimit/Backoff supportability metric.

Tests:
- NRHarvesterTest: Retry-After parsing and 429 backoff behavior (set/escalate/ cap/plateau/skip-during-window/reset-on-success).