### PR TITLE
NR-581396: Handled exceptions stay saved until successfully uploaded

### DIFF
--- a/Agent/Analytics/PersistentEventStore.m
+++ b/Agent/Analytics/PersistentEventStore.m
@@ -92,9 +92,11 @@
                 NRLOG_AGENT_DEBUG(@"Not writing file because it's not dirty");
                 return;
             }
+            // Reset before writing so any _dirty=YES set concurrently by another
+            // thread (e.g. removeObjectForKey:) is preserved for the next write.
+            self->_dirty = NO;
         }
         [self saveToFile];
-        self->_dirty = NO;
     }];
 }
 
@@ -112,9 +114,9 @@
                 NRLOG_AGENT_DEBUG(@"Not writing removed item file because it's not dirty");
                 return;
             }
+            self->_dirty = NO;
         }
         [self saveToFile];
-        self->_dirty = NO;
     });
 }
 
@@ -136,9 +138,9 @@
               //  NRLOG_AGENT_DEBUG(@"Not writing cleared file because it's not dirty");
                 return;
             }
+            self->_dirty = NO;
         }
         [self saveToFile];
-        self->_dirty = NO;
     });
 }
 

--- a/Agent/Analytics/PersistentEventStore.m
+++ b/Agent/Analytics/PersistentEventStore.m
@@ -92,11 +92,9 @@
                 NRLOG_AGENT_DEBUG(@"Not writing file because it's not dirty");
                 return;
             }
-            // Reset before writing so any _dirty=YES set concurrently by another
-            // thread (e.g. removeObjectForKey:) is preserved for the next write.
-            self->_dirty = NO;
         }
         [self saveToFile];
+        self->_dirty = NO;
     }];
 }
 
@@ -114,9 +112,9 @@
                 NRLOG_AGENT_DEBUG(@"Not writing removed item file because it's not dirty");
                 return;
             }
-            self->_dirty = NO;
         }
         [self saveToFile];
+        self->_dirty = NO;
     });
 }
 
@@ -138,9 +136,9 @@
               //  NRLOG_AGENT_DEBUG(@"Not writing cleared file because it's not dirty");
                 return;
             }
-            self->_dirty = NO;
         }
         [self saveToFile];
+        self->_dirty = NO;
     });
 }
 

