### PR TITLE
NR-581396 task-keyed payloadByTaskId, per-payload attempts counter, handledErroredTask:payload:.

### DIFF
--- a/Agent/HandledException/NRMAHexUploader.m
+++ b/Agent/HandledException/NRMAHexUploader.m
@@ -7,7 +7,6 @@
 //
 
 #import "NRMAHexUploader.h"
-#import "NRMARetryTracker.h"
 #import "NRLogger.h"
 #include <libkern/OSAtomic.h>
 #import "NRMASupportMetricHelper.h"
@@ -24,12 +23,18 @@
 // permanently given up, NO to keep it for a later retry.
 @interface NRMAHexPayload : NSObject
 @property(strong) NSData* data;
-// Persisted report path; nil for non-persisted (live) uploads. Used as the stable
-// de-dupe identifier sent to the collector.
+// Persisted report path; nil for non-persisted (live) uploads.
 @property(strong) NSString* reportId;
 @property(copy) void(^completion)(BOOL shouldRemove);
 // Set when a >= 400 HTTP response is seen for the current attempt; reset on retry.
 @property(assign) BOOL httpError;
+// Number of retries already performed for this payload. The retry count lives here,
+// on the payload, rather than in an external request-keyed tracker: every hex upload
+// targets the same URL with no HTTPBody (the bytes go via -fromData:), so their
+// NSURLRequests are all -isEqual: and a request-keyed counter is shared across
+// unrelated reports. The payload survives across a retry (it is re-registered under
+// the new task's identifier), so it is the natural owner of the counter.
+@property(assign) NSUInteger attempts;
 - (void) finishWith:(BOOL)shouldRemove;
 @end
 
@@ -65,19 +70,22 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
 @property(strong) NSString* host;
 @property(strong) NSMutableArray* retryQueue;
 @property(strong) NSURLSession* session;
-@property(strong) NRMARetryTracker* taskStore;
 
 // Concurrency control — guarded by @synchronized(self).
 @property(strong) NSMutableArray<NRMAHexPayload*>* pendingPayloads;
 @property(assign) NSUInteger inFlightCount;
 
-// Tracks the upload payload for each in-flight / retryable request, keyed
-// by content-equal NSURLRequest. NSURLSessionUploadTask requires the payload
-// to come from `fromData:` (not from the request's HTTPBody — iOS warns and
-// strips it), so we cannot stash bytes on the request itself. This dictionary
-// is the parallel store that lets handledErroredRequest: rebuild the upload
-// with the original payload and fire its completion. Guarded by @synchronized(_payloadByRequest).
-@property(strong) NSMutableDictionary<NSURLRequest*, NRMAHexPayload*>* payloadByRequest;
+// Maps an in-flight / retryable task to its payload, keyed by the task's
+// -taskIdentifier (unique within an NSURLSession). It CANNOT be keyed by the
+// NSURLRequest: NSURLSessionUploadTask requires the payload to come from
+// `fromData:` (setting HTTPBody makes iOS warn and strip it), so every hex
+// request has the same URL/method/headers and no body — they are all -isEqual:
+// and would collide on a single dictionary slot. When that happened, concurrent
+// uploads overwrote each other's payload and completions resolved to the wrong
+// (or a removed) payload, so a confirmed report's file was never deleted and got
+// re-uploaded on the next launch (duplicate reports). Keying by taskIdentifier
+// gives each upload its own slot. Guarded by @synchronized(_payloadByTaskId).
+@property(strong) NSMutableDictionary<NSNumber*, NRMAHexPayload*>* payloadByTaskId;
 @end
 
 @implementation NRMAHexUploader
@@ -88,7 +96,7 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
         self.host = host;
         self.retryQueue = [NSMutableArray new];
         self.pendingPayloads = [NSMutableArray new];
-        self.payloadByRequest = [NSMutableDictionary new];
+        self.payloadByTaskId = [NSMutableDictionary new];
         self.inFlightCount = 0;
 
         NSURLSessionConfiguration* sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
@@ -100,7 +108,6 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
         self.session = [NSURLSession sessionWithConfiguration:sessionConfiguration
                                                      delegate:self
                                                 delegateQueue:nil];
-        self.taskStore = [[NRMARetryTracker alloc] initWithRetryLimit:kNRMARetryLimit];
     }
     return self;
 }
@@ -186,19 +193,18 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
 
     // Important: do NOT set HTTPBody on the request. NSURLSessionUploadTask
     // requires the payload to come exclusively from `fromData:`, and iOS
-    // logs a warning + strips the body if both are present. Payload is
-    // tracked separately in payloadByRequest so retries can rebuild.
+    // logs a warning + strips the body if both are present. The payload is
+    // tracked separately in payloadByTaskId (keyed by task identifier) so
+    // retries can rebuild and completions can find the right payload.
 
     NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Hex Upload started: %@", request);
 
     NSURLSessionUploadTask* uploadTask = [self.session uploadTaskWithRequest:request fromData:data];
