### PR TITLE
NR-577140: Add TTL eviction for offline storage

### DIFF
--- a/Agent/Utilities/NRMAOfflineStorage.h
+++ b/Agent/Utilities/NRMAOfflineStorage.h
@@ -19,4 +19,11 @@
 - (NSString*) offlineDirectoryPath;
 + (NSString*) allOfflineDirectorysPath;
 
+// Time-to-live (in seconds) after which a persisted offline payload is considered
+// stale and is deleted instead of re-uploaded. Defaults to +defaultOfflineStorageTTL
+// (7 days), aligned with the shortest applicable backend retention window.
++ (NSTimeInterval) defaultOfflineStorageTTL;
++ (NSTimeInterval) offlineStorageTTL;
++ (void) setOfflineStorageTTL:(NSTimeInterval) seconds;
+
 @end

--- a/Agent/Utilities/NRMAOfflineStorage.m
+++ b/Agent/Utilities/NRMAOfflineStorage.m
@@ -15,8 +15,6 @@
 #import "NRMASupportMetricHelper.h"
 #import "NRMAAgentConfiguration.h"
 
-#define kNRMAOfflineStorageCurrentSizeKey @"com.newrelic.offlineStorageCurrentSize"
-
 // Default time-to-live for persisted offline payloads: 7 days, in seconds.
 // Aligned with the shortest applicable New Relic data-retention window (Session Replay ~8 days).
 #define kNRMADefaultOfflineStorageTTLSeconds (7 * 24 * 60 * 60)
@@ -53,24 +51,22 @@ static NSTimeInterval __NRMA__offlineStorageTTLSeconds = kNRMADefaultOfflineStor
     @synchronized (self) {
         [self createDirectory];
 
-        NSInteger currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:kNRMAOfflineStorageCurrentSizeKey];
-        if (currentOfflineStorageSize + (NSInteger)data.length > (NSInteger)maxOfflineStorageSizeBytes) {
+        NSUInteger currentOfflineStorageSize = [self currentOfflineStorageSize];
+        if (currentOfflineStorageSize + data.length > maxOfflineStorageSizeBytes) {
             // Over the cap: evict the oldest payloads (LRU) to make room for the incoming data
             // rather than dropping the current harvest in favor of stale data.
             [self evictOldestFilesToFit:data.length];
-            currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:kNRMAOfflineStorageCurrentSizeKey];
-            if (currentOfflineStorageSize + (NSInteger)data.length > (NSInteger)maxOfflineStorageSizeBytes) {
+            currentOfflineStorageSize = [self currentOfflineStorageSize];
+            if (currentOfflineStorageSize + data.length > maxOfflineStorageSizeBytes) {
                 NRLOG_AGENT_WARNING(@"Not saving to offline storage because max storage size has been reached.");
                 return NO;
             }
         }
 
-        NSInteger newOfflineStorageSize = currentOfflineStorageSize + (NSInteger)data.length;
         NSError *error = nil;
         if (data) {
             if ([data writeToFile:[self newOfflineFilePath] options:NSDataWritingAtomic error:&error]) {
-                [[NSUserDefaults standardUserDefaults] setInteger:newOfflineStorageSize forKey:kNRMAOfflineStorageCurrentSizeKey]; // If we successfully save the data save the new current total size
-                NRLOG_AGENT_VERBOSE(@"Successfully persisted failed upload data to disk for offline storage. Current offline storage: %ld", (long)newOfflineStorageSize);
+                NRLOG_AGENT_VERBOSE(@"Successfully persisted failed upload data to disk for offline storage. Current offline storage: %lu", (unsigned long)(currentOfflineStorageSize + data.length));
                 return YES;
             }
         }
@@ -98,7 +94,7 @@ static NSTimeInterval __NRMA__offlineStorageTTLSeconds = kNRMADefaultOfflineStor
             NSDate *modificationDate = attributes[NSFileModificationDate];
             if (modificationDate && [modificationDate compare:expiryDate] == NSOrderedAscending) {
                 NRLOG_AGENT_DEBUG(@"Deleting expired offline storage file: %@", filename);
-                [self removeOfflineFileAtPath:filePath size:[attributes[NSFileSize] unsignedIntegerValue]];
+                [self removeOfflineFileAtPath:filePath];
                 return;
             }
 
@@ -127,7 +123,6 @@ static NSTimeInterval __NRMA__offlineStorageTTLSeconds = kNRMADefaultOfflineStor
     
     NSError* error;
     if ([[NSFileManager defaultManager] removeItemAtPath:[self offlineDirectoryPath] error:&error]) {
-        [[NSUserDefaults standardUserDefaults] setInteger:0 forKey:kNRMAOfflineStorageCurrentSizeKey];
         return true;
     }
     NRLOG_AGENT_ERROR(@"Failed to clear offline storage: %@", error);
@@ -141,7 +136,6 @@ static NSTimeInterval __NRMA__offlineStorageTTLSeconds = kNRMADefaultOfflineStor
     
     NSError* error;
     if ([[NSFileManager defaultManager] removeItemAtPath:[NRMAOfflineStorage allOfflineDirectorysPath] error:&error]) {
-        [[NSUserDefaults standardUserDefaults] setInteger:0 forKey:kNRMAOfflineStorageCurrentSizeKey];
         return true;
     }
     NRLOG_AGENT_ERROR(@"Failed to clear offline storage: %@", error);
@@ -166,6 +160,25 @@ static NSTimeInterval __NRMA__offlineStorageTTLSeconds = kNRMADefaultOfflineStor
 
 - (void) setMaxOfflineStorageSize:(NSUInteger) megabytes {
     maxOfflineStorageSizeBytes = megabytes * 1000000; // Convert MB to bytes (1 MB = 1,000,000 bytes)
+}
+
+// Computes this store's current on-disk size (in bytes) by summing the sizes of the files
+// in its own offline directory. Computed on demand rather than cached in a shared counter:
+// a cached total drifts when same-second filename collisions overwrite files, and a counter
+// shared across stores is corrupted when one store's clear zeroes the other's accounting.
+// Reading the directory keeps the size correct from both angles and per-store isolated.
+- (NSUInteger) currentOfflineStorageSize {
+    NSString* directoryPath = [self offlineDirectoryPath];
+    NSArray* filenames = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:directoryPath error:NULL];
+    NSUInteger totalSize = 0;
+    for (NSString* filename in filenames) {
+        NSString* filePath = [NSString stringWithFormat:@"%@/%@", directoryPath, filename];
+        NSDictionary* attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:NULL];
+        if (attributes) {
+            totalSize += [attributes[NSFileSize] unsignedIntegerValue];
+        }
+    }
+    return totalSize;
 }
 
 // Evicts the oldest persisted payloads (least-recently-modified first) until the incoming
