### PR TITLE
NR-572312 Session replay data should be uploaded on next launch unless in error mode

### DIFF
--- a/Agent/Analytics/Constants.h
+++ b/Agent/Analytics/Constants.h
@@ -93,6 +93,7 @@ extern NSString *const  kNRMA_EventStoreFilename;
 
 extern NSString *const kNRMA_Offline_folder;
 extern NSString *const kNRMA_SessionReplayFrames_folder;
+extern NSString *const kNRMA_SessionReplayErrorMode_marker;
 
 extern NSString *const kNRMA_Collector_connect_url;
 extern NSString *const kNRMA_Collector_data_url;

--- a/Agent/Analytics/Constants.m
+++ b/Agent/Analytics/Constants.m
@@ -99,6 +99,10 @@ NSString * const kNRMA_EventStoreFilename    = @"eventsStore.txt";
 
 NSString * const kNRMA_Offline_folder          = @"offlineStorage";
 NSString * const kNRMA_SessionReplayFrames_folder = @"SessionReplayFrames";
+// Marker file written into the SessionReplayFrames folder while recording in error mode.
+// Its presence at next launch (with no crash) indicates the previous session left a stale
+// error-mode buffer that should be cleared.
+NSString * const kNRMA_SessionReplayErrorMode_marker = @".errorMode";
 
 NSString * const kNRMA_Collector_connect_url   = @"/mobile/v5/connect";
 NSString * const kNRMA_Collector_data_url      = @"/mobile/v3/data";

--- a/Agent/CrashHandler/NRMAExceptionHandlerManager.m
+++ b/Agent/CrashHandler/NRMAExceptionHandlerManager.m
@@ -131,8 +131,13 @@ static const NSString* NRMAManagerAccessorLock = @"managerLock";
             }
         }
         else {
-            // Clear saved crashed sessions from Mobile Session Replay
-            [self clearSessionReplayFrames];
+            if ([self previousSessionWasInSessionReplayErrorMode]) {
+                // No crash occurred and the previous session was recording session replay in
+                // error mode, where frames are only buffered to disk and uploaded when an
+                // error/crash happens. With no crash, those buffered frames are now stale and
+                // can be cleared.
+                [self clearSessionReplayFrames];
+            }
         }
         self.handler = [[NRMAUncaughtExceptionHandler alloc] initWithCrashReporter:_crashReporter];
 #endif
@@ -245,6 +250,20 @@ static const NSString* __memoryUsageLock = @"Lock";
             NRMA_setMemoryUsage(memoryUsageMB.UTF8String);
         }
     }
+}
+
+// Determines whether the previous session left a stale error-mode session replay buffer.
+// While recording in error mode, session replay drops a marker file into the frames folder
+// (see NRMASessionReplay.processFrameToFile) and removes it when it leaves error mode. So the
+// marker's presence here means the previous session ended while still in error mode.
+- (BOOL) previousSessionWasInSessionReplayErrorMode
+{
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *documentsDirectory = [paths objectAtIndex:0];
+    NSString *markerPath = [[documentsDirectory stringByAppendingPathComponent:kNRMA_SessionReplayFrames_folder]
+                            stringByAppendingPathComponent:kNRMA_SessionReplayErrorMode_marker];
+
+    return [[NSFileManager defaultManager] fileExistsAtPath:markerPath];
 }
 
 - (BOOL) hasSessionReplayFrames

--- a/Agent/SessionReplay/NRMASessionReplay.swift
+++ b/Agent/SessionReplay/NRMASessionReplay.swift
@@ -523,7 +523,16 @@ public class NRMASessionReplay: NSObject {
             if recordingMode == .error {
                 let attributes = [FileAttributeKey.creationDate: Date()]
                 try FileManager.default.setAttributes(attributes, ofItemAtPath: frameURL.path)
-                
+
+                // Drop a marker so that, if this session ends without a crash, the next
+                // launch knows these buffered frames are a stale error-mode buffer and can
+                // clear them (see NRMAExceptionHandlerManager). The marker lives alongside
+                // the frames and is removed when the frames folder is cleared.
+                let errorModeMarker = self.framesDirectory.appendingPathComponent(kNRMA_SessionReplayErrorMode_marker)
+                if !FileManager.default.fileExists(atPath: errorModeMarker.path) {
+                    FileManager.default.createFile(atPath: errorModeMarker.path, contents: nil)
+                }
+
                 //NRLOG_AGENT_DEBUG("💾 [processFrameToFile] Mode: ERROR - Checking if pruning needed")
                 // Prune old files if in ERROR mode
                 pruneBufferedFiles(in: frameFolder)
@@ -584,6 +593,7 @@ public class NRMASessionReplay: NSObject {
         }
         else if mode == .full {
             NRLOG_AGENT_DEBUG("🎬 [transistionToRecordingMode] Transitioning to FULL mode")
+            removeErrorModeMarker()
         }
         
         NRLOG_AGENT_DEBUG("🎬 [transistionToRecordingMode] ====================================================")
@@ -610,11 +620,22 @@ public class NRMASessionReplay: NSObject {
         
         // Transition to full mode
         recordingMode = .full
-        
+
+        // The buffered frames are now headed for upload rather than being a stale
+        // error-mode buffer, so drop the error-mode marker.
+        removeErrorModeMarker()
+
         // Force next frame to be a full snapshot for clean transition
         sessionReplayFrameProcessor.takeFullSnapshotNext = true
         NRLOG_AGENT_DEBUG("🚨 [transitionToFullModeOnError] Next frame will be a full snapshot")
         NRLOG_AGENT_DEBUG("🚨 [transitionToFullModeOnError] =========================================================")
+    }
+
+    /// Removes the error-mode marker file, if present. Called when leaving error mode so a
+    /// later non-crashing launch does not treat the frames as a stale error-mode buffer.
+    private func removeErrorModeMarker() {
+        let errorModeMarker = self.framesDirectory.appendingPathComponent(kNRMA_SessionReplayErrorMode_marker)
+        try? FileManager.default.removeItem(at: errorModeMarker)
     }
     
     /// Checks if a full snapshot should be forced (every 15 seconds)


### PR DESCRIPTION
The agent use to only upload the persisted frames on crash. Now a force-closed iOS session whose events were captured between two harvests is recoverable on the next app launch with original session attributes (sessionId, timestamps, isFirstChunk, hasMeta, entityGuid, instrumentation identifiers, app version).
I bug was found in implementing this and will be resolved in a separate pr. https://new-relic.atlassian.net/browse/NR-581396