### PR TITLE
NR-586741 changes to fix setUserId vendorId crash

### DIFF
--- a/Agent/General/NewRelicAgentInternal.h
+++ b/Agent/General/NewRelicAgentInternal.h
@@ -82,6 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void) applicationWillEnterForeground;
 - (void) sessionStartInitialization;
+- (void) startNewSessionForUserId:(NSString* _Nullable)userId;
 + (NewRelicAgentInternal* _Nullable) sharedInstance;
 
 - (NSString*) currentSessionId;

--- a/Agent/General/NewRelicAgentInternal.m
+++ b/Agent/General/NewRelicAgentInternal.m
@@ -874,6 +874,24 @@ static const NSString *kNRMA_APPLICATION_WILL_TERMINATE =
     [self onSessionStart];
 }
 
+- (void) startNewSessionForUserId:(NSString* _Nullable)userId {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        @synchronized(kNRMA_BGFG_MUTEX) {
+            [self.analyticsController newSession];
+            [self sessionReplayEndSession];
+            [NewRelicAgentInternal harvestNow];
+            [self sessionStartInitialization];
+            if (userId) {
+                [self.analyticsController setSessionAttribute:kNRMA_Attrib_userId
+                                                        value:userId
+                                                   persistent:YES];
+            } else {
+                [self.analyticsController removeSessionAttributeNamed:kNRMA_Attrib_userId];
+            }
+        }
+    });
+}
+
 - (void) handle4HourSessionRestart {
     NRLOG_AGENT_DEBUG(@"Executing 4-hour automatic session restart");
 

--- a/Agent/Public/NewRelic.m
+++ b/Agent/Public/NewRelic.m
@@ -649,43 +649,43 @@
 }
 
 + (BOOL) setUserId:(NSString* _Nullable)userId {
-    NSString *previousUserId = [[NewRelicAgentInternal sharedInstance] getUserId];
+    NewRelicAgentInternal *agent = [NewRelicAgentInternal sharedInstance];
+    if (!agent || agent.isShutdown) {
+        return NO;
+    }
 
-    BOOL newSession = false;
-    
-    // If userId has been set before and is different from the current userId, then we need to start a new session.
-    if ([previousUserId isEqualToString: userId] == NO) {
-        // end session and harvest.
-        newSession = true;
-    }
-        // Do nothing if passed userId is null and saved userId (for this app session (since app launch)) is null.
-    if (userId == nil) {
-        // end session and harvest.
-        newSession = true;
-    }
+    NSString *previousUserId = [agent getUserId];
+
+    // A new session is only started when a non-nil userId is being replaced with a different value
+    // (including nil). Setting a userId for the first time (previousUserId == nil) continues the
+    // current session so early-startup data is not lost.
+    BOOL newSession = (previousUserId != nil) && ([previousUserId isEqualToString:userId] == NO);
 
     NRLOG_AGENT_VERBOSE(@"setUserId: %@ and previousUserId: %@ and will start newSession=%d", userId, previousUserId, newSession);
 
     if (newSession) {
-        [[[NewRelicAgentInternal sharedInstance] analyticsController] newSession];
-        
-        [[NewRelicAgentInternal sharedInstance] sessionReplayEndSession];
-
-        // Perform harvest
-        [self harvestNow];
-
-        [[NewRelicAgentInternal sharedInstance] sessionStartInitialization];
+        // userId changed — end the current session and harvest its data under the previous userId,
+        // then start a new session and apply the new userId to it. The restart is dispatched off
+        // the main thread to avoid blocking the caller and to avoid making XPC calls (e.g.
+        // UIDevice.identifierForVendor) during sensitive lifecycle transitions such as
+        // sceneWillResignActive. userId is set synchronously here so getUserId() is consistent
+        // before the async restart completes. Returns YES to indicate the restart was enqueued;
+        // callers cannot depend on the restart completing before this method returns.
+        agent.userId = userId;
+        [agent startNewSessionForUserId:userId];
+        return YES;
     }
-    
-    // Update in memory userId.
-    [NewRelicAgentInternal sharedInstance].userId = userId;
 
-    BOOL success = [[NewRelicAgentInternal sharedInstance].analyticsController setSessionAttribute:kNRMA_Attrib_userId
-                                                                                             value:userId
-                                                                                        persistent:YES];
-    // If passed userId == NULL , remove UserId attribute.
-    if (userId == NULL) {
-        success = [[NewRelicAgentInternal sharedInstance].analyticsController removeSessionAttributeNamed:kNRMA_Attrib_userId];
+    // No userId was previously set — continue the current session and apply the userId to it.
+    agent.userId = userId;
+
+    BOOL success;
+    if (userId) {
+        success = [agent.analyticsController setSessionAttribute:kNRMA_Attrib_userId
+                                                 value:userId
+                                            persistent:YES];
+    } else {
+        success = [agent.analyticsController removeSessionAttributeNamed:kNRMA_Attrib_userId];
     }
 
     return success;

--- a/Agent/Utilities/NRMAUDIDManager.m
+++ b/Agent/Utilities/NRMAUDIDManager.m
@@ -21,13 +21,19 @@ static NSString* const kNRMAVendorIDStore   = @"com.newrelic.vendorID";
 @implementation NRMAUDIDManager
 
 + (NSString*) deviceIdentifier {
-//    return ![NRMAFlags shouldReplaceDeviceIdentifier] ? [UIDevice currentDevice].identifierForVendor.UUIDString : [NRMAFlags replacementDeviceIdentifier];
+    if ([NRMAFlags shouldReplaceDeviceIdentifier]) {
+        return [NRMAFlags replacementDeviceIdentifier];
+    }
+    static NSString *cachedVendorId;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
 #if !TARGET_OS_WATCH
-    NSString* vendorId = [UIDevice currentDevice].identifierForVendor.UUIDString;
-#elif TARGET_OS_WATCH
-    NSString* vendorId = [WKInterfaceDevice currentDevice].identifierForVendor.UUIDString;
+        cachedVendorId = [UIDevice currentDevice].identifierForVendor.UUIDString;
+#else
+        cachedVendorId = [WKInterfaceDevice currentDevice].identifierForVendor.UUIDString;
 #endif
-    return ![NRMAFlags shouldReplaceDeviceIdentifier] ? vendorId : [NRMAFlags replacementDeviceIdentifier];
+    });
+    return cachedVendorId;
 }
 
 + (NSString*) UDID {

--- a/Agent/Utilities/NRMAUDIDManager.m
+++ b/Agent/Utilities/NRMAUDIDManager.m
@@ -20,20 +20,28 @@ static NSString* const kNRMAVendorIDStore   = @"com.newrelic.vendorID";
 
 @implementation NRMAUDIDManager
 
+static NSString *_cachedVendorId = nil;
+
 + (NSString*) deviceIdentifier {
     if ([NRMAFlags shouldReplaceDeviceIdentifier]) {
         return [NRMAFlags replacementDeviceIdentifier];
     }
-    static NSString *cachedVendorId;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
+    @synchronized(NRMAUDIDManager.class) {
+        if (!_cachedVendorId) {
 #if !TARGET_OS_WATCH
-        cachedVendorId = [UIDevice currentDevice].identifierForVendor.UUIDString;
+            _cachedVendorId = [UIDevice currentDevice].identifierForVendor.UUIDString;
 #else
-        cachedVendorId = [WKInterfaceDevice currentDevice].identifierForVendor.UUIDString;
+            _cachedVendorId = [WKInterfaceDevice currentDevice].identifierForVendor.UUIDString;
 #endif
-    });
-    return cachedVendorId;
+        }
+        return _cachedVendorId;
+    }
+}
+
++ (void) resetCachedDeviceIdentifier {
+    @synchronized(NRMAUDIDManager.class) {
+        _cachedVendorId = nil;
+    }
 }
 
 + (NSString*) UDID {

--- a/Tests/Unit-Tests/NewRelicAgentTests/API-Tests/NewRelicTests.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/API-Tests/NewRelicTests.m
@@ -342,20 +342,37 @@ static NewRelicAgentInternal* _sharedInstance;
 }
 
 - (void) testSetUserIdSessionBehavior {
-    // set userId to testId
+    // Stub startNewSessionForUserId: to apply the userId attribute synchronously without
+    // triggering the full infrastructure restart (which requires a fully initialized agent).
+    id partialMock = [OCMockObject partialMockForObject:_sharedInstance];
+    [[[partialMock stub] andDo:^(NSInvocation* invocation) {
+        NSString* uid = nil;
+        [invocation getArgument:&uid atIndex:2];
+        if (uid) {
+            [_sharedInstance.analyticsController setSessionAttribute:@"userId" value:uid persistent:YES];
+        } else {
+            [_sharedInstance.analyticsController removeSessionAttributeNamed:@"userId"];
+        }
+    }] startNewSessionForUserId:OCMOCK_ANY];
+
+    // First call — previousUserId is nil, so the current session continues and userId is set.
     BOOL success = [NewRelic setUserId:@"testId"];
     XCTAssertTrue(success);
-    // set userId to Bob
+
+    // Second call — userId changed, so a new session is started and @"Bob" is applied to it.
     success = [NewRelic setUserId:@"Bob"];
     XCTAssertTrue(success);
-    NSString* attributes = [[NewRelicAgentInternal sharedInstance].analyticsController sessionAttributeJSONString];
+    NSString* attributes = [_sharedInstance.analyticsController sessionAttributeJSONString];
     NSDictionary* decode = [NSJSONSerialization JSONObjectWithData:[attributes dataUsingEncoding:NSUTF8StringEncoding]
                                                            options:0
                                                              error:nil];
-    XCTAssertTrue([decode[@"userId"] isEqualToString:@"Bob"]);
-    // set userId to NULL
+    XCTAssertEqualObjects(decode[@"userId"], @"Bob");
+
+    // Third call — userId set to nil, so another new session is started.
     success = [NewRelic setUserId:NULL];
     XCTAssertTrue(success);
+
+    [partialMock stopMocking];
     [self.mockNewRelicInternals stopMocking];
 }
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAUDIDManagerTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAUDIDManagerTest.m
@@ -21,6 +21,7 @@
 + (NRMAUUIDStore*) secureUDIDStore;
 + (NRMAUUIDStore*) identifierForVendorStore;
 + (void) setUDID:(NSString*)udid;