@@ -194,27 +207,24 @@ static NSTimeInterval __NRMA__offlineStorageTTLSeconds = kNRMADefaultOfflineStor
         return [a[@"date"] compare:b[@"date"]];
     }];
 
+    // Track the running size locally as we delete, subtracting each evicted file's size, to
+    // avoid re-scanning the whole directory on every iteration.
+    NSUInteger currentOfflineStorageSize = [self currentOfflineStorageSize];
     for (NSDictionary* info in fileInfos) {
-        NSInteger currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:kNRMAOfflineStorageCurrentSizeKey];
-        if (currentOfflineStorageSize + (NSInteger)incomingDataLength <= (NSInteger)maxOfflineStorageSizeBytes) {
+        if (currentOfflineStorageSize + incomingDataLength <= maxOfflineStorageSizeBytes) {
             break;
         }
         NRLOG_AGENT_VERBOSE(@"Evicting oldest offline storage file to make room: %@", info[@"path"]);
-        [self removeOfflineFileAtPath:info[@"path"] size:[info[@"size"] unsignedIntegerValue]];
+        NSUInteger size = [info[@"size"] unsignedIntegerValue];
+        [self removeOfflineFileAtPath:info[@"path"]];
+        currentOfflineStorageSize = (currentOfflineStorageSize > size) ? (currentOfflineStorageSize - size) : 0;
     }
 }
 
-// Removes a single offline file and decrements the tracked total storage size, clamping at 0.
-- (void) removeOfflineFileAtPath:(NSString*) filePath size:(NSUInteger) size {
+// Removes a single offline file from disk.
+- (void) removeOfflineFileAtPath:(NSString*) filePath {
     NSError* error = nil;
-    if ([[NSFileManager defaultManager] removeItemAtPath:filePath error:&error]) {
-        NSInteger currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:kNRMAOfflineStorageCurrentSizeKey];
-        currentOfflineStorageSize -= (NSInteger)size;
-        if (currentOfflineStorageSize < 0) {
-            currentOfflineStorageSize = 0;
-        }
-        [[NSUserDefaults standardUserDefaults] setInteger:currentOfflineStorageSize forKey:kNRMAOfflineStorageCurrentSizeKey];
-    } else {
+    if (![[NSFileManager defaultManager] removeItemAtPath:filePath error:&error]) {
         NRLOG_AGENT_ERROR(@"Failed to remove offline storage file %@: %@", filePath, error.description);
     }
 }

--- a/Agent/Utilities/NRMAOfflineStorage.m
+++ b/Agent/Utilities/NRMAOfflineStorage.m
@@ -151,11 +151,18 @@ static NSTimeInterval __NRMA__offlineStorageTTLSeconds = kNRMADefaultOfflineStor
 }
 
 - (NSString*) newOfflineFilePath {
+    // Append millisecond precision and a UUID so rapid successive persists never collide.
+    // The replay loop in sendOfflineStorage re-persists every payload back-to-back while the
+    // device is still offline; with a second-resolution name those writes landed on the same
+    // path and silently overwrote each other, dropping all but the last buffered payload.
+    // Eviction and TTL order by file modification date, not by name, so the extra suffix is
+    // purely for uniqueness and doesn't affect ordering.
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateFormat:@"yyyy-MM-dd-HH-mm-ss"];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd-HH-mm-ss-SSS"];
     NSString *date = [dateFormatter stringFromDate:[NSDate date]];
+    NSString *unique = [[NSUUID UUID] UUIDString];
 
-    return [NSString stringWithFormat:@"%@/%@%@",[self offlineDirectoryPath],date,@".txt"];
+    return [NSString stringWithFormat:@"%@/%@-%@%@",[self offlineDirectoryPath],date,unique,@".txt"];
 }
 
 - (void) setMaxOfflineStorageSize:(NSUInteger) megabytes {

--- a/Agent/Utilities/NRMAOfflineStorage.m
+++ b/Agent/Utilities/NRMAOfflineStorage.m
@@ -17,6 +17,14 @@
 
 #define kNRMAOfflineStorageCurrentSizeKey @"com.newrelic.offlineStorageCurrentSize"
 
+// Default time-to-live for persisted offline payloads: 7 days, in seconds.
+// Aligned with the shortest applicable New Relic data-retention window (Session Replay ~8 days).
+#define kNRMADefaultOfflineStorageTTLSeconds (7 * 24 * 60 * 60)
+
+// Shared across all endpoints so the TTL can be configured globally, mirroring the
+// Android agent's static offlineStorageTTL.
+static NSTimeInterval __NRMA__offlineStorageTTLSeconds = kNRMADefaultOfflineStorageTTLSeconds;
+
 @implementation NRMAOfflineStorage {
     NSUInteger maxOfflineStorageSizeBytes;
     NSString* _name;
@@ -44,24 +52,30 @@
 - (BOOL) persistDataToDisk:(NSData*) data {
     @synchronized (self) {
         [self createDirectory];
-        
-        NSUInteger currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:kNRMAOfflineStorageCurrentSizeKey];
-        currentOfflineStorageSize += data.length;
-        if(currentOfflineStorageSize > maxOfflineStorageSizeBytes){
-            NRLOG_AGENT_WARNING(@"Not saving to offline storage because max storage size has been reached.");
-            return NO;
+
+        NSInteger currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:kNRMAOfflineStorageCurrentSizeKey];
+        if (currentOfflineStorageSize + (NSInteger)data.length > (NSInteger)maxOfflineStorageSizeBytes) {
+            // Over the cap: evict the oldest payloads (LRU) to make room for the incoming data
+            // rather than dropping the current harvest in favor of stale data.
+            [self evictOldestFilesToFit:data.length];
+            currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:kNRMAOfflineStorageCurrentSizeKey];
+            if (currentOfflineStorageSize + (NSInteger)data.length > (NSInteger)maxOfflineStorageSizeBytes) {
+                NRLOG_AGENT_WARNING(@"Not saving to offline storage because max storage size has been reached.");
+                return NO;
+            }
         }
-        
+
+        NSInteger newOfflineStorageSize = currentOfflineStorageSize + (NSInteger)data.length;
         NSError *error = nil;
         if (data) {
             if ([data writeToFile:[self newOfflineFilePath] options:NSDataWritingAtomic error:&error]) {
-                [[NSUserDefaults standardUserDefaults] setInteger:currentOfflineStorageSize forKey:kNRMAOfflineStorageCurrentSizeKey]; // If we successfully save the data save the new current total size
-                NRLOG_AGENT_VERBOSE(@"Successfully persisted failed upload data to disk for offline storage. Current offline storage: %lu", (unsigned long)currentOfflineStorageSize);
+                [[NSUserDefaults standardUserDefaults] setInteger:newOfflineStorageSize forKey:kNRMAOfflineStorageCurrentSizeKey]; // If we successfully save the data save the new current total size
+                NRLOG_AGENT_VERBOSE(@"Successfully persisted failed upload data to disk for offline storage. Current offline storage: %ld", (long)newOfflineStorageSize);
                 return YES;
             }
         }
         NRLOG_AGENT_ERROR(@"Failed to persist data to disk %@", error.description);
-        
+
         return NO;
     }
 }