--- a/Agent/HandledException/HexUploadPublisher.mm
+++ b/Agent/HandledException/HexUploadPublisher.mm
@@ -19,9 +19,12 @@ namespace NewRelic {
                 : HexPublisher::HexPublisher(storePath),
                   uploader(new UploaderImpl) {
             // Here we handle the collector address param.
-            uploader->wrapper = [[NRMAHexUploader alloc] initWithHost:[NSString stringWithUTF8String:collectorAddress]];
-            uploader->wrapper.applicationToken = [NSString stringWithUTF8String:appToken];
-            uploader->wrapper.applicationVersion = [NSString stringWithUTF8String:appVersion];
+            // Shared process-wide uploader — its background NSURLSession is a singleton
+            // (one per identifier per process). Retain our reference; the shared instance
+            // also keeps itself alive.
+            uploader->wrapper = [[NRMAHexUploader sharedUploaderWithHost:[NSString stringWithUTF8String:collectorAddress]
+                                                       applicationToken:[NSString stringWithUTF8String:appToken]
+                                                     applicationVersion:[NSString stringWithUTF8String:appVersion]] retain];
         }
 
         void HexUploadPublisher::publish(std::shared_ptr<NewRelic::Hex::HexContext>const& context) {
@@ -42,7 +45,9 @@ namespace NewRelic {
         }
 
         HexUploadPublisher::~HexUploadPublisher() {
-            [uploader->wrapper invalidate];
+            // The uploader is a shared singleton with a process-wide background session — do
+            // NOT invalidate it (that would cancel in-flight background uploads). Just release
+            // our retained reference.
             [uploader->wrapper release];
             delete uploader;
         }

--- a/Agent/HandledException/NRMAHandledExceptions.mm
+++ b/Agent/HandledException/NRMAHandledExceptions.mm
@@ -150,25 +150,9 @@ const NSString* kHexBackupStoreFolder = @"hexbkup/";
 }
 
 - (void) onHarvest {
-    if([NRMAFlags shouldEnableOfflineStorage]) {
-        NRMAReachability* r = [NewRelicInternalUtils reachability];
-        @synchronized(r) {
-#if TARGET_OS_WATCH
-            NRMANetworkStatus status = [NewRelicInternalUtils currentReachabilityStatusTo:[NSURL URLWithString:[NewRelicInternalUtils collectorHostHexURL]]];
-#else
-            NRMANetworkStatus status = [r currentReachabilityStatus];
-#endif
-            if (status != NotReachable) {
-                [self processAndPublishPersistedReports]; // When using offline we always want to send from persisted because the keyContext doesn't persist.
-                _controller->resetKeyContext();
-                _publisher->retry();
-            }
-        }
-    } else {
-        _controller->publish();
-        _store->clear();
-        _publisher->retry();
-    }
+    _controller->publish();
+    _store->clear();
+    _publisher->retry();
 }
 
 - (fbs::Platform) fbsPlatformFromString:(NSString*)platform {

--- a/Agent/HandledException/NRMAHexUploader.h
+++ b/Agent/HandledException/NRMAHexUploader.h
@@ -27,6 +27,13 @@
 
 - (instancetype) initWithHost:(NSString*)host;
 
+// Process-wide shared uploader. A background NSURLSession allows only one session per
+// identifier per process and the identifier must be stable across launches, so the uploader
+// (which owns that session) must be a singleton. Refreshes host/token/version on reuse.
++ (instancetype) sharedUploaderWithHost:(NSString*)host
+                       applicationToken:(NSString*)applicationToken
+                     applicationVersion:(NSString*)applicationVersion;
+
 - (void) sendData:(NSData*)data;
 
 - (void) retryFailedTasks;

--- a/Agent/HandledException/NRMAHexUploader.m
+++ b/Agent/HandledException/NRMAHexUploader.m
@@ -13,9 +13,6 @@
 #import "NRMASupportMetricHelper.h"
 #import "NRConstants.h"
 #import "NewRelicInternalUtils.h"
-#import "NRMAReachability.h"
-#import "NRMAOfflineStorage.h"
-#import "NRMAFlags.h"
 
 #define kNRMARetryLimit 2 // this will result in 2 additional upload attempts.
 
@@ -50,12 +47,6 @@ static const NSTimeInterval kNRMAHexRequestTimeout = 30.0;
 // is the parallel store that lets handledErroredRequest: rebuild the upload
 // with the original payload. Guarded by @synchronized(_payloadByRequest).
 @property(strong) NSMutableDictionary<NSURLRequest*, NSData*>* payloadByRequest;
-
-// Disk-backed retry for uploads that fail because the device is offline (or hit a
-// persist-worthy network error). Mirrors SessionReplayReporter / NRMAHarvesterConnection:
-// persist the payload on a network-error failure, then drain + re-send on a later
-// successful upload. Only used when [NRMAFlags shouldEnableOfflineStorage] is on.
-@property(strong) NRMAOfflineStorage* offlineStorage;
 @end
 
 @implementation NRMAHexUploader
@@ -68,9 +59,6 @@ static const NSTimeInterval kNRMAHexRequestTimeout = 30.0;
         self.pendingPayloads = [NSMutableArray new];
         self.payloadByRequest = [NSMutableDictionary new];
         self.inFlightCount = 0;
-        // initWithEndpoint: seeds the cap from [NRMAAgentConfiguration getMaxOfflineStorageSize]
-        // (bytes); do not call setMaxOfflineStorageSize: (it expects MB and would re-scale).
-        self.offlineStorage = [[NRMAOfflineStorage alloc] initWithEndpoint:@"hex"];
 
         // Background session: once a task is resumed, the OS finishes the transfer
         // out-of-process even if the app is force-closed, and reports the result on the
@@ -256,33 +244,49 @@ didCompleteWithError:(nullable NSError*)error {
         [[NSFileManager defaultManager] removeItemAtPath:tempBodyPath error:nil];
     }
 
+    // Background sessions don't reliably invoke the data delegate for upload tasks, so the
+    // terminal decision is made here from the final HTTP status (an HTTP 4xx/5xx is not an
+    // NSError, so it can't be judged from `error` alone).
+    NSInteger statusCode = 0;
+    if ([task.response isKindOfClass:[NSHTTPURLResponse class]]) {
+        statusCode = ((NSHTTPURLResponse*)task.response).statusCode;
+    }
+
     if (error) {
-#if !TARGET_OS_WATCH
-        if (error.code == kCFURLErrorCancelled) {
-            NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - Handled exception upload cancelled: %@", error);
-        }
-        else {
-            NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - failed to upload handled exception report: %@", [error localizedDescription]);
-        }
-#endif
+        // Transport failure. The background session already waits for connectivity and retries
+        // within its resource window, so reaching here means the OS gave up on this task —
+        // try our own bounded retry, otherwise drop.
+        NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - failed to upload handled exception report: %@", [error localizedDescription]);
         [self handledErroredRequest:task.originalRequest error:error];
-    } else {
+    } else if (statusCode >= 200 && statusCode < 300) {
         NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Handled exception upload completed successfully");
-        if (task.originalRequest) {
-            @synchronized(self.payloadByRequest) {
-                [self.payloadByRequest removeObjectForKey:task.originalRequest];
-            }
-        }
-        [self.taskStore untrack:task.originalRequest];
-        // A successful upload means we're online — drain any reports we persisted while
-        // offline and re-send them.
-        [self sendOfflineStorage];
+        [self forgetRequest:task.originalRequest];
+        [NRMASupportMetricHelper enqueueDataUseMetric:@"f"
+                                                 size:(long)task.countOfBytesSent
+                                             received:(long)task.countOfBytesReceived];
+    } else if (statusCode >= 500) {
+        // Server error — retryable (bounded; gives up after the retry limit).
+        NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - server error %ld uploading handled exception report", (long)statusCode);
+        [self handledErroredRequest:task.originalRequest error:nil];
+    } else {
+        // 4xx (or any other non-2xx, non-5xx): the request itself is bad — give up.
+        NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - giving up on handled exception report (status %ld)", (long)statusCode);
+        [self forgetRequest:task.originalRequest];
     }
 
     @synchronized(self) {
         if (self.inFlightCount > 0) self.inFlightCount--;
     }
     [self drainPending];
+}
+
+// Drop a request's in-memory tracking on a terminal outcome (success or give-up).
+- (void) forgetRequest:(NSURLRequest*)request {
+    if (request == nil) return;
+    @synchronized(self.payloadByRequest) {
+        [self.payloadByRequest removeObjectForKey:request];
+    }
+    [self.taskStore untrack:request];
 }
 
 
@@ -292,46 +296,17 @@ didCompleteWithError:(nullable NSError*)error {
   completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler {
 
     NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Hex Upload response: %@", response);
-
-    if ([response isKindOfClass:[NSHTTPURLResponse class]] &&
-        ((NSHTTPURLResponse*)response).statusCode >= 400) {
-        NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - failed to upload handled exception report: %@", response.description);
-        // An HTTP status is not a persist-worthy network error (checkErrorToPersist:nil is
-        // false), so this path never persists to offline storage.
-        [self handledErroredRequest:dataTask.originalRequest error:nil];
-    }
-    else {
-        // Enqueue Data Usage Supportability Metric for /f if request is successful.
-        [NRMASupportMetricHelper enqueueDataUseMetric:@"f"
-                                                 size:[[[dataTask originalRequest] HTTPBody] length]
-                                             received:response.expectedContentLength];
-    }
-
+    // Terminal handling and the data-use metric are done in didCompleteWithError: from
+    // task.response — background sessions don't reliably call this data delegate for upload
+    // tasks.
     completionHandler(NSURLSessionResponseAllow);
 }
 
+// A retryable failure (transport error or 5xx). Re-send via our own bounded retry tracker;
+// once exhausted, drop. The background session already waits for connectivity and retries
+// within its resource window, so there's no offline hand-off to a separate store.
 - (void) handledErroredRequest:(NSURLRequest*)request error:(NSError*)error {
     if (request == nil) return;
-
-    // If we're offline, don't burn FDs/sockets cycling failed retries —
-    // persist the payload to offline storage (when enabled) so it survives until
-    // connectivity returns, then drop the in-memory tracking.
-#if !TARGET_OS_WATCH
-    NRMAReachability* r = [NewRelicInternalUtils reachability];
-    BOOL offline = NO;
-    @synchronized(r) {
-        offline = ([r currentReachabilityStatus] == NotReachable);
-    }
-    if (offline) {
-        NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - offline, persisting report for later");
-        [self persistPayloadForRequestToOfflineStorage:request];
-        @synchronized(self.payloadByRequest) {
-            [self.payloadByRequest removeObjectForKey:request];
-        }
-        [self.taskStore untrack:request];
-        return;
-    }
-#endif
 
     if ([self.taskStore shouldRetryTask:request]) {
         NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - retrying handled exception report upload");
@@ -341,70 +316,30 @@ didCompleteWithError:(nullable NSError*)error {
         }
         if (body == nil || body.length == 0) {
             NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - retry has no payload, abandoning report");
-            [self.taskStore untrack:request];
+            [self forgetRequest:request];
             return;
         }
         NSURLSessionUploadTask* uploadTask = [self uploadTaskForRequest:request data:body];
         if (uploadTask == nil) {
             NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - retry could not build upload, abandoning report");
-            [self.taskStore untrack:request];
+            [self forgetRequest:request];
             return;
         }
-        // The session may produce a fresh originalRequest copy on the new
-        // task — rekey the payload store so the next failure path can find
-        // the bytes again.
+        // The session may produce a fresh originalRequest copy on the new task — rekey the
+        // payload store (and drop the old key) so the next failure path can find the bytes.
         NSURLRequest* newKey = uploadTask.originalRequest;
         if (newKey && ![newKey isEqual:request]) {
             @synchronized(self.payloadByRequest) {
                 self.payloadByRequest[newKey] = body;
+                [self.payloadByRequest removeObjectForKey:request];
             }
         }
         @synchronized(self.retryQueue) {
             [self.retryQueue addObject:uploadTask];
         }
     } else {
-        NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Handled exception report max upload attempts reached. abandoning report.");
-        // Retries exhausted: if this was a persist-worthy network error (timeout,
-        // connection lost, etc.), keep the report in offline storage to retry later.
-        if ([NRMAOfflineStorage checkErrorToPersist:error]) {
-            [self persistPayloadForRequestToOfflineStorage:request];
-        }
-        @synchronized(self.payloadByRequest) {
-            [self.payloadByRequest removeObjectForKey:request];
-        }
-        [self.taskStore untrack:request];
-    }
-}
-
-// Persists the request's payload to offline storage when offline storage is enabled.
-- (void) persistPayloadForRequestToOfflineStorage:(NSURLRequest*)request {
-    if (![NRMAFlags shouldEnableOfflineStorage]) return;
-    NSData* body = nil;
-    @synchronized(self.payloadByRequest) {
-        body = self.payloadByRequest[request];
-    }
-    if (body.length == 0) return;
-    if ([self.offlineStorage persistDataToDisk:body]) {
-        NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - persisted handled exception report to offline storage");
-    }
-}
-
-// Drains offline storage and re-sends each persisted report. Called after a successful
-// upload (i.e. when we know we're online). Mirrors NRMAHarvesterConnection.
-- (void) sendOfflineStorage {
-    if (![NRMAFlags shouldEnableOfflineStorage]) {
-        [NRMAOfflineStorage clearAllOfflineDirectories];
-        return;
-    }
-    NSArray<NSData*>* offlineData = [self.offlineStorage getAllOfflineData:YES];
-    if (offlineData.count == 0) {
-        return;
-    }
-    NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - re-sending %lu offline handled exception report(s)", (unsigned long)offlineData.count);
-    for (NSData* data in offlineData) {
-        // Re-enter the normal pipeline; a payload that fails again is re-persisted by
-        // the failure path above.
-        [self sendData:data];
+        NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Handled exception report max upload attempts reached, abandoning report.");
+        [self forgetRequest:request];
     }
 }
 

--- a/Agent/HandledException/NRMAHexUploader.m
+++ b/Agent/HandledException/NRMAHexUploader.m
@@ -14,6 +14,8 @@
 #import "NRConstants.h"
 #import "NewRelicInternalUtils.h"
 #import "NRMAReachability.h"
+#import "NRMAOfflineStorage.h"
+#import "NRMAFlags.h"
 
 #define kNRMARetryLimit 2 // this will result in 2 additional upload attempts.
 
@@ -30,7 +32,6 @@ static const NSUInteger kNRMAHexMaxPending = 50;
 // keeps sockets alive for a full minute per task — combined with concurrent
 // retries, that's how the customer hits "Too many open files".
 static const NSTimeInterval kNRMAHexRequestTimeout = 30.0;
-static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
 
 @interface NRMAHexUploader()
 @property(strong) NSString* host;
@@ -49,6 +50,12 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
 // is the parallel store that lets handledErroredRequest: rebuild the upload
 // with the original payload. Guarded by @synchronized(_payloadByRequest).
 @property(strong) NSMutableDictionary<NSURLRequest*, NSData*>* payloadByRequest;
+
+// Disk-backed retry for uploads that fail because the device is offline (or hit a
+// persist-worthy network error). Mirrors SessionReplayReporter / NRMAHarvesterConnection:
+// persist the payload on a network-error failure, then drain + re-send on a later
+// successful upload. Only used when [NRMAFlags shouldEnableOfflineStorage] is on.
+@property(strong) NRMAOfflineStorage* offlineStorage;
 @end
 
 @implementation NRMAHexUploader
@@ -61,19 +68,56 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
         self.pendingPayloads = [NSMutableArray new];
         self.payloadByRequest = [NSMutableDictionary new];
         self.inFlightCount = 0;
+        // initWithEndpoint: seeds the cap from [NRMAAgentConfiguration getMaxOfflineStorageSize]
+        // (bytes); do not call setMaxOfflineStorageSize: (it expects MB and would re-scale).
+        self.offlineStorage = [[NRMAOfflineStorage alloc] initWithEndpoint:@"hex"];
 
-        NSURLSessionConfiguration* sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-        sessionConfiguration.HTTPMaximumConnectionsPerHost = kNRMAHexMaxInFlight;
-        sessionConfiguration.timeoutIntervalForRequest = kNRMAHexRequestTimeout;
-        sessionConfiguration.timeoutIntervalForResource = kNRMAHexResourceTimeout;
-        sessionConfiguration.waitsForConnectivity = NO;
-
-        self.session = [NSURLSession sessionWithConfiguration:sessionConfiguration
-                                                     delegate:self
-                                                delegateQueue:nil];
+        // Background session: once a task is resumed, the OS finishes the transfer
+        // out-of-process even if the app is force-closed, and reports the result on the
+        // next launch. Shared per-process (see ensureBackgroundSession).
+        self.session = [self ensureBackgroundSession];
         self.taskStore = [[NRMARetryTracker alloc] initWithRetryLimit:kNRMARetryLimit];
     }
     return self;
+}
+
++ (instancetype) sharedUploaderWithHost:(NSString*)host
+                       applicationToken:(NSString*)applicationToken
+                     applicationVersion:(NSString*)applicationVersion {
+    static NRMAHexUploader* shared = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        shared = [[NRMAHexUploader alloc] initWithHost:host];
+    });
+    @synchronized(shared) {
+        if (host) shared.host = host;
+        if (applicationToken) shared.applicationToken = applicationToken;
+        if (applicationVersion) shared.applicationVersion = applicationVersion;
+    }
+    return shared;
+}
+
+// Lazily creates the single process-wide background session and returns it. A background
+// session allows only one instance per identifier per process — creating a second would
+// throw — so every uploader shares this one. The first instance to call this becomes its
+// delegate; in production that is the shared uploader.
+- (NSURLSession*) ensureBackgroundSession {
+    static NSURLSession* session = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        NSString* identifier = [NSString stringWithFormat:@"com.newrelic.hex.upload.%@",
+                                [[NSBundle mainBundle] bundleIdentifier] ?: @"agent"];
+        NSURLSessionConfiguration* cfg = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:identifier];
+        cfg.HTTPMaximumConnectionsPerHost = kNRMAHexMaxInFlight;
+        cfg.timeoutIntervalForRequest = kNRMAHexRequestTimeout;
+        // We don't register the app-delegate handleEventsForBackgroundURLSession hook, so
+        // don't have the OS relaunch the app purely in the background to flush events; the
+        // transfer still completes and is reconciled on the next normal launch.
+        cfg.sessionSendsLaunchEvents = NO;
+        cfg.discretionary = NO;
+        session = [NSURLSession sessionWithConfiguration:cfg delegate:self delegateQueue:nil];
+    });
+    return session;
 }
 
 - (void) sendData:(NSData*)data {
@@ -128,21 +172,51 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
     [request setValue:@"application/octet-stream" forHTTPHeaderField:@"Content-Type"];
     [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)data.length] forHTTPHeaderField:@"Content-Length"];
 
