### PR TITLE
NR-581396 working per report delete from upload results

### DIFF
--- a/Agent/HandledException/HexUploadPublisher.hpp
+++ b/Agent/HandledException/HexUploadPublisher.hpp
@@ -7,6 +7,7 @@
 #define NEWRELICAGENT_HEXUPLOADPUBLISHER_H
 
 #include <Hex/HexPublisher.hpp>
+#include <functional>
 /*
  * Follows the HexPublisher interface for dependency injection into the NewRelic::Hex::HexController
  * This class uses a PIMPL to allow for Obj-c code to be called from C++ allowing access to the high-level networking
@@ -22,6 +23,14 @@ namespace NewRelic {
             HexUploadPublisher(const char* storePath, const char* appToken, const char* appVersion, const char* collectorAddress);
             HexUploadPublisher(const HexUploadPublisher&) = delete;
             virtual void publish(std::shared_ptr<HexContext>const& context);
+            // Uploads the report and invokes onComplete(true) when the persisted report
+            // should be removed (upload confirmed, HTTP < 400, OR the per-report retry
+            // limit was reached), or onComplete(false) to keep it for a later retry.
+            // reportId is the persisted file path; its filename is sent as a stable
+            // de-dupe identifier and used as the persisted retry-counter key.
+            virtual void publish(std::shared_ptr<HexContext>const& context,
+                                 const std::string& reportId,
+                                 std::function<void(bool shouldRemove)> onComplete);
             virtual ~HexUploadPublisher();
 //            void auditFlatBuffer(uint8_t* buf);
             void retry();

--- a/Agent/HandledException/HexUploadPublisher.mm
+++ b/Agent/HandledException/HexUploadPublisher.mm
@@ -37,6 +37,33 @@ namespace NewRelic {
             }
         }
 
+        void HexUploadPublisher::publish(std::shared_ptr<NewRelic::Hex::HexContext>const& context,
+                                         const std::string& reportId,
+                                         std::function<void(bool shouldRemove)> onComplete) {
+
+            auto buf = context->getBuilder()->GetBufferPointer();
+            auto size = context->getBuilder()->GetSize();
+
+            @autoreleasepool {
+                NSData* report = [NSData dataWithBytes:buf
+                                                length:size];
+                NSString* nsReportId = [NSString stringWithUTF8String:reportId.c_str()];
+
+                // Bridge the C++ completion to an Obj-C block the uploader fires once
+                // the upload terminally resolves. shouldRemove==YES => delete the
+                // persisted report (confirmed, or gave up after the retry limit).
+                __block std::function<void(bool)> cb = onComplete;
+                [uploader->wrapper sendData:report
+                                   reportId:nsReportId
+                                 completion:^(BOOL shouldRemove) {
+                    if (cb) {
+                        cb(shouldRemove);
+                    }
+                    cb = nullptr;
+                }];
+            }
+        }
+
         void HexUploadPublisher::retry(){
             [uploader->wrapper retryFailedTasks];
         }

--- a/Agent/HandledException/NRMAHandledExceptions.mm
+++ b/Agent/HandledException/NRMAHandledExceptions.mm
@@ -150,24 +150,27 @@ const NSString* kHexBackupStoreFolder = @"hexbkup/";
 }
 
 - (void) onHarvest {
-    if([NRMAFlags shouldEnableOfflineStorage]) {
-        NRMAReachability* r = [NewRelicInternalUtils reachability];
-        @synchronized(r) {
+    // Always upload handled exceptions from the on-disk store. Reports are persisted
+    // by HexController::submit on the record path, and the persisted-report flush
+    // deletes each report only once its upload is confirmed (see
+    // HexStore::markUploaded). This keeps unconfirmed reports on disk across
+    // launches / termination, and does not depend on the offline-storage flag —
+    // a report is never destroyed before we know it was uploaded.
+    NRMAReachability* r = [NewRelicInternalUtils reachability];
+    @synchronized(r) {
 #if TARGET_OS_WATCH
-            NRMANetworkStatus status = [NewRelicInternalUtils currentReachabilityStatusTo:[NSURL URLWithString:[NewRelicInternalUtils collectorHostHexURL]]];
+        NRMANetworkStatus status = [NewRelicInternalUtils currentReachabilityStatusTo:[NSURL URLWithString:[NewRelicInternalUtils collectorHostHexURL]]];
 #else
-            NRMANetworkStatus status = [r currentReachabilityStatus];
+        NRMANetworkStatus status = [r currentReachabilityStatus];
 #endif
-            if (status != NotReachable) {
-                [self processAndPublishPersistedReports]; // When using offline we always want to send from persisted because the keyContext doesn't persist.
-                _controller->resetKeyContext();
-                _publisher->retry();
-            }
+        if (status != NotReachable) {
+            [self processAndPublishPersistedReports];
+            // The in-memory keyContext is only a transient mirror of what submit()
+            // already persisted to disk; reset it so reports are uploaded from disk
+            // (the source of truth) without double-sending.
+            _controller->resetKeyContext();
+            _publisher->retry();
         }
-    } else {
-        _controller->publish();
-        _store->clear();
-        _publisher->retry();
     }
 }
 

--- a/Agent/HandledException/NRMAHexUploader.h
+++ b/Agent/HandledException/NRMAHexUploader.h
@@ -15,9 +15,10 @@
  * It is currently used in tandem with the HexUploadPublisher, which is a C++ class passed to the libMobileAgent to
  * manage Hex Report publication.
  *
- * This is the simpler version of the hex uploader (contrasting the NRMAHexBackgroundUploader) and only manages upload
- * data in memory. This means if the app catastrophically fails the last minute worth of Hex reports will be lost.
- * It is intended to replace this uploader variant with one that saves reports to disk to protect against that loss.
+ * This uploader manages the in-flight upload + retry of reports in memory. Reports are
+ * persisted on disk by the HexStore; sendData:reportId:completion: reports the terminal
+ * upload outcome back through `completion` so the store can delete a report only after
+ * its upload is confirmed (and keep it for retry / next launch otherwise).
  *
  * To replace this object in use look to the HExUploadPublisher where this NRMAHexUploader is injected as a PIMPL
  * object.
@@ -28,6 +29,14 @@
 - (instancetype) initWithHost:(NSString*)host;
 
 - (void) sendData:(NSData*)data;
+
+// Uploads a persisted report identified by `reportId` (its on-disk path). `reportId`'s
+// filename is sent as a stable de-dupe identifier so the collector can drop a report
+// already delivered in a prior session. `completion` is invoked exactly once with
+// shouldRemove=YES when the persisted report should be deleted (upload confirmed, an
+// oversized payload, or the in-memory retries were exhausted), or shouldRemove=NO to
+// keep it for a later attempt. `completion` may be nil.
+- (void) sendData:(NSData*)data reportId:(NSString*)reportId completion:(void(^)(BOOL shouldRemove))completion;
 
 - (void) retryFailedTasks;
 

--- a/Agent/HandledException/NRMAHexUploader.h
+++ b/Agent/HandledException/NRMAHexUploader.h
@@ -31,11 +31,9 @@
 - (void) sendData:(NSData*)data;
 
 // Uploads a persisted report identified by `reportId` (its on-disk path). `reportId`'s
-// filename is sent as a stable de-dupe identifier so the collector can drop a report
-// already delivered in a prior session. `completion` is invoked exactly once with
-// shouldRemove=YES when the persisted report should be deleted (upload confirmed, an
-// oversized payload, or the in-memory retries were exhausted), or shouldRemove=NO to
-// keep it for a later attempt. `completion` may be nil.
+// `completion` is invoked exactly once with shouldRemove=YES when the persisted report
+// should be deleted (upload confirmed, an oversized payload, or the in-memory retries
+// were exhausted), or shouldRemove=NO to keep it for a later attempt. `completion` may be nil.
 - (void) sendData:(NSData*)data reportId:(NSString*)reportId completion:(void(^)(BOOL shouldRemove))completion;
 
 - (void) retryFailedTasks;

--- a/Agent/HandledException/NRMAHexUploader.m
+++ b/Agent/HandledException/NRMAHexUploader.m
@@ -184,14 +184,6 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
     [request setValue:@"application/octet-stream" forHTTPHeaderField:@"Content-Type"];
     [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)data.length] forHTTPHeaderField:@"Content-Length"];
 
-    // Stable per-report de-dupe identifier (the report's persisted filename). It is
-    // identical when the same persisted report is re-uploaded after a termination, so
-    // the collector can drop the duplicate — the equivalent of the crash report's uuid
-    // (which cannot live in the handled-exception flatbuffer payload without a schema change).
-    if (payload.reportId.length) {
-        [request setValue:payload.reportId.lastPathComponent forHTTPHeaderField:@"X-NewRelic-HexReport-Id"];
-    }
-
     // Important: do NOT set HTTPBody on the request. NSURLSessionUploadTask
     // requires the payload to come exclusively from `fromData:`, and iOS
     // logs a warning + strips the body if both are present. Payload is

--- a/Agent/HandledException/NRMAHexUploader.m
+++ b/Agent/HandledException/NRMAHexUploader.m
@@ -17,6 +17,35 @@
 
 #define kNRMARetryLimit 2 // this will result in 2 additional upload attempts.
 
+// Couples an upload payload with the completion that reports its terminal outcome
+// back to the persisted store, plus the per-attempt HTTP-error flag. The completion
+// is fired exactly once at the terminal outcome (retries do not fire it). Its BOOL
+// means "remove the persisted report?": YES when the upload is confirmed or we have
+// permanently given up, NO to keep it for a later retry.
+@interface NRMAHexPayload : NSObject
+@property(strong) NSData* data;
+// Persisted report path; nil for non-persisted (live) uploads. Used as the stable
+// de-dupe identifier sent to the collector.
+@property(strong) NSString* reportId;
+@property(copy) void(^completion)(BOOL shouldRemove);
+// Set when a >= 400 HTTP response is seen for the current attempt; reset on retry.
+@property(assign) BOOL httpError;
+- (void) finishWith:(BOOL)shouldRemove;
+@end
+
+@implementation NRMAHexPayload
+- (void) finishWith:(BOOL)shouldRemove {
+    void(^c)(BOOL) = nil;
+    @synchronized (self) {
+        c = self.completion;
+        self.completion = nil; // guarantee exactly-once
+    }
+    if (c) {
+        c(shouldRemove);
+    }
+}
+@end
+
 // Bound how many uploads we hold in flight. Under low-bandwidth a default
 // session will queue tasks indefinitely; each task holds a socket FD until
 // the request completes or times out, exhausting the per-process FD limit.
@@ -39,7 +68,7 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
 @property(strong) NRMARetryTracker* taskStore;
 
 // Concurrency control — guarded by @synchronized(self).
-@property(strong) NSMutableArray<NSData*>* pendingPayloads;
+@property(strong) NSMutableArray<NRMAHexPayload*>* pendingPayloads;
 @property(assign) NSUInteger inFlightCount;
 
 // Tracks the upload payload for each in-flight / retryable request, keyed
@@ -47,8 +76,8 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
 // to come from `fromData:` (not from the request's HTTPBody — iOS warns and
 // strips it), so we cannot stash bytes on the request itself. This dictionary
 // is the parallel store that lets handledErroredRequest: rebuild the upload
-// with the original payload. Guarded by @synchronized(_payloadByRequest).
-@property(strong) NSMutableDictionary<NSURLRequest*, NSData*>* payloadByRequest;
+// with the original payload and fire its completion. Guarded by @synchronized(_payloadByRequest).
+@property(strong) NSMutableDictionary<NSURLRequest*, NRMAHexPayload*>* payloadByRequest;
 @end
 
 @implementation NRMAHexUploader
@@ -77,23 +106,47 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
 }
 
 - (void) sendData:(NSData*)data {
-    if (data == nil) return;
+    [self sendData:data reportId:nil completion:nil];
+}
+
+- (void) sendData:(NSData*)data reportId:(NSString*)reportId completion:(void(^)(BOOL shouldRemove))completion {
+    if (data == nil) {
+        // Nothing to upload; keep any persisted report untouched.
+        if (completion) completion(NO);
+        return;
+    }
 
     if ([data length] > kNRMAMaxPayloadSizeLimit) {
         NRLOG_AGENT_ERROR(@"Hex uploader handled exceptions payload is greater than 1 MB, discarding payload");
         [NRMASupportMetricHelper enqueueMaxPayloadSizeLimitMetric:@"f"];
+        // Can never be uploaded — remove it so we don't retry it every harvest
+        // (matches the crash uploader's handling of oversized reports).
+        if (completion) completion(YES);
         return;
     }
 
+    NRMAHexPayload* payload = [NRMAHexPayload new];
+    payload.data = data;
+    payload.reportId = reportId;
+    payload.completion = completion;
+
+    NSMutableArray<NRMAHexPayload*>* dropped = nil;
     @synchronized(self) {
         // Drop oldest first if pending grows beyond the soft cap. This is the
         // memory-spike guard the customer reported — under permanent offline
         // we'd otherwise hold every report in RAM forever.
         while (self.pendingPayloads.count >= kNRMAHexMaxPending) {
+            if (dropped == nil) dropped = [NSMutableArray new];
+            [dropped addObject:self.pendingPayloads.firstObject];
             [self.pendingPayloads removeObjectAtIndex:0];
             NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - dropping oldest pending payload, queue full");
         }
-        [self.pendingPayloads addObject:data];
+        [self.pendingPayloads addObject:payload];
+    }
+    // Report dropped payloads as not-confirmed outside the lock so their reports
+    // stay on disk for a later attempt.
+    for (NRMAHexPayload* d in dropped) {
+        [d finishWith:NO];
     }
     [self drainPending];
 }
@@ -101,7 +154,7 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
 // Caller must NOT hold @synchronized(self) when invoking. Drains as many
 // pending payloads as the in-flight cap allows; reentrant-safe.
 - (void) drainPending {
-    NSMutableArray<NSData*>* toSend = nil;
+    NSMutableArray<NRMAHexPayload*>* toSend = nil;
     @synchronized(self) {
         while (self.inFlightCount < kNRMAHexMaxInFlight && self.pendingPayloads.count > 0) {
             if (toSend == nil) toSend = [NSMutableArray new];
@@ -110,23 +163,34 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
             self.inFlightCount++;
         }
     }
-    for (NSData* data in toSend) {
-        [self launchUpload:data];
+    for (NRMAHexPayload* payload in toSend) {
+        [self launchUpload:payload];
     }
 }
 
-- (void) launchUpload:(NSData*)data {
+- (void) launchUpload:(NRMAHexPayload*)payload {
+    NSData* data = payload.data;
     NSMutableURLRequest* request = [self newPostWithURI:self.host];
     if (request == nil) {
         @synchronized(self) {
             if (self.inFlightCount > 0) self.inFlightCount--;
         }
+        // Couldn't build the request; not confirmed — keep the report for a later attempt.
+        [payload finishWith:NO];
         return;
     }
 
     request.HTTPMethod = @"POST";
     [request setValue:@"application/octet-stream" forHTTPHeaderField:@"Content-Type"];
     [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)data.length] forHTTPHeaderField:@"Content-Length"];
+
+    // Stable per-report de-dupe identifier (the report's persisted filename). It is
+    // identical when the same persisted report is re-uploaded after a termination, so
+    // the collector can drop the duplicate — the equivalent of the crash report's uuid
+    // (which cannot live in the handled-exception flatbuffer payload without a schema change).
+    if (payload.reportId.length) {
+        [request setValue:payload.reportId.lastPathComponent forHTTPHeaderField:@"X-NewRelic-HexReport-Id"];
+    }
 
     // Important: do NOT set HTTPBody on the request. NSURLSessionUploadTask
     // requires the payload to come exclusively from `fromData:`, and iOS
@@ -138,8 +202,9 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
     NSURLSessionUploadTask* uploadTask = [self.session uploadTaskWithRequest:request fromData:data];
     NSURLRequest* key = uploadTask.originalRequest ?: request;
 
+    payload.httpError = NO;
     @synchronized(self.payloadByRequest) {
-        self.payloadByRequest[key] = data;
+        self.payloadByRequest[key] = payload;
     }
     [self.taskStore track:key];
     [uploadTask resume];
@@ -176,24 +241,36 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
                 task:(NSURLSessionTask*)task
 didCompleteWithError:(nullable NSError*)error {
 
-    if (error) {
+    NSURLRequest* key = task.originalRequest;
+    NRMAHexPayload* payload = nil;
+    @synchronized(self.payloadByRequest) {
+        payload = key ? self.payloadByRequest[key] : nil;
+    }
+    // A >= 400 response (recorded in didReceiveResponse) completes without a
+    // transport error, so fold that into the failure decision here — this is
+    // the single terminal handler for the attempt.
+    BOOL httpError = payload.httpError;
+
+    if (error || httpError) {
 #if !TARGET_OS_WATCH
         if (error.code == kCFURLErrorCancelled) {
             NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - Handled exception upload cancelled: %@", error);
         }
-        else {
+        else if (error) {
             NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - failed to upload handled exception report: %@", [error localizedDescription]);
         }
 #endif
-        [self handledErroredRequest:task.originalRequest];
+        [self handledErroredRequest:key];
     } else {
         NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Handled exception upload completed successfully");
-        if (task.originalRequest) {
+        if (key) {
             @synchronized(self.payloadByRequest) {
-                [self.payloadByRequest removeObjectForKey:task.originalRequest];
+                [self.payloadByRequest removeObjectForKey:key];
             }
         }
-        [self.taskStore untrack:task.originalRequest];
+        [self.taskStore untrack:key];
+        // Upload confirmed — let the store delete the persisted report (shouldRemove = YES).
+        [payload finishWith:YES];
     }
 
     @synchronized(self) {
@@ -213,7 +290,14 @@ didCompleteWithError:(nullable NSError*)error {
     if ([response isKindOfClass:[NSHTTPURLResponse class]] &&
         ((NSHTTPURLResponse*)response).statusCode >= 400) {
         NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - failed to upload handled exception report: %@", response.description);
-        [self handledErroredRequest:dataTask.originalRequest];
+        // Record the HTTP failure; the terminal retry/abandon decision (and the
+        // payload completion) is made in didCompleteWithError so it happens
+        // exactly once per attempt.
+        NSURLRequest* key = dataTask.originalRequest;
+        @synchronized(self.payloadByRequest) {
+            NRMAHexPayload* payload = key ? self.payloadByRequest[key] : nil;
+            payload.httpError = YES;
+        }
     }
     else {
         // Enqueue Data Usage Supportability Metric for /f if request is successful.
@@ -228,9 +312,13 @@ didCompleteWithError:(nullable NSError*)error {
 - (void) handledErroredRequest:(NSURLRequest*)request {
     if (request == nil) return;
 
+    NRMAHexPayload* payload = nil;
+    @synchronized(self.payloadByRequest) {
+        payload = self.payloadByRequest[request];
+    }
+
     // If we're offline, don't burn FDs/sockets cycling failed retries —
-    // queue the task and let the next harvest's retryFailedTasks fire it
-    // when reachability returns.
+    // keep the report on disk and let the next harvest retry when reachable.
 #if !TARGET_OS_WATCH
     NRMAReachability* r = [NewRelicInternalUtils reachability];
     BOOL offline = NO;
@@ -243,29 +331,34 @@ didCompleteWithError:(nullable NSError*)error {
             [self.payloadByRequest removeObjectForKey:request];
         }
         [self.taskStore untrack:request];
+        [payload finishWith:NO];
         return;
     }
 #endif
 
     if ([self.taskStore shouldRetryTask:request]) {
         NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - retrying handled exception report upload");
-        NSData* body = nil;
-        @synchronized(self.payloadByRequest) {
-            body = self.payloadByRequest[request];
-        }
+        NSData* body = payload.data;
         if (body == nil || body.length == 0) {
             NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - retry has no payload, abandoning report");
+            @synchronized(self.payloadByRequest) {
+                [self.payloadByRequest removeObjectForKey:request];
+            }
             [self.taskStore untrack:request];
+            [payload finishWith:NO];
             return;
         }
         NSURLSessionUploadTask* uploadTask = [self.session uploadTaskWithRequest:request fromData:body];
-        // The session may produce a fresh originalRequest copy on the new
-        // task — rekey the payload store so the next failure path can find
-        // the bytes again.
+        // The session may produce a fresh originalRequest copy on the new task.
+        // Requests with identical content are -isEqual:, so the retried task's
+        // originalRequest maps to the same payloadByRequest / retry-tracker slot;
+        // re-keying just ensures the payload is found again. Reset the per-attempt
+        // HTTP-error flag so the retry starts clean.
+        payload.httpError = NO;
         NSURLRequest* newKey = uploadTask.originalRequest;
-        if (newKey && ![newKey isEqual:request]) {
+        if (newKey) {
             @synchronized(self.payloadByRequest) {
-                self.payloadByRequest[newKey] = body;
+                self.payloadByRequest[newKey] = payload;
             }
         }
         @synchronized(self.retryQueue) {
@@ -277,6 +370,8 @@ didCompleteWithError:(nullable NSError*)error {
             [self.payloadByRequest removeObjectForKey:request];
         }
         [self.taskStore untrack:request];
+        // Retries exhausted — not confirmed; remove the report on disk
+        [payload finishWith:YES];
     }
 }
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/Handled-Exception-Tests/TestHexUploader.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Handled-Exception-Tests/TestHexUploader.m
@@ -25,7 +25,8 @@
 @property(strong) NSURLSession* session;
 @property(strong) NSMutableArray* pendingPayloads;
 @property(assign) NSUInteger inFlightCount;
-@property(strong) NSMutableDictionary<NSURLRequest*, NSData*>* payloadByRequest;
+// Values are NRMAHexPayload (private to NRMAHexUploader.m); accessed here via KVC.
+@property(strong) NSMutableDictionary* payloadByRequest;
 @end
 
 @interface TestHexUploader : NRMAAgentTestBase {
@@ -78,17 +79,33 @@
     id mockUploader = [OCMockObject partialMockForObject:self.hexUploader];
     [[mockUploader expect] handledErroredRequest:OCMOCK_ANY];
 
+    // A >= 400 response is recorded against the in-flight payload, but the
+    // terminal retry/abandon decision is made in didCompleteWithError so it
+    // happens exactly once per attempt. Register a payload + a task carrying a
+    // matching originalRequest so the flow can find it.
+    NSURLRequest* request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost/f"]];
+    id payload = [NSClassFromString(@"NRMAHexPayload") new];
+    [payload setValue:[@"x" dataUsingEncoding:NSUTF8StringEncoding] forKey:@"data"];
+    @synchronized(self.hexUploader.payloadByRequest) {
+        self.hexUploader.payloadByRequest[request] = payload;
+    }
+
+    id mockTask = [OCMockObject niceMockForClass:[NSURLSessionDataTask class]];
+    [[[mockTask stub] andReturn:request] originalRequest];
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-    NSHTTPURLResponse* response = [[NSHTTPURLResponse alloc] initWithURL:nil
+    NSHTTPURLResponse* response = [[NSHTTPURLResponse alloc] initWithURL:request
                                                               statusCode:400
                                                              HTTPVersion:@"1.1"
                                                             headerFields:nil];
 
     [mockUploader URLSession:nil
-                    dataTask:nil
+                    dataTask:mockTask
           didReceiveResponse:response
            completionHandler:^(NSURLSessionResponseDisposition d){}];
+    // Completion of the task is where the recorded HTTP error is acted on.
+    [mockUploader URLSession:nil task:mockTask didCompleteWithError:nil];
 #pragma clang diagnostic pop
 
     XCTAssertNoThrow([mockUploader verify]);
@@ -223,7 +240,7 @@
     // has been launched and its payload recorded. The task may already have
     // failed under the simulator (no listener), but the dict entry persists
     // for the duration of any retry chain — so it must be present here.
-    NSDictionary<NSURLRequest*, NSData*>* snapshot = nil;
+    NSDictionary* snapshot = nil;
     @synchronized(self.hexUploader.payloadByRequest) {
         snapshot = [self.hexUploader.payloadByRequest copy];
     }
@@ -235,7 +252,9 @@
         // The request itself must NOT carry HTTPBody — that would trip the
         // iOS upload-task warning and strip the body.
         XCTAssertNil(key.HTTPBody, @"upload-task request must have no HTTPBody");
-        if (snapshot[key].length == data.length) {
+        // Values are NRMAHexPayload; the original bytes live on its `data` property.
+        NSData* trackedData = [snapshot[key] valueForKey:@"data"];
+        if (trackedData.length == data.length) {
             foundOriginalLength = YES;
         }
     }

--- a/libMobileAgent/src/Hex/include/Hex/HexPublisher.hpp
+++ b/libMobileAgent/src/Hex/include/Hex/HexPublisher.hpp
@@ -7,6 +7,7 @@
 #define LIBMOBILEAGENT_HEXPUBLISHER_HPP
 
 #include <Hex/HexContext.hpp>
+#include <functional>
 
 namespace NewRelic {
     namespace Hex {
@@ -14,6 +15,17 @@ namespace NewRelic {
 
         public:
             virtual void publish(std::shared_ptr<HexContext> const& context);
+
+            // Publish a persisted report identified by reportId (its on-disk path) and
+            // report the outcome via onComplete: true means "remove the persisted report"
+            // (the upload was confirmed, OR it permanently gave up after the retry limit),
+            // false means "keep it" for a later retry. reportId is also used as a stable
+            // de-dupe / idempotency identifier so the collector can drop a report that was
+            // already delivered in a previous session. The default implementation has no
+            // upload result to report and simply completes with remove=true after publishing.
+            virtual void publish(std::shared_ptr<HexContext> const& context,
+                                 const std::string& reportId,
+                                 std::function<void(bool shouldRemove)> onComplete);
 
             std::string lastPublishedFile();
 

--- a/libMobileAgent/src/Hex/include/Hex/HexStore.hpp
+++ b/libMobileAgent/src/Hex/include/Hex/HexStore.hpp
@@ -10,6 +10,8 @@
 #include <memory>
 #include <string>
 #include <future>
+#include <functional>
+#include <mutex>
 #include <Hex/HexReport.hpp>
 
 namespace NewRelic {
@@ -23,11 +25,30 @@ namespace NewRelic {
 
             /*
              * readAll()
-             * executes callback closure on new thread with flatbuffer data array as parameter.
+             * executes callback closure on new thread with the flatbuffer data array
+             * and the report's on-disk path (reportId) as parameters.
+             *
+             * Unlike the previous implementation, readAll() does NOT delete a report
+             * after handing it to the callback. The report stays on disk and is marked
+             * in-flight; the consumer must call markUploaded(reportId) once the upload
+             * is confirmed (which deletes the file) or markFailed(reportId) to release
+             * it for a later retry. Reports already in flight are skipped so a pending
+             * upload is not read and re-sent on the next pass. A report whose upload is
+             * never confirmed (e.g. the app is terminated mid-upload) therefore survives
+             * on disk and is retried on the next launch.
+             *
+             * Corrupt / empty files are still removed inline since they can never upload.
              *
              * The uint8_t buffer param will be freed after the closure is complete.
              */