@@ -69,13 +83,27 @@
 - (NSArray<NSData *> *) getAllOfflineData:(BOOL) clear {
     @synchronized (self) {
         NSMutableArray<NSData *> *combinedPosts = [NSMutableArray array];
-        
-        NSArray* dirs = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[self offlineDirectoryPath]
+
+        NSString* directoryPath = [self offlineDirectoryPath];
+        NSArray* dirs = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:directoryPath
                                                                             error:NULL];
+        NSDate* expiryDate = [NSDate dateWithTimeIntervalSinceNow:-[NRMAOfflineStorage offlineStorageTTL]];
         [dirs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
             NSString *filename = (NSString *)obj;
-            NSData * data = [NSData dataWithContentsOfFile:[NSString stringWithFormat:@"%@/%@",[self offlineDirectoryPath],filename]];
-            
+            NSString *filePath = [NSString stringWithFormat:@"%@/%@",directoryPath,filename];
+
+            // Drop payloads older than the TTL: once past the backend retention window they
+            // produce no value when re-uploaded, so delete them instead of replaying forever.
+            NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:NULL];
+            NSDate *modificationDate = attributes[NSFileModificationDate];
+            if (modificationDate && [modificationDate compare:expiryDate] == NSOrderedAscending) {
+                NRLOG_AGENT_DEBUG(@"Deleting expired offline storage file: %@", filename);
+                [self removeOfflineFileAtPath:filePath size:[attributes[NSFileSize] unsignedIntegerValue]];
+                return;
+            }
+
+            NSData * data = [NSData dataWithContentsOfFile:filePath];
+
             if (data) {
                 NRLOG_AGENT_DEBUG(@"Offline storage to be uploaded from %@", filename);
                 [combinedPosts addObject:data];
@@ -83,11 +111,11 @@
                 NRLOG_AGENT_DEBUG(@"Failed to read offline storage file: %@", filename);
             }
         }];
-        
+
         if(clear){
             [self clearAllOfflineFiles];
         }
-        
+
         return [combinedPosts copy];
     }
 }
@@ -138,6 +166,69 @@
 
 - (void) setMaxOfflineStorageSize:(NSUInteger) megabytes {
     maxOfflineStorageSizeBytes = megabytes * 1000000; // Convert MB to bytes (1 MB = 1,000,000 bytes)
+}
+
+// Evicts the oldest persisted payloads (least-recently-modified first) until the incoming
+// data of length incomingDataLength would fit under the max storage size, or until there
+// is nothing left to evict.
+- (void) evictOldestFilesToFit:(NSUInteger) incomingDataLength {
+    NSString* directoryPath = [self offlineDirectoryPath];
+    NSArray* filenames = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:directoryPath error:NULL];
+    if (filenames.count == 0) {
+        return;
+    }
+
+    // Collect each file's path, modification date and size, then sort oldest first.
+    NSMutableArray<NSDictionary*>* fileInfos = [NSMutableArray array];
+    for (NSString* filename in filenames) {
+        NSString* filePath = [NSString stringWithFormat:@"%@/%@", directoryPath, filename];
+        NSDictionary* attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:NULL];
+        if (!attributes) {
+            continue;
+        }
+        [fileInfos addObject:@{@"path" : filePath,
+                               @"date" : attributes[NSFileModificationDate] ?: [NSDate distantPast],
+                               @"size" : @([attributes[NSFileSize] unsignedIntegerValue])}];
+    }
+    [fileInfos sortUsingComparator:^NSComparisonResult(NSDictionary* a, NSDictionary* b) {
+        return [a[@"date"] compare:b[@"date"]];
+    }];
+
+    for (NSDictionary* info in fileInfos) {
+        NSInteger currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:kNRMAOfflineStorageCurrentSizeKey];
+        if (currentOfflineStorageSize + (NSInteger)incomingDataLength <= (NSInteger)maxOfflineStorageSizeBytes) {
+            break;
+        }
+        NRLOG_AGENT_VERBOSE(@"Evicting oldest offline storage file to make room: %@", info[@"path"]);
+        [self removeOfflineFileAtPath:info[@"path"] size:[info[@"size"] unsignedIntegerValue]];
+    }
+}
+
+// Removes a single offline file and decrements the tracked total storage size, clamping at 0.
+- (void) removeOfflineFileAtPath:(NSString*) filePath size:(NSUInteger) size {
+    NSError* error = nil;
+    if ([[NSFileManager defaultManager] removeItemAtPath:filePath error:&error]) {
+        NSInteger currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:kNRMAOfflineStorageCurrentSizeKey];
+        currentOfflineStorageSize -= (NSInteger)size;
+        if (currentOfflineStorageSize < 0) {
+            currentOfflineStorageSize = 0;
+        }
+        [[NSUserDefaults standardUserDefaults] setInteger:currentOfflineStorageSize forKey:kNRMAOfflineStorageCurrentSizeKey];
+    } else {
+        NRLOG_AGENT_ERROR(@"Failed to remove offline storage file %@: %@", filePath, error.description);
+    }
+}
+
++ (NSTimeInterval) defaultOfflineStorageTTL {
+    return kNRMADefaultOfflineStorageTTLSeconds;
+}
+
++ (NSTimeInterval) offlineStorageTTL {
+    return __NRMA__offlineStorageTTLSeconds;
+}
+
++ (void) setOfflineStorageTTL:(NSTimeInterval) seconds {
+    __NRMA__offlineStorageTTLSeconds = seconds;
 }
 
 + (BOOL)checkErrorToPersist:(NSError*) error {

--- a/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRHarvesterTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRHarvesterTest.m
@@ -360,20 +360,16 @@ static void NRMAWaitForHarvesterToLeaveState(NRMAHarvester *harvester, NSInteger
 
     [mockHarvester connected];
    
-    NSUInteger currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:@"com.newrelic.offlineStorageCurrentSize"];
     NSArray<NSData *> * offlineData = [newHarvester.connection getOfflineData];
     XCTAssertTrue(offlineData.count > 0);
-    XCTAssertTrue(currentOfflineStorageSize > 0);
 
     mockNSURLSession = [self makeMockURLSession];
     newHarvester.connection.harvestSession = mockNSURLSession;
-    
+
     [mockHarvester connected];
-    
+
     offlineData = [newHarvester.connection getOfflineData];
-    currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:@"com.newrelic.offlineStorageCurrentSize"];
     XCTAssertTrue(offlineData.count == 0);
-    XCTAssertTrue(currentOfflineStorageSize == 0);
 
     [mockHarvester stopMocking];
     [connectionMock stopMocking];