-    // Important: do NOT set HTTPBody on the request. NSURLSessionUploadTask
-    // requires the payload to come exclusively from `fromData:`, and iOS
-    // logs a warning + strips the body if both are present. Payload is
-    // tracked separately in payloadByRequest so retries can rebuild.
+    // Important: do NOT set HTTPBody on the request. A background NSURLSession upload task
+    // takes its body exclusively from a file (see uploadTaskForRequest:data:); the payload
+    // is also tracked in payloadByRequest so retries can rebuild a fresh body file.
 
-    NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Hex Upload started: %@", request);
-
-    NSURLSessionUploadTask* uploadTask = [self.session uploadTaskWithRequest:request fromData:data];
+    NSURLSessionUploadTask* uploadTask = [self uploadTaskForRequest:request data:data];
+    if (uploadTask == nil) {
+        @synchronized(self) {
+            if (self.inFlightCount > 0) self.inFlightCount--;
+        }
+        return;
+    }
     NSURLRequest* key = uploadTask.originalRequest ?: request;
 
     @synchronized(self.payloadByRequest) {
         self.payloadByRequest[key] = data;
     }
     [self.taskStore track:key];
+    NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Hex Upload started: %@", request);
     [uploadTask resume];
+}
+
+// Background sessions require the body to come from a file. Writes the payload to a temp
+// file and builds an upload task from it; the temp path is stored in taskDescription so it
+// can be removed once the task completes (including after an app relaunch).
+- (NSURLSessionUploadTask*) uploadTaskForRequest:(NSURLRequest*)request data:(NSData*)data {
+    NSURL* bodyURL = [self writeTempBody:data];
+    if (bodyURL == nil) return nil;
+    NSURLSessionUploadTask* task = [self.session uploadTaskWithRequest:request fromFile:bodyURL];
+    task.taskDescription = bodyURL.path;
+    return task;
+}
+
+- (NSURL*) writeTempBody:(NSData*)data {
+    NSString* dir = [NSTemporaryDirectory() stringByAppendingPathComponent:@"nr-hex-upload"];
+    [[NSFileManager defaultManager] createDirectoryAtPath:dir
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+    NSString* path = [dir stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+    NSError* error = nil;
+    if (![data writeToFile:path options:NSDataWritingAtomic error:&error]) {
+        NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - failed to write temp upload body: %@", error);
+        return nil;
+    }
+    return [NSURL fileURLWithPath:path];
 }
 
 - (void) retryFailedTasks {
@@ -160,21 +234,27 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
 }
 
 - (void) invalidate {
-    [self.session finishTasksAndInvalidate];
+    // No-op: the background session is a process-wide singleton shared across uploader
+    // instances and must stay alive to receive completions — including across an app
+    // relaunch. Tearing it down here would cancel in-flight background uploads.
 }
 
 - (void) dealloc {
-    // Defense-in-depth: NSURLSession holds a strong ref to its delegate
-    // (self), so without an explicit invalidate the session + delegate +
-    // any in-flight tasks live forever. The publisher dtor normally
-    // invalidates first, but covering the dealloc path guarantees
-    // FDs and sockets are released even if ownership shifts.
-    [_session invalidateAndCancel];
+    // Intentionally do NOT invalidate/cancel the shared background session here; it is
+    // process-wide and outlives any individual uploader instance.
 }
 
 - (void)  URLSession:(NSURLSession*)session
                 task:(NSURLSessionTask*)task
 didCompleteWithError:(nullable NSError*)error {
+
+    // Remove the temp body file backing this task. taskDescription survives an app relaunch,
+    // so this also cleans up tasks that completed while the app was dead. A retry rebuilds a
+    // fresh temp file from the in-memory payload, so deleting this one here is safe.
+    NSString* tempBodyPath = task.taskDescription;
+    if (tempBodyPath.length) {
+        [[NSFileManager defaultManager] removeItemAtPath:tempBodyPath error:nil];
+    }
 
     if (error) {
 #if !TARGET_OS_WATCH
@@ -185,7 +265,7 @@ didCompleteWithError:(nullable NSError*)error {
             NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - failed to upload handled exception report: %@", [error localizedDescription]);
         }
 #endif
-        [self handledErroredRequest:task.originalRequest];
+        [self handledErroredRequest:task.originalRequest error:error];
     } else {
         NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Handled exception upload completed successfully");
         if (task.originalRequest) {
@@ -194,6 +274,9 @@ didCompleteWithError:(nullable NSError*)error {
             }
         }
         [self.taskStore untrack:task.originalRequest];
+        // A successful upload means we're online — drain any reports we persisted while
+        // offline and re-send them.
+        [self sendOfflineStorage];
     }
 
     @synchronized(self) {
@@ -213,7 +296,9 @@ didCompleteWithError:(nullable NSError*)error {
     if ([response isKindOfClass:[NSHTTPURLResponse class]] &&
         ((NSHTTPURLResponse*)response).statusCode >= 400) {
         NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - failed to upload handled exception report: %@", response.description);
-        [self handledErroredRequest:dataTask.originalRequest];
+        // An HTTP status is not a persist-worthy network error (checkErrorToPersist:nil is
+        // false), so this path never persists to offline storage.
+        [self handledErroredRequest:dataTask.originalRequest error:nil];
     }
     else {
         // Enqueue Data Usage Supportability Metric for /f if request is successful.
@@ -225,12 +310,12 @@ didCompleteWithError:(nullable NSError*)error {
     completionHandler(NSURLSessionResponseAllow);
 }
 
-- (void) handledErroredRequest:(NSURLRequest*)request {
+- (void) handledErroredRequest:(NSURLRequest*)request error:(NSError*)error {
     if (request == nil) return;
 
     // If we're offline, don't burn FDs/sockets cycling failed retries —
-    // queue the task and let the next harvest's retryFailedTasks fire it
-    // when reachability returns.
+    // persist the payload to offline storage (when enabled) so it survives until
+    // connectivity returns, then drop the in-memory tracking.
 #if !TARGET_OS_WATCH
     NRMAReachability* r = [NewRelicInternalUtils reachability];
     BOOL offline = NO;
@@ -238,7 +323,8 @@ didCompleteWithError:(nullable NSError*)error {
         offline = ([r currentReachabilityStatus] == NotReachable);
     }
     if (offline) {
-        NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - offline, deferring retry");
+        NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - offline, persisting report for later");
+        [self persistPayloadForRequestToOfflineStorage:request];
         @synchronized(self.payloadByRequest) {
             [self.payloadByRequest removeObjectForKey:request];
         }
@@ -258,7 +344,12 @@ didCompleteWithError:(nullable NSError*)error {
             [self.taskStore untrack:request];
             return;
         }
-        NSURLSessionUploadTask* uploadTask = [self.session uploadTaskWithRequest:request fromData:body];
+        NSURLSessionUploadTask* uploadTask = [self uploadTaskForRequest:request data:body];
+        if (uploadTask == nil) {
+            NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - retry could not build upload, abandoning report");
+            [self.taskStore untrack:request];
+            return;
+        }
         // The session may produce a fresh originalRequest copy on the new
         // task — rekey the payload store so the next failure path can find
         // the bytes again.
@@ -273,10 +364,47 @@ didCompleteWithError:(nullable NSError*)error {
         }
     } else {
         NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Handled exception report max upload attempts reached. abandoning report.");
+        // Retries exhausted: if this was a persist-worthy network error (timeout,
+        // connection lost, etc.), keep the report in offline storage to retry later.
+        if ([NRMAOfflineStorage checkErrorToPersist:error]) {
+            [self persistPayloadForRequestToOfflineStorage:request];
+        }
         @synchronized(self.payloadByRequest) {
             [self.payloadByRequest removeObjectForKey:request];
         }
         [self.taskStore untrack:request];
+    }
+}
+
+// Persists the request's payload to offline storage when offline storage is enabled.
+- (void) persistPayloadForRequestToOfflineStorage:(NSURLRequest*)request {
+    if (![NRMAFlags shouldEnableOfflineStorage]) return;
+    NSData* body = nil;
+    @synchronized(self.payloadByRequest) {
+        body = self.payloadByRequest[request];
+    }
+    if (body.length == 0) return;
+    if ([self.offlineStorage persistDataToDisk:body]) {
+        NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - persisted handled exception report to offline storage");
+    }
+}
+
+// Drains offline storage and re-sends each persisted report. Called after a successful
+// upload (i.e. when we know we're online). Mirrors NRMAHarvesterConnection.
+- (void) sendOfflineStorage {
+    if (![NRMAFlags shouldEnableOfflineStorage]) {
+        [NRMAOfflineStorage clearAllOfflineDirectories];
+        return;
+    }
+    NSArray<NSData*>* offlineData = [self.offlineStorage getAllOfflineData:YES];
+    if (offlineData.count == 0) {
+        return;
+    }
+    NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - re-sending %lu offline handled exception report(s)", (unsigned long)offlineData.count);
+    for (NSData* data in offlineData) {
+        // Re-enter the normal pipeline; a payload that fails again is re-persisted by
+        // the failure path above.
+        [self sendData:data];
     }
 }
 

--- a/Agent/HandledException/NRMAHexUploader.m
+++ b/Agent/HandledException/NRMAHexUploader.m
@@ -13,6 +13,9 @@
 #import "NRMASupportMetricHelper.h"
 #import "NRConstants.h"
 #import "NewRelicInternalUtils.h"
+#import "NRMAReachability.h"
+#import "NRMAOfflineStorage.h"
+#import "NRMAFlags.h"
 
 #define kNRMARetryLimit 2 // this will result in 2 additional upload attempts.
 
@@ -47,6 +50,12 @@ static const NSTimeInterval kNRMAHexRequestTimeout = 30.0;
 // is the parallel store that lets handledErroredRequest: rebuild the upload
 // with the original payload. Guarded by @synchronized(_payloadByRequest).
 @property(strong) NSMutableDictionary<NSURLRequest*, NSData*>* payloadByRequest;
+
+// Disk-backed retry for uploads that fail because the device is offline (or hit a
+// persist-worthy network error). Mirrors SessionReplayReporter / NRMAHarvesterConnection:
+// persist the payload on a network-error failure, then drain + re-send on a later
+// successful upload. Only used when [NRMAFlags shouldEnableOfflineStorage] is on.
+@property(strong) NRMAOfflineStorage* offlineStorage;
 @end
 
 @implementation NRMAHexUploader
@@ -59,6 +68,9 @@ static const NSTimeInterval kNRMAHexRequestTimeout = 30.0;
         self.pendingPayloads = [NSMutableArray new];
         self.payloadByRequest = [NSMutableDictionary new];
         self.inFlightCount = 0;
+        // initWithEndpoint: seeds the cap from [NRMAAgentConfiguration getMaxOfflineStorageSize]
+        // (bytes); do not call setMaxOfflineStorageSize: (it expects MB and would re-scale).
+        self.offlineStorage = [[NRMAOfflineStorage alloc] initWithEndpoint:@"hex"];
 
         // Background session: once a task is resumed, the OS finishes the transfer
         // out-of-process even if the app is force-closed, and reports the result on the
@@ -244,49 +256,33 @@ didCompleteWithError:(nullable NSError*)error {
         [[NSFileManager defaultManager] removeItemAtPath:tempBodyPath error:nil];
     }
 
-    // Background sessions don't reliably invoke the data delegate for upload tasks, so the
-    // terminal decision is made here from the final HTTP status (an HTTP 4xx/5xx is not an
-    // NSError, so it can't be judged from `error` alone).
-    NSInteger statusCode = 0;
-    if ([task.response isKindOfClass:[NSHTTPURLResponse class]]) {
-        statusCode = ((NSHTTPURLResponse*)task.response).statusCode;
-    }
-
     if (error) {
-        // Transport failure. The background session already waits for connectivity and retries
-        // within its resource window, so reaching here means the OS gave up on this task —
-        // try our own bounded retry, otherwise drop.
-        NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - failed to upload handled exception report: %@", [error localizedDescription]);
+#if !TARGET_OS_WATCH
+        if (error.code == kCFURLErrorCancelled) {
+            NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - Handled exception upload cancelled: %@", error);
+        }
+        else {
+            NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - failed to upload handled exception report: %@", [error localizedDescription]);
+        }
+#endif
         [self handledErroredRequest:task.originalRequest error:error];
-    } else if (statusCode >= 200 && statusCode < 300) {
-        NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Handled exception upload completed successfully");
-        [self forgetRequest:task.originalRequest];
-        [NRMASupportMetricHelper enqueueDataUseMetric:@"f"
-                                                 size:(long)task.countOfBytesSent
-                                             received:(long)task.countOfBytesReceived];
-    } else if (statusCode >= 500) {
-        // Server error — retryable (bounded; gives up after the retry limit).
-        NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - server error %ld uploading handled exception report", (long)statusCode);
-        [self handledErroredRequest:task.originalRequest error:nil];
     } else {
-        // 4xx (or any other non-2xx, non-5xx): the request itself is bad — give up.
-        NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - giving up on handled exception report (status %ld)", (long)statusCode);
-        [self forgetRequest:task.originalRequest];
+        NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Handled exception upload completed successfully");
+        if (task.originalRequest) {
+            @synchronized(self.payloadByRequest) {
+                [self.payloadByRequest removeObjectForKey:task.originalRequest];
+            }
+        }
+        [self.taskStore untrack:task.originalRequest];
+        // A successful upload means we're online — drain any reports we persisted while
+        // offline and re-send them.
+        [self sendOfflineStorage];
     }
 
     @synchronized(self) {
         if (self.inFlightCount > 0) self.inFlightCount--;
     }
     [self drainPending];
-}
-
-// Drop a request's in-memory tracking on a terminal outcome (success or give-up).
-- (void) forgetRequest:(NSURLRequest*)request {
-    if (request == nil) return;
-    @synchronized(self.payloadByRequest) {
-        [self.payloadByRequest removeObjectForKey:request];
-    }
-    [self.taskStore untrack:request];
 }
 
 
@@ -296,17 +292,46 @@ didCompleteWithError:(nullable NSError*)error {
   completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler {
 
     NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Hex Upload response: %@", response);
-    // Terminal handling and the data-use metric are done in didCompleteWithError: from
-    // task.response — background sessions don't reliably call this data delegate for upload
-    // tasks.
+
+    if ([response isKindOfClass:[NSHTTPURLResponse class]] &&
+        ((NSHTTPURLResponse*)response).statusCode >= 400) {
+        NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - failed to upload handled exception report: %@", response.description);
+        // An HTTP status is not a persist-worthy network error (checkErrorToPersist:nil is
+        // false), so this path never persists to offline storage.
+        [self handledErroredRequest:dataTask.originalRequest error:nil];
+    }
+    else {
+        // Enqueue Data Usage Supportability Metric for /f if request is successful.
+        [NRMASupportMetricHelper enqueueDataUseMetric:@"f"
+                                                 size:[[[dataTask originalRequest] HTTPBody] length]
+                                             received:response.expectedContentLength];
+    }
+
     completionHandler(NSURLSessionResponseAllow);
 }
 
-// A retryable failure (transport error or 5xx). Re-send via our own bounded retry tracker;
-// once exhausted, drop. The background session already waits for connectivity and retries
-// within its resource window, so there's no offline hand-off to a separate store.
 - (void) handledErroredRequest:(NSURLRequest*)request error:(NSError*)error {
     if (request == nil) return;
+
+    // If we're offline, don't burn FDs/sockets cycling failed retries —
+    // persist the payload to offline storage (when enabled) so it survives until
+    // connectivity returns, then drop the in-memory tracking.
+#if !TARGET_OS_WATCH
+    NRMAReachability* r = [NewRelicInternalUtils reachability];
+    BOOL offline = NO;
+    @synchronized(r) {
+        offline = ([r currentReachabilityStatus] == NotReachable);
+    }
+    if (offline) {
+        NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - offline, persisting report for later");
+        [self persistPayloadForRequestToOfflineStorage:request];
+        @synchronized(self.payloadByRequest) {
+            [self.payloadByRequest removeObjectForKey:request];
+        }
+        [self.taskStore untrack:request];
+        return;
+    }
+#endif
 
     if ([self.taskStore shouldRetryTask:request]) {
         NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - retrying handled exception report upload");
@@ -316,30 +341,70 @@ didCompleteWithError:(nullable NSError*)error {
         }
         if (body == nil || body.length == 0) {
             NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - retry has no payload, abandoning report");
-            [self forgetRequest:request];
+            [self.taskStore untrack:request];
             return;
         }
         NSURLSessionUploadTask* uploadTask = [self uploadTaskForRequest:request data:body];
         if (uploadTask == nil) {
             NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - retry could not build upload, abandoning report");
-            [self forgetRequest:request];
+            [self.taskStore untrack:request];
             return;
         }
-        // The session may produce a fresh originalRequest copy on the new task — rekey the
-        // payload store (and drop the old key) so the next failure path can find the bytes.
+        // The session may produce a fresh originalRequest copy on the new
+        // task — rekey the payload store so the next failure path can find
+        // the bytes again.
         NSURLRequest* newKey = uploadTask.originalRequest;
         if (newKey && ![newKey isEqual:request]) {
             @synchronized(self.payloadByRequest) {
                 self.payloadByRequest[newKey] = body;
-                [self.payloadByRequest removeObjectForKey:request];
             }
         }
         @synchronized(self.retryQueue) {
             [self.retryQueue addObject:uploadTask];
         }
     } else {
-        NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Handled exception report max upload attempts reached, abandoning report.");
-        [self forgetRequest:request];
+        NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Handled exception report max upload attempts reached. abandoning report.");
+        // Retries exhausted: if this was a persist-worthy network error (timeout,
+        // connection lost, etc.), keep the report in offline storage to retry later.
+        if ([NRMAOfflineStorage checkErrorToPersist:error]) {
+            [self persistPayloadForRequestToOfflineStorage:request];
+        }
+        @synchronized(self.payloadByRequest) {
+            [self.payloadByRequest removeObjectForKey:request];
+        }
+        [self.taskStore untrack:request];
+    }
+}
+
+// Persists the request's payload to offline storage when offline storage is enabled.
+- (void) persistPayloadForRequestToOfflineStorage:(NSURLRequest*)request {
+    if (![NRMAFlags shouldEnableOfflineStorage]) return;
+    NSData* body = nil;
+    @synchronized(self.payloadByRequest) {
+        body = self.payloadByRequest[request];
+    }
+    if (body.length == 0) return;
+    if ([self.offlineStorage persistDataToDisk:body]) {
+        NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - persisted handled exception report to offline storage");
+    }
+}
+
+// Drains offline storage and re-sends each persisted report. Called after a successful
+// upload (i.e. when we know we're online). Mirrors NRMAHarvesterConnection.
+- (void) sendOfflineStorage {
+    if (![NRMAFlags shouldEnableOfflineStorage]) {
+        [NRMAOfflineStorage clearAllOfflineDirectories];
+        return;
+    }
+    NSArray<NSData*>* offlineData = [self.offlineStorage getAllOfflineData:YES];
+    if (offlineData.count == 0) {
+        return;
+    }
+    NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - re-sending %lu offline handled exception report(s)", (unsigned long)offlineData.count);
+    for (NSData* data in offlineData) {
+        // Re-enter the normal pipeline; a payload that fails again is re-persisted by
+        // the failure path above.
+        [self sendData:data];
     }
 }
 

--- a/Agent/Public/NewRelic.m
+++ b/Agent/Public/NewRelic.m
@@ -176,10 +176,11 @@
     if([NewRelicAgentInternal sharedInstance].isShutdown) {
         return;
     }
+    
+    [[NewRelicAgentInternal sharedInstance] sessionReplayOnError:nil];
 
     [[NewRelicAgentInternal sharedInstance].handledExceptionsController recordHandledException:exception];
     
-    [[NewRelicAgentInternal sharedInstance] sessionReplayOnError:nil];
 }
 
 + (void) recordHandledException:(NSException*)exception
@@ -189,11 +190,11 @@
     if([NewRelicAgentInternal sharedInstance].isShutdown) {
         return;
     }
-    [[NewRelicAgentInternal sharedInstance].handledExceptionsController recordHandledException:exception
-                                                                                    attributes:attributes];
     
     [[NewRelicAgentInternal sharedInstance] sessionReplayOnError:nil];
 
+    [[NewRelicAgentInternal sharedInstance].handledExceptionsController recordHandledException:exception
+                                                                                    attributes:attributes];
 }
 
 + (void)recordHandledExceptionWithStackTrace:(NSDictionary* _Nonnull)exceptionDictionary {
@@ -202,24 +203,23 @@
     if([NewRelicAgentInternal sharedInstance].isShutdown) {
         return;
     }
-
-    [[NewRelicAgentInternal sharedInstance].handledExceptionsController recordHandledExceptionWithStackTrace:exceptionDictionary];
     
     [[NewRelicAgentInternal sharedInstance] sessionReplayOnError:nil];
 
+    [[NewRelicAgentInternal sharedInstance].handledExceptionsController recordHandledExceptionWithStackTrace:exceptionDictionary];
 }
 
 + (void) recordError:(NSError* _Nonnull)error {
-
+    
     // If Agent is shutdown we shouldn't respond.
     if([NewRelicAgentInternal sharedInstance].isShutdown) {
         return;
     }
-
-    [[NewRelicAgentInternal sharedInstance].handledExceptionsController recordError:error
-                                                                         attributes:nil];
     
     [[NewRelicAgentInternal sharedInstance] sessionReplayOnError:nil];
+    
+    [[NewRelicAgentInternal sharedInstance].handledExceptionsController recordError:error
+                                                                         attributes:nil];
 }
 
 + (void) recordError:(NSError* _Nonnull)error
@@ -229,11 +229,11 @@
     if([NewRelicAgentInternal sharedInstance].isShutdown) {
         return;
     }
+    
+    [[NewRelicAgentInternal sharedInstance] sessionReplayOnError:nil];
 
     [[NewRelicAgentInternal sharedInstance].handledExceptionsController recordError:error
                                                                          attributes:attributes];
-    
-    [[NewRelicAgentInternal sharedInstance] sessionReplayOnError:nil];
 }
 
 + (void) setPlatform:(NRMAApplicationPlatform)platform {

--- a/Tests/Unit-Tests/NewRelicAgentTests/API-Tests/APINetworkNoticeTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/API-Tests/APINetworkNoticeTest.m
@@ -62,7 +62,9 @@
                                traceHeaders:nil
                                      params:nil];
 
-    while(CFRunLoopGetCurrent() && !helper.result) {}
+    while(CFRunLoopGetCurrent() && !helper.result) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    }
 
     NRMAHTTPTransactionMeasurement* result = (NRMAHTTPTransactionMeasurement*)helper.result;
     XCTAssertEqualObjects(result.url, @"google.com", @"result url matches recorded url");
@@ -108,7 +110,9 @@
                                traceHeaders:nil 
                                      params:nil];
 
-    while(CFRunLoopGetCurrent() && !helper.result) {}
+    while(CFRunLoopGetCurrent() && !helper.result) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    }
 
     NRMAHTTPTransactionMeasurement* result = (NRMAHTTPTransactionMeasurement*)helper.result;
 
@@ -133,7 +137,9 @@
                                   withTimer:[[NRTimer alloc] initWithStartTime:startTime andEndTime:endTime]
                                   withError:error];
 