-    NSURLRequest* key = uploadTask.originalRequest ?: request;
 
     payload.httpError = NO;
-    @synchronized(self.payloadByRequest) {
-        self.payloadByRequest[key] = payload;
+    @synchronized(self.payloadByTaskId) {
+        self.payloadByTaskId[@(uploadTask.taskIdentifier)] = payload;
     }
-    [self.taskStore track:key];
     [uploadTask resume];
 }
 
@@ -233,10 +239,10 @@ static const NSTimeInterval kNRMAHexResourceTimeout = 60.0;
                 task:(NSURLSessionTask*)task
 didCompleteWithError:(nullable NSError*)error {
 
-    NSURLRequest* key = task.originalRequest;
+    NSNumber* key = @(task.taskIdentifier);
     NRMAHexPayload* payload = nil;
-    @synchronized(self.payloadByRequest) {
-        payload = key ? self.payloadByRequest[key] : nil;
+    @synchronized(self.payloadByTaskId) {
+        payload = self.payloadByTaskId[key];
     }
     // A >= 400 response (recorded in didReceiveResponse) completes without a
     // transport error, so fold that into the failure decision here — this is
@@ -252,15 +258,12 @@ didCompleteWithError:(nullable NSError*)error {
             NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - failed to upload handled exception report: %@", [error localizedDescription]);
         }
 #endif
-        [self handledErroredRequest:key];
+        [self handledErroredTask:task payload:payload];
     } else {
         NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Handled exception upload completed successfully");
-        if (key) {
-            @synchronized(self.payloadByRequest) {
-                [self.payloadByRequest removeObjectForKey:key];
-            }
+        @synchronized(self.payloadByTaskId) {
+            [self.payloadByTaskId removeObjectForKey:key];
         }
-        [self.taskStore untrack:key];
         // Upload confirmed — let the store delete the persisted report (shouldRemove = YES).
         [payload finishWith:YES];
     }
@@ -285,9 +288,8 @@ didCompleteWithError:(nullable NSError*)error {
         // Record the HTTP failure; the terminal retry/abandon decision (and the
         // payload completion) is made in didCompleteWithError so it happens
         // exactly once per attempt.
-        NSURLRequest* key = dataTask.originalRequest;
-        @synchronized(self.payloadByRequest) {
-            NRMAHexPayload* payload = key ? self.payloadByRequest[key] : nil;
+        @synchronized(self.payloadByTaskId) {
+            NRMAHexPayload* payload = self.payloadByTaskId[@(dataTask.taskIdentifier)];
             payload.httpError = YES;
         }
     }
@@ -301,13 +303,10 @@ didCompleteWithError:(nullable NSError*)error {
     completionHandler(NSURLSessionResponseAllow);
 }
 
-- (void) handledErroredRequest:(NSURLRequest*)request {
-    if (request == nil) return;
+- (void) handledErroredTask:(NSURLSessionTask*)task payload:(NRMAHexPayload*)payload {
+    if (task == nil) return;
 
-    NRMAHexPayload* payload = nil;
-    @synchronized(self.payloadByRequest) {
-        payload = self.payloadByRequest[request];
-    }
+    NSNumber* oldKey = @(task.taskIdentifier);
 
     // If we're offline, don't burn FDs/sockets cycling failed retries —
     // keep the report on disk and let the next harvest retry when reachable.
@@ -319,49 +318,43 @@ didCompleteWithError:(nullable NSError*)error {
     }
     if (offline) {
         NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - offline, deferring retry");
-        @synchronized(self.payloadByRequest) {
-            [self.payloadByRequest removeObjectForKey:request];
+        @synchronized(self.payloadByTaskId) {
+            [self.payloadByTaskId removeObjectForKey:oldKey];
         }
-        [self.taskStore untrack:request];
         [payload finishWith:NO];
         return;
     }
 #endif
 
-    if ([self.taskStore shouldRetryTask:request]) {
+    if (payload.attempts < kNRMARetryLimit) {
+        payload.attempts += 1;
         NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - retrying handled exception report upload");
         NSData* body = payload.data;
         if (body == nil || body.length == 0) {
             NRLOG_AGENT_ERROR(@"NEWRELIC HEX UPLOADER - retry has no payload, abandoning report");
-            @synchronized(self.payloadByRequest) {
-                [self.payloadByRequest removeObjectForKey:request];
+            @synchronized(self.payloadByTaskId) {
+                [self.payloadByTaskId removeObjectForKey:oldKey];
             }
-            [self.taskStore untrack:request];
             [payload finishWith:NO];
             return;
         }
-        NSURLSessionUploadTask* uploadTask = [self.session uploadTaskWithRequest:request fromData:body];
-        // The session may produce a fresh originalRequest copy on the new task.
-        // Requests with identical content are -isEqual:, so the retried task's
-        // originalRequest maps to the same payloadByRequest / retry-tracker slot;
-        // re-keying just ensures the payload is found again. Reset the per-attempt
-        // HTTP-error flag so the retry starts clean.
+        // Rebuild the upload from the original request. The new task gets its own
+        // -taskIdentifier, so move the payload from the old key to the new one and
+        // reset the per-attempt HTTP-error flag so the retry starts clean.
+        NSURLSessionUploadTask* uploadTask = [self.session uploadTaskWithRequest:task.originalRequest fromData:body];
         payload.httpError = NO;
-        NSURLRequest* newKey = uploadTask.originalRequest;
-        if (newKey) {
-            @synchronized(self.payloadByRequest) {
-                self.payloadByRequest[newKey] = payload;
-            }
+        @synchronized(self.payloadByTaskId) {
+            [self.payloadByTaskId removeObjectForKey:oldKey];
+            self.payloadByTaskId[@(uploadTask.taskIdentifier)] = payload;
         }
         @synchronized(self.retryQueue) {
             [self.retryQueue addObject:uploadTask];
         }
     } else {
         NRLOG_AGENT_VERBOSE(@"NEWRELIC HEX UPLOADER - Handled exception report max upload attempts reached. abandoning report.");
-        @synchronized(self.payloadByRequest) {
-            [self.payloadByRequest removeObjectForKey:request];
+        @synchronized(self.payloadByTaskId) {
+            [self.payloadByTaskId removeObjectForKey:oldKey];
         }
-        [self.taskStore untrack:request];
         // Retries exhausted — not confirmed; remove the report on disk
         [payload finishWith:YES];
     }

--- a/Test Harness/NRTestApp/NRTestApp/ViewModels/UtilViewModel.swift
+++ b/Test Harness/NRTestApp/NRTestApp/ViewModels/UtilViewModel.swift
@@ -23,6 +23,7 @@ class UtilViewModel {
     var badAttribute = false
     var attributes = ""
     var events = 0 
+    var count: Int = 0
 
     var uniqueInteractionTraceIdentifier: String? =  nil
 
@@ -91,8 +92,8 @@ class UtilViewModel {
         do {
             try errorMethod()
         } catch {
-            NewRelic.recordError(error)
-            
+            NewRelic.recordError(error, attributes: ["id": count])
+            count += 1
         }
     }
     

--- a/Tests/Unit-Tests/NewRelicAgentTests/Handled-Exception-Tests/TestHexUploader.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Handled-Exception-Tests/TestHexUploader.m
@@ -21,12 +21,13 @@
 #import "NRMASupportMetricHelper.h"
 
 @interface NRMAHexUploader ()
-- (void) handledErroredRequest:(NSURLRequest*)request;
+- (void) handledErroredTask:(NSURLSessionTask*)task payload:(id)payload;
 @property(strong) NSURLSession* session;
 @property(strong) NSMutableArray* pendingPayloads;
 @property(assign) NSUInteger inFlightCount;
-// Values are NRMAHexPayload (private to NRMAHexUploader.m); accessed here via KVC.
-@property(strong) NSMutableDictionary* payloadByRequest;
+// Keyed by @(task.taskIdentifier); values are NRMAHexPayload (private to
+// NRMAHexUploader.m), accessed here via KVC.
+@property(strong) NSMutableDictionary* payloadByTaskId;
 @end
 
 @interface TestHexUploader : NRMAAgentTestBase {
@@ -77,21 +78,23 @@
 
 - (void) testHandledNetworkError {
     id mockUploader = [OCMockObject partialMockForObject:self.hexUploader];
-    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY];
+    [[mockUploader expect] handledErroredTask:OCMOCK_ANY payload:OCMOCK_ANY];
 
     // A >= 400 response is recorded against the in-flight payload, but the
     // terminal retry/abandon decision is made in didCompleteWithError so it
-    // happens exactly once per attempt. Register a payload + a task carrying a
-    // matching originalRequest so the flow can find it.
+    // happens exactly once per attempt. Register a payload under the task's
+    // identifier so the response/completion handlers can find it.
     NSURLRequest* request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost/f"]];
     id payload = [NSClassFromString(@"NRMAHexPayload") new];
     [payload setValue:[@"x" dataUsingEncoding:NSUTF8StringEncoding] forKey:@"data"];
-    @synchronized(self.hexUploader.payloadByRequest) {
-        self.hexUploader.payloadByRequest[request] = payload;
-    }
 
     id mockTask = [OCMockObject niceMockForClass:[NSURLSessionDataTask class]];
     [[[mockTask stub] andReturn:request] originalRequest];
+    // The nice mock returns 0 for the unstubbed -taskIdentifier; register the
+    // payload under that same identifier so lookups resolve to it.
+    @synchronized(self.hexUploader.payloadByTaskId) {
+        self.hexUploader.payloadByTaskId[@(0)] = payload;
+    }
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
@@ -115,7 +118,7 @@
 
 - (void) testNoRetryOnSuccess {
     id mockUploader = [OCMockObject partialMockForObject:self.hexUploader];
-    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY];
+    [[mockUploader expect] handledErroredTask:OCMOCK_ANY payload:OCMOCK_ANY];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
@@ -138,7 +141,7 @@
 
 - (void) testRetryOnFailure {
     id mockUploader = [OCMockObject partialMockForObject:self.hexUploader];
-    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY];
+    [[mockUploader expect] handledErroredTask:OCMOCK_ANY payload:OCMOCK_ANY];
 
     NSError* error = [NSError errorWithDomain:(NSString*)kCFErrorDomainCFNetwork
                                          code:kCFURLErrorDNSLookupFailed
@@ -156,7 +159,7 @@
 
 - (void) testSuccessSupportMetric {
     id mockUploader = [OCMockObject partialMockForObject:self.hexUploader];
-    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY];
+    [[mockUploader expect] handledErroredTask:OCMOCK_ANY payload:OCMOCK_ANY];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
@@ -192,7 +195,7 @@
 
     self.hexUploader.applicationToken = @"IMTHETOKENNOW";
     id mockUploader = [OCMockObject partialMockForObject:self.hexUploader];
-    [[mockUploader expect] handledErroredRequest:OCMOCK_ANY];
+    [[mockUploader expect] handledErroredTask:OCMOCK_ANY payload:OCMOCK_ANY];
     
     XCTAssertThrows([mockUploader verify]);
 
@@ -239,20 +242,18 @@
     // Bookkeeping is synchronous: by the time sendData: returns, the upload
     // has been launched and its payload recorded. The task may already have
     // failed under the simulator (no listener), but the dict entry persists
-    // for the duration of any retry chain — so it must be present here.
+    // for the duration of any retry chain — so it must be present here. The
+    // dictionary is now keyed by @(task.taskIdentifier), and the original
+    // bytes live on the tracked NRMAHexPayload's `data` property.
     NSDictionary* snapshot = nil;
-    @synchronized(self.hexUploader.payloadByRequest) {
-        snapshot = [self.hexUploader.payloadByRequest copy];
+    @synchronized(self.hexUploader.payloadByTaskId) {
+        snapshot = [self.hexUploader.payloadByTaskId copy];
     }
     XCTAssertGreaterThanOrEqual(snapshot.count, (NSUInteger)1,
                                 @"payload must be tracked for retry");
 
     BOOL foundOriginalLength = NO;
-    for (NSURLRequest* key in snapshot) {
-        // The request itself must NOT carry HTTPBody — that would trip the
-        // iOS upload-task warning and strip the body.
-        XCTAssertNil(key.HTTPBody, @"upload-task request must have no HTTPBody");
-        // Values are NRMAHexPayload; the original bytes live on its `data` property.
+    for (NSNumber* key in snapshot) {
         NSData* trackedData = [snapshot[key] valueForKey:@"data"];
         if (trackedData.length == data.length) {
             foundOriginalLength = YES;


### PR DESCRIPTION
Handled-exception ("hex") reports were being uploaded to the collector more than once. Reproducible by generating several handled exceptions, backgrounding → foregrounding the app, then force-quitting: on the next launch the same reports were re-sent, producing duplicates in the UI.

## Fix

`Agent/HandledException/NRMAHexUploader.m`:
- Replace `payloadByRequest` (keyed by `NSURLRequest`) with `payloadByTaskId`, keyed by `@(task.taskIdentifier)`, which is unique within an `NSURLSession`. Each upload now gets its own slot; completions always resolve to their own payload.
- Move the retry counter onto the `NRMAHexPayload` (`attempts`) and drop the request-keyed `NRMARetryTracker` usage (it was broken the same way — retry counts were shared across unrelated reports). The payload survives across a retry and is re-registered under the rebuilt task's new identifier.
- Rename `handledErroredRequest:` → `handledErroredTask:payload:`.

Retry semantics (`kNRMARetryLimit = 2`), offline deferral, oversized-payload handling, and the concurrency cap are all unchanged. No public API changes.

`NRMARetryTracker.{h,m}` are now unused by production code but retained (still covered directly by `TestRetryTracker.m`); removing them can be a follow-up.