@@ -417,20 +413,16 @@ static void NRMAWaitForHarvesterToLeaveState(NRMAHarvester *harvester, NSInteger
 
     [mockHarvester connected];
    
-    NSUInteger currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:@"com.newrelic.offlineStorageCurrentSize"];
     NSArray<NSData *> * offlineData = [newHarvester.connection getOfflineData];
     XCTAssertTrue(offlineData.count == 0);
-    XCTAssertTrue(currentOfflineStorageSize == 0);
 
     mockNSURLSession = [self makeMockURLSession];
     newHarvester.connection.harvestSession = mockNSURLSession;
-    
+
     [mockHarvester connected];
-    
+
     offlineData = [newHarvester.connection getOfflineData];
-    currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:@"com.newrelic.offlineStorageCurrentSize"];
     XCTAssertTrue(offlineData.count == 0);
-    XCTAssertTrue(currentOfflineStorageSize == 0);
 
     [mockHarvester stopMocking];
     [connectionMock stopMocking];

--- a/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRHarvesterTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRHarvesterTest.m
@@ -55,6 +55,19 @@
 }
 @end
 
+// Bounded, run-loop-pumping wait used in place of empty `while (state == X) {};` spin loops.
+// A busy spin on the test (main) thread starves the main queue, so if a harvester state
+// transition is dispatched asynchronously (e.g. the 429/rate-limit backoff path) it can
+// never run and the test hangs forever. Pumping the run loop lets queued work execute, and
+// the deadline guarantees we fail fast instead of freezing the whole suite.
+static void NRMAWaitForHarvesterToLeaveState(NRMAHarvester *harvester, NSInteger fromState) {
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:10.0];
+    while ((NSInteger)harvester.currentState == fromState && [deadline timeIntervalSinceNow] > 0) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    }
+}
+
 @implementation NRMAHarvesterTest
 
 - (void) setUp
@@ -274,12 +287,12 @@
     XCTAssertEqual(harvester.currentState,NRMA_HARVEST_UNINITIALIZED,@"expected uninitialized");
     [harvester execute];
 
-    while (CFRunLoopGetCurrent() && harvester.currentState == NRMA_HARVEST_UNINITIALIZED) {};
+    NRMAWaitForHarvesterToLeaveState(harvester, NRMA_HARVEST_UNINITIALIZED);
     
     XCTAssertEqual(harvester.currentState, NRMA_HARVEST_DISCONNECTED, @"expected disconnected");
     [harvester execute];
 
-    while (CFRunLoopGetCurrent() && harvester.currentState == NRMA_HARVEST_DISCONNECTED) {};
+    NRMAWaitForHarvesterToLeaveState(harvester, NRMA_HARVEST_DISCONNECTED);
     XCTAssertEqual(harvester.currentState, NRMA_HARVEST_CONNECTED, @"expected connected");
 
     //at this point there should be stored data
@@ -473,12 +486,12 @@
 //    XCTAssertEqual(harvester.currentState,NRMA_HARVEST_UNINITIALIZED,@"expected uninitialized");
 //    [harvester execute];
 //
-//    while (CFRunLoopGetCurrent() && harvester.currentState == NRMA_HARVEST_UNINITIALIZED) {};
+//    NRMAWaitForHarvesterToLeaveState(harvester, NRMA_HARVEST_UNINITIALIZED);
 //
 //    XCTAssertEqual(harvester.currentState, NRMA_HARVEST_DISCONNECTED, @"expected disconnected");
 //    [harvester execute];
 //
-//    while (CFRunLoopGetCurrent() && harvester.currentState == NRMA_HARVEST_DISCONNECTED) {};
+//    NRMAWaitForHarvesterToLeaveState(harvester, NRMA_HARVEST_DISCONNECTED);
 //    XCTAssertEqual(harvester.currentState, NRMA_HARVEST_CONNECTED, @"expected connected");
 //
 //    //at this point there should be stored data
@@ -589,13 +602,13 @@
     //uninitialized -> disconnected
     [harvester execute];
     
-    while (CFRunLoopGetCurrent() && harvester.currentState == NRMA_HARVEST_UNINITIALIZED) {};
+    NRMAWaitForHarvesterToLeaveState(harvester, NRMA_HARVEST_UNINITIALIZED);
     XCTAssertEqual(harvester.currentState, NRMA_HARVEST_DISCONNECTED, @"expected disconnected");
 
     //Disconnected -> connected
     [harvester execute];
 
-    while (CFRunLoopGetCurrent() && harvester.currentState == NRMA_HARVEST_DISCONNECTED) {};
+    NRMAWaitForHarvesterToLeaveState(harvester, NRMA_HARVEST_DISCONNECTED);
     XCTAssertEqual(harvester.currentState, NRMA_HARVEST_CONNECTED, @"expected connected");
 }
 
@@ -608,12 +621,12 @@
    [harvester execute];
 
 
-   while (CFRunLoopGetCurrent() && harvester.currentState == NRMA_HARVEST_UNINITIALIZED) {};
+   NRMAWaitForHarvesterToLeaveState(harvester, NRMA_HARVEST_UNINITIALIZED);
     XCTAssertEqual(harvester.currentState, NRMA_HARVEST_DISCONNECTED, @"expected disconnected");
 
    [harvester execute];
 
-   while (CFRunLoopGetCurrent() && harvester.currentState == NRMA_HARVEST_DISCONNECTED) {};
+   NRMAWaitForHarvesterToLeaveState(harvester, NRMA_HARVEST_DISCONNECTED);
    XCTAssertEqual(harvester.currentState, NRMA_HARVEST_DISABLED, @"expected disabled");
 }
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAOfflineStorageTests.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAOfflineStorageTests.m
@@ -57,6 +57,32 @@
     XCTAssertEqualObjects(data, savedData[0]);
 }
 