-    while(CFRunLoopGetCurrent() && !helper.result) {}
+    while(CFRunLoopGetCurrent() && !helper.result) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    }
 
     NRMAHTTPTransactionMeasurement* result = (NRMAHTTPTransactionMeasurement*)helper.result;
 
@@ -162,7 +168,9 @@
                                traceHeaders:@{@"traceparent":@"parent-awesomeid-verycool"}
                                      params:nil];
 
-    while(CFRunLoopGetCurrent() && !helper.result) {}
+    while(CFRunLoopGetCurrent() && !helper.result) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    }
 
     NRMAHTTPTransactionMeasurement* result = (NRMAHTTPTransactionMeasurement*)helper.result;
 
@@ -223,7 +231,9 @@
                                traceHeaders:@{@"traceparent":@"parent-awesomeid-verycool"}
                                      params:nil];
 
-    while(CFRunLoopGetCurrent() && !helper.result) {}
+    while(CFRunLoopGetCurrent() && !helper.result) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    }
 
     NRMAHTTPTransactionMeasurement* result = (NRMAHTTPTransactionMeasurement*)helper.result;
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/API-Tests/NewRelicTests.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/API-Tests/NewRelicTests.m
@@ -154,7 +154,9 @@ static NewRelicAgentInternal* _sharedInstance;
                                withTimer:[[NRTimer alloc] initWithStartTime:startTime andEndTime:endTime]
                           andFailureCode:-1];
 