-            std::future<bool> readAll(std::function<void(uint8_t*, std::size_t)> callback);
+            std::future<bool> readAll(std::function<void(uint8_t*, std::size_t, const std::string& reportId)> callback);
+
+            // Upload confirmed: delete the persisted report and clear its in-flight mark.
+            void markUploaded(const std::string& reportId);
+
+            // Upload not confirmed: clear the in-flight mark only, leaving the file on
+            // disk so the next readAll() pass picks it up again.
+            void markFailed(const std::string& reportId);
 
             void clear();
 
@@ -40,6 +61,13 @@ namespace NewRelic {
             static const char* FILE_BASE;
             static const char* FILE_EXTENSION;
             mutable std::mutex _storeMutex;
+            // NOTE: the set of reports currently in flight (handed to a publisher,
+            // upload not yet resolved) is intentionally process-global rather than a
+            // member here — see inFlightSet() in HexStore.cxx. Multiple HexStore
+            // instances can exist over the same directory (the agent re-runs
+            // onSessionStart on foreground transitions), and a per-instance set would
+            // let each instance upload the same report. markUploaded()/markFailed()
+            // resolve a claim in that global set.
         };
     }
 }

--- a/libMobileAgent/src/Hex/src/HexPersistenceManager.cxx
+++ b/libMobileAgent/src/Hex/src/HexPersistenceManager.cxx
@@ -19,7 +19,10 @@ HexPersistenceManager::HexPersistenceManager(std::shared_ptr<HexStore>& store,
 }
 
 void NewRelic::Hex::HexPersistenceManager::retrieveAndPublishReports() {
-    auto future = _store->readAll([this](uint8_t* buf, std::size_t size) {
+    // Capture the store by value (shared_ptr) so the upload-completion callbacks,
+    // which fire asynchronously after this method returns, keep it alive.
+    std::shared_ptr<HexStore> store = _store;
+    auto future = _store->readAll([this, store](uint8_t* buf, std::size_t size, const std::string& reportId) {
         auto verifier = flatbuffers::Verifier(buf, size);
         if (fbs::VerifyHexAgentDataBuffer(verifier)) {
             auto agentDataObj = UnPackHexAgentData(buf, nullptr);
@@ -32,10 +35,26 @@ void NewRelic::Hex::HexPersistenceManager::retrieveAndPublishReports() {
             auto bundle = fbs::CreateHexAgentDataBundle(*context->getBuilder(), agentDataVector);
             FinishHexAgentDataBundleBuffer(*context->getBuilder(), bundle);
 
-            // Publish the context for this agent data
+            // Publish the context for this agent data. The report is removed from disk
+            // only when the publisher says so: shouldRemove==true on a confirmed upload
+            // OR after the per-report retry limit is reached; false keeps it for retry.
             if (context) {
-                _publisher->publish(context);
+                _publisher->publish(context, reportId, [store, reportId](bool shouldRemove) {
+                    if (shouldRemove) {
+                        store->markUploaded(reportId);
+                    } else {
+                        store->markFailed(reportId);
+                    }
+                });
+            } else {
+                // Could not build a context to publish; release the in-flight mark
+                // so the report is retried on the next pass.
+                store->markFailed(reportId);
             }
+        } else {
+            // Un-verifiable flatbuffer: it can never be uploaded, so drop it
+            // permanently rather than retrying it forever.
+            store->markUploaded(reportId);
         }
     });
 

--- a/libMobileAgent/src/Hex/src/HexPublisher.cxx
+++ b/libMobileAgent/src/Hex/src/HexPublisher.cxx
@@ -18,6 +18,18 @@ void NewRelic::Hex::HexPublisher::publish(std::shared_ptr<NewRelic::Hex::HexCont
     filename = writeBytesToStore(bufPointer, size);
 }
 
+void NewRelic::Hex::HexPublisher::publish(std::shared_ptr<NewRelic::Hex::HexContext> const& context,
+                                          const std::string& reportId,
+                                          std::function<void(bool shouldRemove)> onComplete) {
+    // Base publisher has no asynchronous upload to await; publish and tell the caller
+    // it is safe to remove the persisted report.
+    (void)reportId;
+    publish(context);
+    if (onComplete) {
+        onComplete(true);
+    }
+}
+
 std::string HexPublisher::lastPublishedFile() {
     return filename;
 }

--- a/libMobileAgent/src/Hex/src/HexStore.cxx
+++ b/libMobileAgent/src/Hex/src/HexStore.cxx
@@ -15,6 +15,8 @@
 #include <algorithm>
 #include <memory>
 #include <vector>
+#include <mutex>
+#include <unordered_set>
 #include "Hex/HexStore.hpp"
 #include <Utilities/libLogger.hpp>
 #include <cstddef>
@@ -22,6 +24,25 @@
 #include "jserror_generated.h"
 
 namespace {
+    // Process-global set of report paths currently handed to a publisher whose upload
+    // has not yet resolved. It is intentionally NOT per-HexStore: the agent can create
+    // more than one NRMAHandledExceptions (hence more than one HexStore) over the SAME
+    // on-disk directory during startup (e.g. initial start + the foreground-transition
+    // session restart both run onSessionStart). A per-instance set would let each store
+    // read and upload the same .fbad file. Keying a single process-wide set by absolute
+    // file path guarantees each report is published at most once per process, regardless
+    // of how many HexStore instances exist. Function-local statics avoid static-init-order
+    // issues. The set is in-memory, so a fresh process starts empty and re-reads any file
+    // still on disk (the desired crash/termination recovery).
+    std::mutex& inFlightMutex() {
+        static std::mutex m;
+        return m;
+    }
+    std::unordered_set<std::string>& inFlightSet() {
+        static std::unordered_set<std::string> s;
+        return s;
+    }
+
     // Max number of persisted .fbad reports we keep on disk. Beyond this we evict
     // the oldest by mtime. Bounds disk + FD pressure when uploads cannot drain.
     constexpr std::size_t kMaxBacklog = 100;
@@ -123,7 +144,7 @@ namespace NewRelic {
             // file closed by UniqueFile dtor on every exit path.
         }
 
-        std::future<bool> HexStore::readAll(std::function<void(uint8_t*,std::size_t)> callback) {
+        std::future<bool> HexStore::readAll(std::function<void(uint8_t*,std::size_t,const std::string&)> callback) {
 
             std::string path = storePath;
             return std::async(std::launch::async, [callback, path, this]() {
@@ -154,6 +175,17 @@ namespace NewRelic {
                     }
 
                     std::string fullPath = path + "/" + filename;
+
+                    // Skip reports whose upload from a prior pass (or a concurrent
+                    // HexStore instance over the same directory) has not yet resolved,
+                    // so a pending report is not read and uploaded twice.
+                    {
+                        std::lock_guard<std::mutex> inFlightLock(inFlightMutex());
+                        if (inFlightSet().count(fullPath)) {
+                            continue;
+                        }
+                    }
+
                     std::ifstream file{fullPath.c_str(), std::ios::binary | std::ios::ate};
                     if (!file.good()) {
                         file.close();
@@ -165,7 +197,8 @@ namespace NewRelic {
                     if (size <= 0) {
                         // Corrupt / empty file — log, drop, and skip. Previously the code
                         // fell through to `new uint8_t[size]` with size == -1, allocating
-                        // ~SIZE_MAX bytes (crash).
+                        // ~SIZE_MAX bytes (crash). Corrupt files can never upload, so they
+                        // are still removed inline.
                         LLOG_ERROR("dropping handled exception report (size %lld): %s",
                                    static_cast<long long>(size), filename.c_str());
                         file.close();
@@ -182,25 +215,69 @@ namespace NewRelic {
                         continue;
                     }
                     if (file.read(reinterpret_cast<char*>(buf.get()), size)) {
+                        // Claim the report BEFORE handing off so an upload that resolves
+                        // synchronously (or a concurrent pass / another HexStore instance)
+                        // can't double-process it. Claim + skip-check share inFlightMutex,
+                        // so the claim is atomic with respect to other readers.
+                        {
+                            std::lock_guard<std::mutex> inFlightLock(inFlightMutex());
+                            if (!inFlightSet().insert(fullPath).second) {
+                                // Another reader claimed it between the skip-check above
+                                // and here; leave it to them.
+                                file.close();
+                                continue;
+                            }
+                        }
                         try {
-                            callback(buf.get(), static_cast<std::size_t>(size));
+                            callback(buf.get(), static_cast<std::size_t>(size), fullPath);
                             ++flushed;
                         } catch (...) {
                             // Never let a publisher exception leak the DIR* / buffer.
+                            // The upload was never queued, so release the claim
+                            // and leave the file for the next pass.
                             LLOG_ERROR("publisher threw while consuming %s — continuing",
                                        filename.c_str());
+                            std::lock_guard<std::mutex> inFlightLock(inFlightMutex());
+                            inFlightSet().erase(fullPath);
                         }
                     } else {
                         LLOG_ERROR("failed to read file %s", filename.c_str());
                     }
                     file.close();
-                    std::remove(fullPath.c_str());
+                    // NOTE: the report is intentionally NOT removed here. It is deleted
+                    // only once its upload is confirmed via markUploaded().
                 }
                 return true;
             });
         }
 
+        void HexStore::markUploaded(const std::string& reportId) {
+            std::lock_guard<std::mutex> inFlightLock(inFlightMutex());
+            std::remove(reportId.c_str());
+            inFlightSet().erase(reportId);
+        }
+
+        void HexStore::markFailed(const std::string& reportId) {
+            std::lock_guard<std::mutex> inFlightLock(inFlightMutex());
+            // Leave the file on disk; just release the claim so the next readAll()
+            // pass re-reads and re-uploads it.
+            inFlightSet().erase(reportId);
+        }
+
         void HexStore::clear() {
+            {
+                // Release only this store's in-flight claims (the global set may hold
+                // claims for other directories).
+                std::lock_guard<std::mutex> inFlightLock(inFlightMutex());
+                auto& s = inFlightSet();
+                for (auto it = s.begin(); it != s.end(); ) {
+                    if (it->rfind(storePath, 0) == 0) {
+                        it = s.erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+            }
             std::string path = storePath;
             // Honor the original async intent without the std::async-discarded-future
             // gotcha (~future() of a launch::async future blocks). Use a detached

--- a/libMobileAgent/src/Hex/src/HexStore.cxx
+++ b/libMobileAgent/src/Hex/src/HexStore.cxx
@@ -270,8 +270,12 @@ namespace NewRelic {
                 // claims for other directories).
                 std::lock_guard<std::mutex> inFlightLock(inFlightMutex());
                 auto& s = inFlightSet();
+                // Match the store dir followed by a separator so sibling stores
+                // sharing a prefix (e.g. "/hex" vs "/hex2") don't get erased.
+                // Every claim is keyed as storePath + "/" + filename.
+                std::string prefix = storePath + "/";
                 for (auto it = s.begin(); it != s.end(); ) {
-                    if (it->rfind(storePath, 0) == 0) {
+                    if (it->rfind(prefix, 0) == 0) {
                         it = s.erase(it);
                     } else {
                         ++it;

--- a/libMobileAgent/test/HexTests/HexStore_test.cxx
+++ b/libMobileAgent/test/HexTests/HexStore_test.cxx
@@ -83,7 +83,7 @@ TEST_F(HexStoreTest, testStoreLifeCycle) {
 
     ASSERT_TRUE(stat (TESTFILE.c_str(), &buffer) == 0);
 
-    auto f = store.readAll([](uint8_t* buf, size_t size) {
+    auto f = store.readAll([](uint8_t* buf, size_t size, const std::string& reportId) {
         ASSERT_TRUE(buf != NULL);
         auto agentData = GetAgentData(buf);
         ASSERT_TRUE(agentData != NULL);
@@ -100,7 +100,7 @@ TEST_F(HexStoreTest, testStoreLifeCycle) {
     HexStoreTestChild store("./inaccessible");
 
     ASSERT_NO_THROW(store.store(report));
-    auto f = store.readAll([](uint8_t* buf, size_t size) {
+    auto f = store.readAll([](uint8_t* buf, size_t size, const std::string& reportId) {
         assert(false);
     });
     ASSERT_FALSE(f.get());
@@ -193,7 +193,7 @@ TEST_F(HexStoreTest, testCorruptFileSkipped) {
 
     NewRelic::Hex::HexStore store(dir.c_str());
     std::atomic<int> callbackCount{0};
-    auto f = store.readAll([&](uint8_t* buf, size_t size) {
+    auto f = store.readAll([&](uint8_t* buf, size_t size, const std::string& reportId) {
         callbackCount++;
     });
     ASSERT_TRUE(f.get());
@@ -203,6 +203,129 @@ TEST_F(HexStoreTest, testCorruptFileSkipped) {
     ASSERT_EQ(callbackCount.load(), 0);
     ASSERT_EQ(countFilesWithExtension(dir, ext), 0u);
 
+    rmdir(dir.c_str());
+}
+
+// readAll() must NOT delete a valid report after handing it to the callback;
+// the report is removed only once markUploaded() confirms its upload. This is
+// the core "keep until confirmed" guarantee.
+TEST_F(HexStoreTest, testReadAllKeepsReportUntilMarkedUploaded) {
+    const std::string dir = "./hexbkup_keep";
+    const std::string ext = ".fbad";
+    mkpath_np(dir.c_str(), 0755);
+    removeAllWithExtension(dir, ext);
+
+    // A non-empty report file (readAll does not verify flatbuffer contents).
+    std::string reportPath = dir + "/NRExceptionReport_keep" + ext;
+    { std::ofstream f(reportPath, std::ios::binary); f << "report-bytes"; }
+    ASSERT_EQ(countFilesWithExtension(dir, ext), 1u);
+
+    NewRelic::Hex::HexStore store(dir.c_str());
+    std::atomic<int> callbackCount{0};
+    std::string capturedId;
+    auto f = store.readAll([&](uint8_t* buf, size_t size, const std::string& reportId) {
+        callbackCount++;
+        capturedId = reportId;
+    });
+    ASSERT_TRUE(f.get());
+
+    // Callback fired and the file is STILL on disk (not deleted by readAll).
+    ASSERT_EQ(callbackCount.load(), 1);
+    ASSERT_EQ(countFilesWithExtension(dir, ext), 1u);
+    ASSERT_FALSE(capturedId.empty());
+
+    // Confirming the upload deletes the file.
+    store.markUploaded(capturedId);
+    ASSERT_EQ(countFilesWithExtension(dir, ext), 0u);
+
+    removeAllWithExtension(dir, ext);
+    rmdir(dir.c_str());
+}
+
+// While a report is in flight (handed to the callback but not yet confirmed),
+// a subsequent readAll() must skip it so it is not uploaded twice. markFailed()
+// releases it so a later pass retries it.
+TEST_F(HexStoreTest, testInFlightReportSkippedUntilReleased) {
+    const std::string dir = "./hexbkup_inflight";
+    const std::string ext = ".fbad";
+    mkpath_np(dir.c_str(), 0755);
+    removeAllWithExtension(dir, ext);
+
+    std::string reportPath = dir + "/NRExceptionReport_inflight" + ext;
+    { std::ofstream f(reportPath, std::ios::binary); f << "report-bytes"; }
+
+    NewRelic::Hex::HexStore store(dir.c_str());
+
+    // First pass marks the report in flight (callback does not confirm it).
+    std::atomic<int> count1{0};
+    std::string capturedId;
+    auto f1 = store.readAll([&](uint8_t* buf, size_t size, const std::string& reportId) {
+        count1++;
+        capturedId = reportId;
+    });
+    ASSERT_TRUE(f1.get());
+    ASSERT_EQ(count1.load(), 1);
+
+    // Second pass must skip the still-in-flight report.
+    std::atomic<int> count2{0};
+    auto f2 = store.readAll([&](uint8_t* buf, size_t size, const std::string& reportId) {
+        count2++;
+    });
+    ASSERT_TRUE(f2.get());
+    ASSERT_EQ(count2.load(), 0);
+
+    // Releasing it (upload not confirmed) lets the next pass pick it up again.
+    store.markFailed(capturedId);
+    std::atomic<int> count3{0};
+    auto f3 = store.readAll([&](uint8_t* buf, size_t size, const std::string& reportId) {
+        count3++;
+    });
+    ASSERT_TRUE(f3.get());
+    ASSERT_EQ(count3.load(), 1);
+
+    removeAllWithExtension(dir, ext);
+    rmdir(dir.c_str());
+}
+
+// The in-flight claim is process-global, not per-HexStore: two HexStore instances over
+// the SAME directory (as happens when the agent re-runs onSessionStart and creates a
+// second NRMAHandledExceptions/HexStore on a foreground transition) must not BOTH read
+// and upload the same report. This is the guard against duplicate uploads from double
+// initialization.
+TEST_F(HexStoreTest, testInFlightClaimSharedAcrossInstances) {
+    const std::string dir = "./hexbkup_shared";
+    const std::string ext = ".fbad";
+    mkpath_np(dir.c_str(), 0755);
+    removeAllWithExtension(dir, ext);
+
+    std::string reportPath = dir + "/NRExceptionReport_shared" + ext;
+    { std::ofstream f(reportPath, std::ios::binary); f << "report-bytes"; }
+
+    NewRelic::Hex::HexStore storeA(dir.c_str());
+    NewRelic::Hex::HexStore storeB(dir.c_str());
+
+    std::atomic<int> countA{0};
+    std::string capturedId;
+    auto fA = storeA.readAll([&](uint8_t* buf, size_t size, const std::string& reportId) {
+        countA++;
+        capturedId = reportId;
+    });
+    ASSERT_TRUE(fA.get());
+    ASSERT_EQ(countA.load(), 1);
+
+    // Second instance must skip the report claimed (in-flight) by the first.
+    std::atomic<int> countB{0};
+    auto fB = storeB.readAll([&](uint8_t* buf, size_t size, const std::string& reportId) {
+        countB++;
+    });
+    ASSERT_TRUE(fB.get());
+    ASSERT_EQ(countB.load(), 0);
+
+    // Resolving the claim deletes the file; neither instance uploaded it twice.
+    storeA.markUploaded(capturedId);
+    ASSERT_EQ(countFilesWithExtension(dir, ext), 0u);
+
+    removeAllWithExtension(dir, ext);
     rmdir(dir.c_str());
 }
 


### PR DESCRIPTION
Changed the hex uploader to track report uploads with a reportId so that they can be deleted when uploading either succeeds or fails three times.