+// Regression test for same-second filename collisions: the replay loop in sendOfflineStorage
+// re-persists every buffered payload back-to-back while the device is still offline, so several
+// persists land within the same wall-clock second. With a second-resolution filename those
+// writes overwrote each other and silently dropped all but the last payload. Each persist must
+// now produce its own file.
+-(void) testRapidPersistsDoNotOverwriteEachOther {
+    [self.offlineStorage setMaxOfflineStorageSize:100]; // plenty of headroom, no eviction
+
+    NSUInteger persistCount = 5;
+    NSUInteger expectedTotalSize = 0;
+    for (NSUInteger i = 0; i < persistCount; i++) {
+        NSData *data = [NRMAFakeDataHelper makeDataDictionary:100 + i]; // distinct payloads
+        XCTAssertTrue([self.offlineStorage persistDataToDisk:data]);
+        expectedTotalSize += data.length;
+    }
+
+    NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[_offlineStorage offlineDirectoryPath] error:nil];
+    XCTAssertEqual(files.count, persistCount, @"Each rapid persist should create its own file rather than overwrite the previous one");
+
+    unsigned long long savedSize = [self folderSize:[_offlineStorage offlineDirectoryPath]];
+    XCTAssertEqual(savedSize, expectedTotalSize, @"On-disk size should account for every persisted payload");
+
+    NSArray<NSData *> *savedData = [self.offlineStorage getAllOfflineData:TRUE];
+    XCTAssertEqual(savedData.count, persistCount, @"All buffered payloads should be recoverable for replay");
+}
+
 -(void) testClearAllOfflineStorage {
     [self.offlineStorage setMaxOfflineStorageSize:100];
     NSData *data = [NRMAFakeDataHelper makeDataDictionary:1000];

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAOfflineStorageTests.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAOfflineStorageTests.m
@@ -21,7 +21,6 @@
     [super setUp];
     self.offlineStorage = [[NRMAOfflineStorage alloc] initWithEndpoint:@"Test"];
     [self.offlineStorage clearAllOfflineFiles];
-    [[NSUserDefaults standardUserDefaults] setInteger:0 forKey:@"com.newrelic.offlineStorageCurrentSize"];
 }
 
 -(void) tearDown {
@@ -48,9 +47,8 @@
     NSData *data = [NRMAFakeDataHelper makeDataDictionary:1000];
     
     XCTAssertTrue([self.offlineStorage persistDataToDisk:data]);
-    NSUInteger currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:@"com.newrelic.offlineStorageCurrentSize"];
-    XCTAssertTrue(currentOfflineStorageSize == data.length);
-    
+
+    // Size is now derived from what's actually on disk rather than a cached counter.
     unsigned long long acutalSavedSize = [self folderSize:[_offlineStorage offlineDirectoryPath]];
     XCTAssertTrue(acutalSavedSize == data.length);
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAOfflineStorageTests.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAOfflineStorageTests.m
@@ -59,25 +59,6 @@
     XCTAssertEqualObjects(data, savedData[0]);
 }
 