-    while(CFRunLoopGetCurrent() && !helper.result) {}
+    while(CFRunLoopGetCurrent() && !helper.result) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    }
 
     NRMAHTTPTransactionMeasurement* result = (NRMAHTTPTransactionMeasurement*)helper.result;
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/Handled-Exception-Tests/TestHexUploader.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Handled-Exception-Tests/TestHexUploader.m
@@ -19,17 +19,23 @@
 #import "NewRelicInternalUtils.h"
 #import "NewRelic.h"
 #import "NRMASupportMetricHelper.h"
+#import "NRMAOfflineStorage.h"
+#import "NRMAFlags.h"
 
 @interface NRMAHexUploader ()
-- (void) handledErroredRequest:(NSURLRequest*)request;
+- (void) handledErroredRequest:(NSURLRequest*)request error:(NSError*)error;
+- (void) sendOfflineStorage;
+- (void) persistPayloadForRequestToOfflineStorage:(NSURLRequest*)request;
 @property(strong) NSURLSession* session;
 @property(strong) NSMutableArray* pendingPayloads;
 @property(assign) NSUInteger inFlightCount;
 @property(strong) NSMutableDictionary<NSURLRequest*, NSData*>* payloadByRequest;
+@property(strong) NRMAOfflineStorage* offlineStorage;
 @end
 
 @interface TestHexUploader : NRMAAgentTestBase {
     NRMAMeasurementConsumerHelper* helper;
+    NRMAFeatureFlags _originalFlags;
 }
 @property(strong) NRMAHexUploader* hexUploader;
 
