### PR TITLE
fix: NRMAWKWebViewNavigationDelegate webViewWebContentProcessDidTerminate crash fix

### DIFF
--- a/Agent/Instrumentation/WKWebView/NRMAWKWebViewNavigationDelegate.m
+++ b/Agent/Instrumentation/WKWebView/NRMAWKWebViewNavigationDelegate.m
@@ -24,7 +24,44 @@
 }
 
 - (id)forwardingTargetForSelector:(SEL)aSelector {
-    return self.realDelegate;
+    // realDelegate is held weakly. WebKit caches the result of respondsToSelector:
+    // at navigation-delegate-assignment time, so it can later send us a selector that
+    // only the real delegate implements (e.g. webViewWebContentProcessDidTerminate:,
+    // which fires when a backgrounded web view's content process is reclaimed) after
+    // that real delegate has been deallocated. Only fast-forward when the real delegate
+    // is still alive and actually implements the selector; otherwise return nil so the
+    // message drops into the full forwarding machinery below and is absorbed rather than
+    // falling through to doesNotRecognizeSelector: and crashing the host app.
+    NSObject* delegate = self.realDelegate;
+    if ([delegate respondsToSelector:aSelector]) {
+        return delegate;
+    }
+    return nil;
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector {
+    NSMethodSignature* signature = [super methodSignatureForSelector:aSelector];
+    if (signature) {
+        return signature;
+    }
+
+    NSObject* delegate = self.realDelegate;
+    if ([delegate respondsToSelector:aSelector]) {
+        return [delegate methodSignatureForSelector:aSelector];
+    }
+
+    // The real delegate was deallocated after WebKit cached respondsToSelector: == YES.
+    // Return a benign void signature so the runtime routes the call to forwardInvocation:
+    // (where it is dropped) instead of to doesNotRecognizeSelector: (which would throw).
+    return [NSMethodSignature signatureWithObjCTypes:"v@:@"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation {
+    NSObject* delegate = self.realDelegate;
+    if ([delegate respondsToSelector:invocation.selector]) {
+        [invocation invokeWithTarget:delegate];
+    }
+    // Otherwise the real delegate is gone; silently drop the message instead of crashing.
 }
 
 @end

--- a/Agent/Instrumentation/WKWebView/NRWKNavigationDelegateBase.m
+++ b/Agent/Instrumentation/WKWebView/NRWKNavigationDelegateBase.m
@@ -229,15 +229,24 @@ didFailNavigation:(WKNavigation*)navigation
 }
 
 -(void)invokeMethod:(NSMethodSignature*) methodSignature selector:(SEL)selector parameters:(NSArray*)parameters {
-    NSInvocation *inv = [NSInvocation invocationWithMethodSignature:[self.realDelegate methodSignatureForSelector:selector]];
+    // realDelegate is weak and may have been deallocated since the caller's
+    // respondsToSelector: check (it lives only as long as the host app keeps it).
+    // Snapshot it once and bail if it is gone or no longer responds, otherwise
+    // +invocationWithMethodSignature: would receive a nil signature and throw.
+    NSObject* delegate = self.realDelegate;
+    if (![delegate respondsToSelector:selector]) {
+        return;
+    }
+
+    NSInvocation *inv = [NSInvocation invocationWithMethodSignature:[delegate methodSignatureForSelector:selector]];
     [inv setSelector:selector];
-    [inv setTarget:self.realDelegate];
+    [inv setTarget:delegate];
 
     for(int i = 0; i < parameters.count; i++) {
         NSValue *value = [parameters objectAtIndex:i];
         [inv setArgument:[value pointerValue] atIndex:i+2];//arguments 0 and 1 are self.realDelegate and _cmd respectively, automatically set by NSInvocation
     }
-    
+
     [inv invoke];
 }
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
@@ -27,6 +27,14 @@
 @interface NRMAWKNavigationDelegateWithOldDelegateFunction : NSObject <WKNavigationDelegate>
 @end
 
+// Implements the optional webViewWebContentProcessDidTerminate: callback. Used to
+// reproduce the crash that occurs when WebKit caches respondsToSelector: == YES while
+// this delegate is alive, the delegate is then deallocated (the proxy holds it weakly),
+// and WebKit later fires the cached callback against the orphaned proxy.
+@interface NRMAWKNavigationDelegateWithTerminateFunction : NSObject <WKNavigationDelegate>
+@property(nonatomic) BOOL didTerminateCalled;
+@end
+
 @interface NRWKNavigationDelegateBase ()
 - (instancetype) initWithOriginalDelegate:(NSObject<WKNavigationDelegate>* __nullable __weak)delegate;
 + (NSURL*) navigationURL:(WKNavigation*) nav;
@@ -212,6 +220,41 @@
     XCTAssertEqual(testResponse.receivedPolicy, WKNavigationResponsePolicyAllow);
 }
 
+// Reproduces NR-414430 / the 7.7.0 crash:
+// "-[NRMAWKWebViewNavigationDelegate webViewWebContentProcessDidTerminate:]: unrecognized selector".
+// WebKit caches respondsToSelector: == YES while the real delegate is alive, the real
+// delegate is later deallocated (the proxy holds it weakly), and WebKit fires the cached
+// callback against the orphaned proxy. The proxy must absorb the message, not crash.
+- (void) testWebContentProcessDidTerminateAfterRealDelegateDeallocated {
+    NRMAWKWebViewNavigationDelegate* proxy;
+    @autoreleasepool {
+        NRMAWKNavigationDelegateWithTerminateFunction* realDelegate = [[NRMAWKNavigationDelegateWithTerminateFunction alloc] init];
+        proxy = [[NRMAWKWebViewNavigationDelegate alloc] initWithOriginalDelegate:realDelegate];
+        // WebKit caches this == YES at delegate-assignment time, while realDelegate is alive.
+        XCTAssertTrue([proxy respondsToSelector:@selector(webViewWebContentProcessDidTerminate:)]);
+        realDelegate = nil;
+    }
+
+    // The weak realDelegate has now been zeroed by the deallocation above.
+    XCTAssertNil(proxy.realDelegate);
+
+    // WebKit fires the cached callback. With the bug this throws an unrecognized-selector
+    // NSInvalidArgumentException via the message-forwarding fall-through.
+    id<WKNavigationDelegate> nav = (id<WKNavigationDelegate>)proxy;
+    XCTAssertNoThrow([nav webViewWebContentProcessDidTerminate:self.webView]);
+}
+
+// Guards the happy path: while the real delegate is alive, an optional callback that only
+// the real delegate implements must still be forwarded to it.
+- (void) testWebContentProcessDidTerminateForwardsToLiveDelegate {
+    NRMAWKNavigationDelegateWithTerminateFunction* realDelegate = [[NRMAWKNavigationDelegateWithTerminateFunction alloc] init];
+    NRMAWKWebViewNavigationDelegate* proxy = [[NRMAWKWebViewNavigationDelegate alloc] initWithOriginalDelegate:realDelegate];
+
+    id<WKNavigationDelegate> nav = (id<WKNavigationDelegate>)proxy;
+    XCTAssertNoThrow([nav webViewWebContentProcessDidTerminate:self.webView]);
+    XCTAssertTrue(realDelegate.didTerminateCalled);
+}
+
 - (void)testWebViewLoadTimeMetric {
     [self startWebKitLoad];
     
@@ -323,6 +366,15 @@
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
     decisionHandler(WKNavigationActionPolicyCancel);
+}
+
+@end
+
+@implementation NRMAWKNavigationDelegateWithTerminateFunction
+#pragma mark Delegate Functions
+
+- (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView {
+    self.didTerminateCalled = YES;
 }
 
 @end


### PR DESCRIPTION
…

Root cause

NRMAWKWebViewNavigationDelegate is a proxy the agent slots in front of the app's real WKNavigationDelegate. It holds the real delegate weakly (@property(weak) NSObject* realDelegate; — uniquely among the agent's delegate proxies; the NSURLSession/NSURLConnection ones retain theirs, which is why only WebKit crashes). The crash is a three-step race:

1. At delegate-assignment time the real delegate is alive and implements webViewWebContentProcessDidTerminate:, so the proxy's respondsToSelector: returns YES — WebKit caches this.
2. The owning controller deallocates → the weak realDelegate zeroes to nil.
3. The web view's content process is reclaimed (common when backgrounded) → WebKit fires the cached callback. The proxy doesn't implement it, so forwardingTargetForSelector: returns the now-nil delegate, the runtime falls through to methodSignatureForSelector: (returns nil) → doesNotRecognizeSelector: → NSInvalidArgumentException.

This is general to any optional WKNavigationDelegate method the base class doesn't implement directly — webViewWebContentProcessDidTerminate: is just the one that reliably fires after teardown.

The fix (NRMAWKWebViewNavigationDelegate.m + NRWKNavigationDelegateBase.m)

Hardened the proxy's message-forwarding layer so a vanished weak delegate is absorbed, not crashed — keeping the weak semantics (changing 's memory behavior / risk leaks):
- forwardingTargetForSelector: — fast-forward only when the delegate is alive and responds; else fall through.
- methodSignatureForSelector: / forwardInvocation: — when the delegate is gone, return a benign       signature and silently drop instead oector:.
- Defense-in-depth in invokeMethod: — snapshot the weak ref and bail if gone (same root cause; otherwi+invocationWithMethodSignature:nil th
                                                                                                      Verification
                                                                                                      - Reproduced the exact crash against solated clang harness:NSInvalidArgumentException: -[NRMAWKWebViewNavigationDelegate webViewWebContentProcessDidTerminate:]: unrecognized selector — matching the y.
- Red → green confirmed: after the fix, the deallocated-delegate scenario passes (no exception) and the
live-delegate scenario still forwards
- xcodebuild build -scheme Agent-iOS → ** BUILD SUCCEEDED ** with both files compiling cleanly.
- Added two unit tests in NRMAWKNaviging both scenarios.