++ (void) resetCachedDeviceIdentifier;
 
 + (NSString*) getSystemIdentifier;
 + (NSString*) saltValue;
@@ -43,6 +44,7 @@
 - (void)setUp {
     [super setUp];
     [NRMAUDIDManager setUDID:nil];
+    [NRMAUDIDManager resetCachedDeviceIdentifier];
 }
 
 - (void) testUUIDSalt {
@@ -105,6 +107,7 @@
 
 - (void)tearDown {
     [NRMAUDIDManager setUDID:nil];
+    [NRMAUDIDManager resetCachedDeviceIdentifier];
     [super tearDown];
 }
 
@@ -248,6 +251,7 @@
 
     //reset in memory udid
     [NRMAUDIDManager setUDID:nil];
+    [NRMAUDIDManager resetCachedDeviceIdentifier];
 
    self.vendorId = @"51";
 
@@ -272,6 +276,7 @@
 
     //reset in memory udid
     [NRMAUDIDManager setUDID:nil];
+    [NRMAUDIDManager resetCachedDeviceIdentifier];
 
     self.vendorId = @"51";
 


### PR DESCRIPTION
File: NewRelicAgentInternal.m
Change: Implemented it: dispatches to global queue under kNRMA_BGFG_MUTEX, runs
  newSession + sessionReplayEndSession + harvestNow +
  sessionStartInitialization, then sets/removes the userId attribute on the new
   session
────────────────────────────────────────
File: NewRelic.m
Change: setUserId: now guards isShutdown, calls startNewSessionForUserId: and
  returns YES immediately for the new-session path; only the same-userId
  (no-restart) path still sets the attribute synchronously
────────────────────────────────────────
File: NRMAUDIDManager.m
Change: deviceIdentifier now caches identifierForVendor via dispatch_once — the XPC call to LaunchServices happens exactly once at stable startup instead of on every session restart.

The second crash (a different invocation of the same unguarded path from willResignActive) would have been impossible after the dispatch fix alone; the cache is a belt-and-suspenders guard against calling into the XPC layer during any sensitive lifecycle moment.