@@ -42,12 +48,14 @@
 
     [NewRelic setPlatform:NRMAPlatform_Native];
 
+    _originalFlags = [NRMAFlags featureFlags];
+
     self.hexUploader = [[NRMAHexUploader alloc] initWithHost:@"localhost"];
 
     helper = [[NRMAMeasurementConsumerHelper alloc] initWithType:NRMAMT_NamedValue];
     [NRMAMeasurements initializeMeasurements];
     [NRMAMeasurements addMeasurementConsumer:helper];
-    
+
     [NRMASupportMetricHelper processDeferredMetrics];
 }
 
@@ -57,6 +65,11 @@
     helper = nil;
 
     [NRMAMeasurements shutdown];
+
+    // Don't let offline-storage state or the feature flag leak between tests.
+    // setFeatureFlags: restores flags without emitting an enableFeature support metric.
+    [NRMAFlags setFeatureFlags:_originalFlags];
+    [NRMAOfflineStorage clearAllOfflineDirectories];
 
     [super tearDown];
 }
@@ -76,7 +89,7 @@
 
 - (void) testHandledNetworkError {
     id mockUploader = [OCMockObject partialMockForObject:self.hexUploader];
-    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY];
+    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY error:OCMOCK_ANY];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
@@ -98,7 +111,7 @@
 
 - (void) testNoRetryOnSuccess {
     id mockUploader = [OCMockObject partialMockForObject:self.hexUploader];
-    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY];
+    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY error:OCMOCK_ANY];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
@@ -121,7 +134,7 @@
 
 - (void) testRetryOnFailure {
     id mockUploader = [OCMockObject partialMockForObject:self.hexUploader];
-    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY];
+    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY error:OCMOCK_ANY];
 
     NSError* error = [NSError errorWithDomain:(NSString*)kCFErrorDomainCFNetwork
                                          code:kCFURLErrorDNSLookupFailed
@@ -139,7 +152,7 @@
 
 - (void) testSuccessSupportMetric {
     id mockUploader = [OCMockObject partialMockForObject:self.hexUploader];
-    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY];
+    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY error:OCMOCK_ANY];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
@@ -175,7 +188,7 @@
 
     self.hexUploader.applicationToken = @"IMTHETOKENNOW";
     id mockUploader = [OCMockObject partialMockForObject:self.hexUploader];