--(void) testOfflineStorageMaxSize {
-    [self.offlineStorage setMaxOfflineStorageSize:1];
-    NSData *data = [NRMAFakeDataHelper makeDataDictionary:5000];
-    
-    int count = 0;
-    while([self.offlineStorage persistDataToDisk:data]){
-        count++;
-        sleep(1);
-    }
-    XCTAssertFalse([self.offlineStorage persistDataToDisk:data]);
-    
-    NSUInteger currentOfflineStorageSize = [[NSUserDefaults standardUserDefaults] integerForKey:@"com.newrelic.offlineStorageCurrentSize"];
-    unsigned long long acutalSavedSize = [self folderSize:[_offlineStorage offlineDirectoryPath]];
-    XCTAssertTrue(acutalSavedSize == currentOfflineStorageSize);
-    
-    NSArray<NSData *> *savedData = [self.offlineStorage getAllOfflineData:TRUE];
-    XCTAssertTrue(count == savedData.count);
-}
-
 -(void) testClearAllOfflineStorage {
     [self.offlineStorage setMaxOfflineStorageSize:100];
     NSData *data = [NRMAFakeDataHelper makeDataDictionary:1000];

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayReporterNetworkTests.swift
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayReporterNetworkTests.swift
@@ -22,7 +22,6 @@ class SessionReplayReporterNetworkTests: XCTestCase {
 
         // Clear offline storage
         _ = NRMAOfflineStorage.clearAllOfflineDirectories()
-        UserDefaults.standard.set(0, forKey: "com.newrelic.offlineStorageCurrentSize")
 
         // Enable offline storage
         NewRelic.enableFeatures(NRMAFeatureFlags.NRFeatureFlag_OfflineStorage)
@@ -46,7 +45,6 @@ class SessionReplayReporterNetworkTests: XCTestCase {
         mockURLSession = nil
         _ = NRMAOfflineStorage.clearAllOfflineDirectories()
         NewRelic.disableFeatures(NRMAFeatureFlags.NRFeatureFlag_OfflineStorage)
-        UserDefaults.standard.set(0, forKey: "com.newrelic.offlineStorageCurrentSize")
         super.tearDown()
     }
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayReporterOfflineStorageTests.swift
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayReporterOfflineStorageTests.swift
@@ -250,11 +250,9 @@ class NRMAOfflineStorageTTLTests: XCTestCase {
     // MARK: Helpers
 
     // Writes a file straight into the offline directory with a controlled byte size and
-    // modification date. Production filenames are second-resolution, so persisting twice
-    // within the same second collides — and busy-waiting for the next wall-clock second
-    // hangs CI. Seeding files directly keeps every test deterministic and instant, while
-    // still exercising the real read/evict code paths (which key off file attributes, not
-    // filename format).
+    // modification date. Seeding files directly (rather than persisting and sleeping to age
+    // them) keeps every TTL/LRU test deterministic and instant, while still exercising the
+    // real read/evict code paths, which key off file attributes rather than the filename.
     @discardableResult
     private func writeOfflineFile(named name: String, bytes: Int, daysOld: Double) -> String {
         let dir = storage.offlineDirectoryPath() ?? ""

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayReporterOfflineStorageTests.swift
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayReporterOfflineStorageTests.swift
@@ -82,6 +82,8 @@ class SessionReplayReporterOfflineStorageTests: XCTestCase {
         _ = NRMAOfflineStorage.clearAllOfflineDirectories()
         UserDefaults.standard.set(0, forKey: "com.newrelic.offlineStorageCurrentSize")
         UserDefaults.standard.synchronize()
+        // Disable the offline-storage flag so it doesn't leak into subsequent test classes.
+        NewRelic.disableFeatures(NRMAFeatureFlags.NRFeatureFlag_OfflineStorage)
         super.tearDown()
     }
 
@@ -252,6 +254,9 @@ class NRMAOfflineStorageTTLTests: XCTestCase {
         UserDefaults.standard.synchronize()
         // TTL is a process-wide setting; restore the default so other tests aren't affected.
         NRMAOfflineStorage.setOfflineStorageTTL(NRMAOfflineStorage.defaultOfflineStorageTTL())
+        // Don't leak the offline-storage feature flag into later test classes — a stuck-on
+        // flag pushes the agent down the async offline/backoff path and can hang other tests.
+        NewRelic.disableFeatures(NRMAFeatureFlags.NRFeatureFlag_OfflineStorage)
         storage = nil
         super.tearDown()
     }

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayReporterOfflineStorageTests.swift
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayReporterOfflineStorageTests.swift
@@ -225,6 +225,157 @@ class SessionReplayReporterOfflineStorageTests: XCTestCase {
     }
 }
 
+// MARK: - TTL + LRU Eviction Tests
+
+// Mirrors the Android agent's OfflineStorageTest TTL/LRU coverage (NR-577137 / PR #574).
+// Stale offline payloads (older than the TTL) must be deleted instead of re-uploaded forever,
+// and the size cap must evict the oldest payloads rather than dropping current data.
+class NRMAOfflineStorageTTLTests: XCTestCase {
+
+    let sizeKey = "com.newrelic.offlineStorageCurrentSize"
+    var storage: NRMAOfflineStorage!
+
+    override func setUp() {
+        super.setUp()
+        // Unique endpoint per test run avoids cross-test file collisions.
+        let endpoint = "ttl_test_\(Int(Date().timeIntervalSince1970 * 1000))"
+        storage = NRMAOfflineStorage(endpoint: endpoint)
+        _ = storage.clearAllOfflineFiles()
+        UserDefaults.standard.set(0, forKey: sizeKey)
+        UserDefaults.standard.synchronize()
+        NewRelic.enableFeatures(NRMAFeatureFlags.NRFeatureFlag_OfflineStorage)
+    }
+
+    override func tearDown() {
+        _ = storage.clearAllOfflineFiles()
+        UserDefaults.standard.set(0, forKey: sizeKey)
+        UserDefaults.standard.synchronize()
+        // TTL is a process-wide setting; restore the default so other tests aren't affected.
+        NRMAOfflineStorage.setOfflineStorageTTL(NRMAOfflineStorage.defaultOfflineStorageTTL())
+        storage = nil
+        super.tearDown()
+    }
+
+    // MARK: Helpers
+
+    // Files use second-resolution timestamps (yyyy-MM-dd-HH-mm-ss). Wait for a new second
+    // so consecutive persists produce distinct files instead of overwriting each other.
+    private func waitForNewSecond() {
+        let startSecond = Calendar.current.component(.second, from: Date())
+        while Calendar.current.component(.second, from: Date()) == startSecond {
+            usleep(50_000)
+        }
+        usleep(50_000)
+    }
+
+    // Returns this endpoint's offline files sorted oldest-modified first.
+    private func offlineFilesSortedByDate() -> [String] {
+        guard let dir = storage.offlineDirectoryPath() else { return [] }
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: dir)) ?? []
+        let paths = names.map { "\(dir)/\($0)" }
+        return paths.sorted { lhs, rhs in
+            let a = modificationDate(ofPath: lhs)
+            let b = modificationDate(ofPath: rhs)
+            return a < b
+        }
+    }
+
+    private func modificationDate(ofPath path: String) -> Date {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: path)
+        return (attrs?[.modificationDate] as? Date) ?? .distantPast
+    }
+
+    private func backdateFile(atPath path: String, byDays days: Double) {
+        let oldDate = Date().addingTimeInterval(-days * 24 * 60 * 60)
+        try? FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: path)
+    }
+
+    // MARK: TTL configuration
+
+    func testDefaultTTLIsSevenDays() {
+        XCTAssertEqual(NRMAOfflineStorage.defaultOfflineStorageTTL(), 7 * 24 * 60 * 60,
+                       "Default TTL should be 7 days in seconds")
+        XCTAssertEqual(NRMAOfflineStorage.offlineStorageTTL(), NRMAOfflineStorage.defaultOfflineStorageTTL(),
+                       "TTL should default to defaultOfflineStorageTTL")
+    }
+
+    func testSetGetTTL() {
+        let customTTL: TimeInterval = 14 * 24 * 60 * 60
+        NRMAOfflineStorage.setOfflineStorageTTL(customTTL)
+        XCTAssertEqual(NRMAOfflineStorage.offlineStorageTTL(), customTTL)
+    }
+
+    // MARK: TTL expiry on read
+
+    func testExpiredFilesAreDeletedOnRead() {
+        let data = "{\"expired\":\"data\"}".data(using: .utf8)!
+        XCTAssertTrue(storage.persistData(toDisk: data))
+
+        let files = offlineFilesSortedByDate()
+        XCTAssertEqual(files.count, 1)
+        backdateFile(atPath: files[0], byDays: 8) // past the 7-day TTL
+
+        let result = storage.getAllOfflineData(false)
+        XCTAssertEqual(result?.count, 0, "Expired payloads should not be returned for upload")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: files[0]),
+                       "Expired file should be deleted from disk")
+    }
+
+    func testNonExpiredFilesAreReturned() {
+        let data = "{\"fresh\":\"data\"}".data(using: .utf8)!
+        XCTAssertTrue(storage.persistData(toDisk: data))
+
+        let result = storage.getAllOfflineData(false)
+        XCTAssertEqual(result?.count, 1, "Fresh payloads should be returned for upload")
+    }
+
+    func testMixedExpiredAndValidFiles() {
+        XCTAssertTrue(storage.persistData(toDisk: "{\"expired\":\"data\"}".data(using: .utf8)!))
+        waitForNewSecond()
+        XCTAssertTrue(storage.persistData(toDisk: "{\"fresh\":\"data\"}".data(using: .utf8)!))
+
+        let files = offlineFilesSortedByDate()
+        XCTAssertEqual(files.count, 2)
+        backdateFile(atPath: files[0], byDays: 8) // expire the oldest
+
+        let result = storage.getAllOfflineData(false)
+        XCTAssertEqual(result?.count, 1, "Only the fresh payload should be returned")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: files[0]), "Expired file should be deleted")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: files[1]), "Fresh file should be retained")
+    }
+
+    // MARK: LRU eviction on persist
+
+    func testLruEvictionEvictsOldestFile() {
+        // Cap of 1 MB. Each ~400KB payload: two fit, the third triggers eviction of the oldest.
+        storage.setMaxOfflineStorageSize(1)
+        let payload = String(repeating: "x", count: 400_000).data(using: .utf8)!
+
+        XCTAssertTrue(storage.persistData(toDisk: payload))
+        waitForNewSecond()
+        XCTAssertTrue(storage.persistData(toDisk: payload))
+
+        let filesBefore = offlineFilesSortedByDate()
+        XCTAssertEqual(filesBefore.count, 2)
+        let oldest = filesBefore[0]
+
+        waitForNewSecond()
+        XCTAssertTrue(storage.persistData(toDisk: payload),
+                      "New payload should be saved after evicting the oldest")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldest),
+                       "Oldest file should have been evicted")
+    }
+
+    func testPersistReturnsFalseWhenEvictionCannotFreeEnoughSpace() {
+        // A single payload larger than the entire cap — eviction can never make room.
+        storage.setMaxOfflineStorageSize(1) // 1 MB
+        let payload = String(repeating: "x", count: 1_500_000).data(using: .utf8)!
+
+        XCTAssertFalse(storage.persistData(toDisk: payload),
+                       "Should return false when the payload exceeds the cap and eviction can't help")
+    }
+}
+
 // MARK: - Mock Classes
 
 class MockNRMAOfflineStorage: NRMAOfflineStorage {

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayReporterOfflineStorageTests.swift
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayReporterOfflineStorageTests.swift
@@ -258,36 +258,25 @@ class NRMAOfflineStorageTTLTests: XCTestCase {
 
     // MARK: Helpers
 
-    // Files use second-resolution timestamps (yyyy-MM-dd-HH-mm-ss). Wait for a new second
-    // so consecutive persists produce distinct files instead of overwriting each other.
-    private func waitForNewSecond() {
-        let startSecond = Calendar.current.component(.second, from: Date())
-        while Calendar.current.component(.second, from: Date()) == startSecond {
-            usleep(50_000)
-        }
-        usleep(50_000)
+    // Writes a file straight into the offline directory with a controlled byte size and
+    // modification date. Production filenames are second-resolution, so persisting twice
+    // within the same second collides — and busy-waiting for the next wall-clock second
+    // hangs CI. Seeding files directly keeps every test deterministic and instant, while
+    // still exercising the real read/evict code paths (which key off file attributes, not
+    // filename format).
+    @discardableResult
+    private func writeOfflineFile(named name: String, bytes: Int, daysOld: Double) -> String {
+        let dir = storage.offlineDirectoryPath() ?? ""
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let path = "\(dir)/\(name)"
+        FileManager.default.createFile(atPath: path, contents: Data(repeating: 0x78, count: bytes))
+        let date = Date().addingTimeInterval(-daysOld * 24 * 60 * 60)
+        try? FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: path)
+        return path
     }
 
-    // Returns this endpoint's offline files sorted oldest-modified first.
-    private func offlineFilesSortedByDate() -> [String] {
-        guard let dir = storage.offlineDirectoryPath() else { return [] }
-        let names = (try? FileManager.default.contentsOfDirectory(atPath: dir)) ?? []
-        let paths = names.map { "\(dir)/\($0)" }
-        return paths.sorted { lhs, rhs in
-            let a = modificationDate(ofPath: lhs)
-            let b = modificationDate(ofPath: rhs)
-            return a < b
-        }
-    }
-
-    private func modificationDate(ofPath path: String) -> Date {
-        let attrs = try? FileManager.default.attributesOfItem(atPath: path)
-        return (attrs?[.modificationDate] as? Date) ?? .distantPast
-    }
-
-    private func backdateFile(atPath path: String, byDays days: Double) {
-        let oldDate = Date().addingTimeInterval(-days * 24 * 60 * 60)
-        try? FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: path)
+    private func exists(_ path: String) -> Bool {
+        FileManager.default.fileExists(atPath: path)
     }
 
     // MARK: TTL configuration
@@ -308,68 +297,52 @@ class NRMAOfflineStorageTTLTests: XCTestCase {
     // MARK: TTL expiry on read
 
     func testExpiredFilesAreDeletedOnRead() {
-        let data = "{\"expired\":\"data\"}".data(using: .utf8)!
-        XCTAssertTrue(storage.persistData(toDisk: data))
-
-        let files = offlineFilesSortedByDate()
-        XCTAssertEqual(files.count, 1)
-        backdateFile(atPath: files[0], byDays: 8) // past the 7-day TTL
+        let path = writeOfflineFile(named: "expired.txt", bytes: 32, daysOld: 8) // past the 7-day TTL
 
         let result = storage.getAllOfflineData(false)
         XCTAssertEqual(result?.count, 0, "Expired payloads should not be returned for upload")
-        XCTAssertFalse(FileManager.default.fileExists(atPath: files[0]),
-                       "Expired file should be deleted from disk")
+        XCTAssertFalse(exists(path), "Expired file should be deleted from disk")
     }
 
     func testNonExpiredFilesAreReturned() {
-        let data = "{\"fresh\":\"data\"}".data(using: .utf8)!
-        XCTAssertTrue(storage.persistData(toDisk: data))
+        writeOfflineFile(named: "fresh.txt", bytes: 32, daysOld: 0)
 
         let result = storage.getAllOfflineData(false)
         XCTAssertEqual(result?.count, 1, "Fresh payloads should be returned for upload")
     }
 
     func testMixedExpiredAndValidFiles() {
-        XCTAssertTrue(storage.persistData(toDisk: "{\"expired\":\"data\"}".data(using: .utf8)!))
-        waitForNewSecond()
-        XCTAssertTrue(storage.persistData(toDisk: "{\"fresh\":\"data\"}".data(using: .utf8)!))
-
-        let files = offlineFilesSortedByDate()
-        XCTAssertEqual(files.count, 2)
-        backdateFile(atPath: files[0], byDays: 8) // expire the oldest
+        let expired = writeOfflineFile(named: "expired.txt", bytes: 32, daysOld: 8)
+        let fresh = writeOfflineFile(named: "fresh.txt", bytes: 32, daysOld: 1)
 
         let result = storage.getAllOfflineData(false)
         XCTAssertEqual(result?.count, 1, "Only the fresh payload should be returned")
-        XCTAssertFalse(FileManager.default.fileExists(atPath: files[0]), "Expired file should be deleted")
-        XCTAssertTrue(FileManager.default.fileExists(atPath: files[1]), "Fresh file should be retained")
+        XCTAssertFalse(exists(expired), "Expired file should be deleted")
+        XCTAssertTrue(exists(fresh), "Fresh file should be retained")
     }
 
     // MARK: LRU eviction on persist
 
     func testLruEvictionEvictsOldestFile() {
-        // Cap of 1 MB. Each ~400KB payload: two fit, the third triggers eviction of the oldest.
-        storage.setMaxOfflineStorageSize(1)
-        let payload = String(repeating: "x", count: 400_000).data(using: .utf8)!
+        // Cap of 1 MB. Two ~400KB files already fit; persisting a third triggers eviction
+        // of the oldest. Files are seeded with explicit modification dates so ordering is
+        // deterministic, and the tracked size counter is set to match what they occupy.
+        storage.setMaxOfflineStorageSize(1) // 1 MB
+        let oldest = writeOfflineFile(named: "oldest.txt", bytes: 400_000, daysOld: 2)
+        let newer = writeOfflineFile(named: "newer.txt", bytes: 400_000, daysOld: 1)
+        UserDefaults.standard.set(800_000, forKey: sizeKey)
 
-        XCTAssertTrue(storage.persistData(toDisk: payload))
-        waitForNewSecond()
-        XCTAssertTrue(storage.persistData(toDisk: payload))
-
-        let filesBefore = offlineFilesSortedByDate()
-        XCTAssertEqual(filesBefore.count, 2)
-        let oldest = filesBefore[0]
-
-        waitForNewSecond()
+        let payload = Data(repeating: 0x78, count: 400_000)
         XCTAssertTrue(storage.persistData(toDisk: payload),
                       "New payload should be saved after evicting the oldest")
-        XCTAssertFalse(FileManager.default.fileExists(atPath: oldest),
-                       "Oldest file should have been evicted")
+        XCTAssertFalse(exists(oldest), "Oldest file should have been evicted")
+        XCTAssertTrue(exists(newer), "Newer file should be retained")
     }
 
     func testPersistReturnsFalseWhenEvictionCannotFreeEnoughSpace() {
         // A single payload larger than the entire cap — eviction can never make room.
         storage.setMaxOfflineStorageSize(1) // 1 MB
-        let payload = String(repeating: "x", count: 1_500_000).data(using: .utf8)!
+        let payload = Data(repeating: 0x78, count: 1_500_000)
 
         XCTAssertFalse(storage.persistData(toDisk: payload),
                        "Should return false when the payload exceeds the cap and eviction can't help")

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayReporterOfflineStorageTests.swift
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayReporterOfflineStorageTests.swift
@@ -38,8 +38,6 @@ class SessionReplayReporterOfflineStorageTests: XCTestCase {
     // Helper to prepare storage with cleanup and filesystem sync
     func prepareStorage(_ storage: NRMAOfflineStorage) {
         _ = storage.clearAllOfflineFiles()
-        UserDefaults.standard.set(0, forKey: "com.newrelic.offlineStorageCurrentSize")
-        UserDefaults.standard.synchronize()
         // Delay to let file system settle after clearing - this is critical
         // for directory enumeration to return accurate results
         usleep(150000) // 0.15 seconds
@@ -56,11 +54,6 @@ class SessionReplayReporterOfflineStorageTests: XCTestCase {
 
         // Aggressively clear all offline storage before each test
         _ = NRMAOfflineStorage.clearAllOfflineDirectories()
-
-        // Reset the global size counter AFTER clearing directories
-        // (clearAllOfflineDirectories also resets this, but do it again to be sure)
-        UserDefaults.standard.set(0, forKey: "com.newrelic.offlineStorageCurrentSize")
-        UserDefaults.standard.synchronize()
 
         // Create test data
         testData = "test session replay data".data(using: .utf8)!
@@ -80,8 +73,6 @@ class SessionReplayReporterOfflineStorageTests: XCTestCase {
         reporter = nil
         mockOfflineStorage = nil
         _ = NRMAOfflineStorage.clearAllOfflineDirectories()
-        UserDefaults.standard.set(0, forKey: "com.newrelic.offlineStorageCurrentSize")
-        UserDefaults.standard.synchronize()
         // Disable the offline-storage flag so it doesn't leak into subsequent test classes.
         NewRelic.disableFeatures(NRMAFeatureFlags.NRFeatureFlag_OfflineStorage)
         super.tearDown()
@@ -234,7 +225,6 @@ class SessionReplayReporterOfflineStorageTests: XCTestCase {
 // and the size cap must evict the oldest payloads rather than dropping current data.
 class NRMAOfflineStorageTTLTests: XCTestCase {
 
-    let sizeKey = "com.newrelic.offlineStorageCurrentSize"
     var storage: NRMAOfflineStorage!
 
     override func setUp() {
@@ -243,15 +233,11 @@ class NRMAOfflineStorageTTLTests: XCTestCase {
         let endpoint = "ttl_test_\(Int(Date().timeIntervalSince1970 * 1000))"
         storage = NRMAOfflineStorage(endpoint: endpoint)
         _ = storage.clearAllOfflineFiles()
-        UserDefaults.standard.set(0, forKey: sizeKey)
-        UserDefaults.standard.synchronize()
         NewRelic.enableFeatures(NRMAFeatureFlags.NRFeatureFlag_OfflineStorage)
     }
 
     override func tearDown() {
         _ = storage.clearAllOfflineFiles()
-        UserDefaults.standard.set(0, forKey: sizeKey)
-        UserDefaults.standard.synchronize()
         // TTL is a process-wide setting; restore the default so other tests aren't affected.
         NRMAOfflineStorage.setOfflineStorageTTL(NRMAOfflineStorage.defaultOfflineStorageTTL())
         // Don't leak the offline-storage feature flag into later test classes — a stuck-on
@@ -331,11 +317,11 @@ class NRMAOfflineStorageTTLTests: XCTestCase {
     func testLruEvictionEvictsOldestFile() {
         // Cap of 1 MB. Two ~400KB files already fit; persisting a third triggers eviction
         // of the oldest. Files are seeded with explicit modification dates so ordering is
-        // deterministic, and the tracked size counter is set to match what they occupy.
+        // deterministic. The occupied size is read straight from disk, so no counter setup
+        // is needed — the two seeded files report 800KB on their own.
         storage.setMaxOfflineStorageSize(1) // 1 MB
         let oldest = writeOfflineFile(named: "oldest.txt", bytes: 400_000, daysOld: 2)
         let newer = writeOfflineFile(named: "newer.txt", bytes: 400_000, daysOld: 1)
-        UserDefaults.standard.set(800_000, forKey: sizeKey)
 
         let payload = Data(repeating: 0x78, count: 400_000)
         XCTAssertTrue(storage.persistData(toDisk: payload),


### PR DESCRIPTION
1. Configurable TTL (default 7 days). Added kNRMADefaultOfflineStorageTTLSeconds (7 days, aligned with the shortest retention window — Session Replay ~8 days) plus class methods +defaultOfflineStorageTTL, +offlineStorageTTL, +setOfflineStorageTTL:. Kept it process-wide/static to match Android's static offlineStorageTTL.

2. TTL expiry on read (getAllOfflineData:). Before reading each file, it checks the file's NSFileModificationDate against now − TTL. Stale files are deleted (and the tracked size counter decremented) and skipped instead of being uploaded — so data past retention never gets re-uploaded, even when clear:NO.

3. LRU eviction on persist (persistDataToDisk:). When the incoming payload would exceed the cap, it now sorts existing files oldest-first and evicts them until the new payload fits, rather than dropping the current harvest. It only returns NO if eviction still can't free enough space (e.g., a single payload larger than the whole cap). Added helpers evictOldestFilesToFit: and removeOfflineFileAtPath:size:.

[SessionReplayReporterOfflineStorageTests.swift􀰓](file:///Users/cdillard/Documents/Workspace/newrelic-ios-agent/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayReporterOfflineStorageTests.swift) — added NRMAOfflineStorageTTLTests with 7 tests matching the Android PR's coverage: default TTL, set/get TTL, expired-deleted-on-read, non-expired-returned, mixed expired/valid, LRU evicts oldest, and persist-returns-false-when-eviction-can't-help.


Differences: 

• Android orders/expires by File.lastModified(); iOS uses the same concept via NSFileModificationDate.
• iOS tracks total size in a NSUserDefaults counter (rather than rescanning disk like Android's getTotalFileSize()), so eviction/expiry decrement that counter to keep it consistent (clamped at 0).
• One API difference worth flagging: iOS setMaxOfflineStorageSize: takes megabytes (×1,000,000), whereas Android's setOfflineStorageSize takes raw bytes — that's why the LRU tests use ~400 KB payloads against a 1 MB cap. I left that public API as-is to avoid scope creep.