-    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY];
+    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY error:OCMOCK_ANY];
     
     XCTAssertThrows([mockUploader verify]);
 
@@ -243,6 +256,84 @@
                   @"a tracked payload must match the original byte length");
 
     [self.hexUploader invalidate];
+}
+
+// A persist-worthy network-error failure must hand the payload to offline storage so it
+// survives until connectivity returns (mirrors SessionReplayReporter / NRMAHarvesterConnection).
+- (void) testNetworkErrorPersistsToOfflineStorage {
+    [NRMAFlags setFeatureFlags:NRFeatureFlag_OfflineStorage];
+    [NRMAOfflineStorage clearAllOfflineDirectories];
+
+    NSURLRequest* request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://localhost/mobile/f"]];
+    NSData* data = [@"hex-report-bytes" dataUsingEncoding:NSUTF8StringEncoding];
+    @synchronized(self.hexUploader.payloadByRequest) {
+        self.hexUploader.payloadByRequest[request] = data;
+    }
+
+    [self.hexUploader persistPayloadForRequestToOfflineStorage:request];
+
+    XCTAssertEqual([self.hexUploader.offlineStorage getAllOfflineData:NO].count, (NSUInteger)1,
+                   @"network-error failure must persist the payload to offline storage");
+}
+
+// A successful upload triggers a drain: persisted reports are read+cleared and re-sent.
+- (void) testSendOfflineStorageDrainsPersistedReports {
+    [NRMAFlags setFeatureFlags:NRFeatureFlag_OfflineStorage];
+    [NRMAOfflineStorage clearAllOfflineDirectories];
+
+    NSData* data = [@"persisted-hex-report" dataUsingEncoding:NSUTF8StringEncoding];
+    XCTAssertTrue([self.hexUploader.offlineStorage persistDataToDisk:data]);
+    XCTAssertEqual([self.hexUploader.offlineStorage getAllOfflineData:NO].count, (NSUInteger)1);
+
+    [self.hexUploader sendOfflineStorage];
+
+    // getAllOfflineData:YES inside sendOfflineStorage clears the directory synchronously.
+    XCTAssertEqual([self.hexUploader.offlineStorage getAllOfflineData:NO].count, (NSUInteger)0,
+                   @"offline storage must be drained after sendOfflineStorage");
+
+    [self.hexUploader invalidate];
+}
+
+// With offline storage disabled, a drain must clear any existing offline directories and
+// persist nothing.
+- (void) testSendOfflineStorageDisabledClears {
+    [NRMAFlags setFeatureFlags:NRFeatureFlag_OfflineStorage];
+    [NRMAOfflineStorage clearAllOfflineDirectories];
+    NSData* data = [@"x" dataUsingEncoding:NSUTF8StringEncoding];
+    XCTAssertTrue([self.hexUploader.offlineStorage persistDataToDisk:data]);
+
+    [NRMAFlags setFeatureFlags:0];
+    [self.hexUploader sendOfflineStorage];
+
+    XCTAssertEqual([self.hexUploader.offlineStorage getAllOfflineData:NO].count, (NSUInteger)0,
+                   @"disabled offline storage must be cleared");
+}
+
+// Background uploads send their body from a temp file; when the task completes the temp
+// file must be removed (the path travels in taskDescription so this also works across an
+// app relaunch).
+- (void) testCompletionRemovesTempBodyFile {
+    NSString* dir = [NSTemporaryDirectory() stringByAppendingPathComponent:@"nr-hex-upload"];
+    [[NSFileManager defaultManager] createDirectoryAtPath:dir
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+    NSString* tempPath = [dir stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+    [[@"body" dataUsingEncoding:NSUTF8StringEncoding] writeToFile:tempPath atomically:YES];
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:tempPath]);
+
+    id task = [OCMockObject niceMockForClass:[NSURLSessionTask class]];
+    [[[task stub] andReturn:tempPath] taskDescription];
+    [[[task stub] andReturn:nil] originalRequest];
+    [[[task stub] andReturn:nil] response];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    [self.hexUploader URLSession:self.hexUploader.session task:task didCompleteWithError:nil];
+#pragma clang diagnostic pop
+
+    XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:tempPath],
+                   @"temp upload body must be removed when its task completes");
 }
 
 //// Concurrency cap: more sendData: calls than kNRMAHexMaxInFlight (=4) must

--- a/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRMASessionDurationManagerTests.swift
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRMASessionDurationManagerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import NewRelic
+import NewRelic
 
 class NRMASessionDurationManagerTests: XCTestCase {
 


### PR DESCRIPTION
### Problem
Handled-exception (Hex) reports could be **lost on force-close**: the uploader used a
default in-process `NSURLSession`, so an upload that was in flight when the app was killed
died with the process, and the on-disk copy had already been removed when the report was
read for upload.

### Change
Route Hex uploads through a **background `NSURLSession`** so the OS (`nsurlsessiond`)
finishes the transfer out-of-process — it waits for connectivity, retries within its
resource window, and completes even after a force-close, reporting the result on the next
launch. This gives "stay until uploaded" without duplicating reports.