### PR TITLE
Fix atomicity across NRMA Trace collections:  587952 587955 587949 587944

### DIFF
--- a/Agent/ActivityTracing/NRMAActivityTrace.h
+++ b/Agent/ActivityTracing/NRMAActivityTrace.h
@@ -14,13 +14,18 @@
 
 //used to identify the original object that initiated the activity trace
 //generally just the memory address of the object. 
-@property(nonatomic,strong) NSString          *initiatingObjectIdentifier;
-@property(nonatomic,strong) NRMATrace         *rootTrace;
+// atomic: read cross-thread (e.g. -isInteractionObject:) while mutated under kNRMAStartAndEndTracingLock.
+@property(atomic,strong) NSString          *initiatingObjectIdentifier;
+// atomic: read on background trace-completion threads (completeTrace:) while set during setup.
+@property(atomic,strong) NRMATrace         *rootTrace;
 @property(atomic,strong) NSMutableSet    *missingChildren;
 @property(nonatomic,assign) double      lastUpdated;
 @property(atomic,assign)    BOOL            isComplete;
-@property(nonatomic,strong) NSString        *type;
-@property(nonatomic,strong) NSString        *name;
+// atomic: name/type are read on background completion threads (getCurrentActivityName)
+// while being replaced on other threads; a nonatomic getter would return an
+// unretained pointer that a concurrent setter can free before ARC retains it.
+@property(atomic,strong) NSString        *type;
+@property(atomic,strong) NSString        *name;
 @property(nonatomic,strong) NSMutableDictionary *memoryVitals;
 @property(nonatomic,strong) NSMutableDictionary *cpuVitals;
 @property(nonatomic)        double          totalExclusiveTimeMillis;

--- a/Agent/ActivityTracing/NRMAActivityTrace.m
+++ b/Agent/ActivityTracing/NRMAActivityTrace.m
@@ -21,6 +21,10 @@
     CPUTime _lastCPUTime;
     BOOL _lastCPUTimeValid;
     double _lastRecordVitalsTime;
+    // Guards the vitals bookkeeping ivars above. recordVitals(Throttled) can be called
+    // concurrently from method entry (addTrace:) and method exit (completeTrace:) on
+    // different threads; without this the CPUTime struct and throttle timestamp tear.
+    NSObject* _vitalsLock;
 }
 @end
 @implementation NRMAActivityTrace
@@ -41,6 +45,7 @@
         self.memoryVitals = [[NSMutableDictionary alloc] init];
         self.cpuVitals = [[NSMutableDictionary alloc] init];
         
+        _vitalsLock = [[NSObject alloc] init];
         _lastRecordVitalsTime = NRMAMillisecondTimestamp();
         int errorCode = [NRMACPUVitals cpuTime:&_lastCPUTime];
         _lastCPUTimeValid = (errorCode==0)?YES:NO;
@@ -60,13 +65,25 @@
 
 - (void)recordVitalsThrottled
 {
-    if (NRMAMillisecondTimestamp() - _lastRecordVitalsTime > RECORD_VITALS_THROTTLE_MS) {
-        [self recordVitals];
+    @synchronized(_vitalsLock) {
+        // Throttle check and record must be atomic together so two threads can't both
+        // pass the check and double-record.
+        if (NRMAMillisecondTimestamp() - _lastRecordVitalsTime > RECORD_VITALS_THROTTLE_MS) {
+            [self recordVitalsLocked];
+        }
     }
-
 }
 
 - (void)recordVitals
+{
+    @synchronized(_vitalsLock) {
+        [self recordVitalsLocked];
+    }
+}
+
+// Records CPU/memory vitals. Callers MUST hold _vitalsLock (protects the _lastCPUTime /
+// _lastRecordVitalsTime / _lastCPUTimeValid bookkeeping ivars mutated below).
+- (void)recordVitalsLocked
 {
     NSTimeInterval now = NRMAMillisecondTimestamp();
     CPUTime cpuTime;
@@ -74,7 +91,7 @@
 
     int errorCode = [NRMACPUVitals cpuTime:&cpuTime];
     memoryUseInMegabytes = [NRMAMemoryVitals memoryUseInMegabytes];
- 
+
     durationInSeconds = (now - _lastRecordVitalsTime) / 1000.0;
     if (durationInSeconds == 0) {
         return;

--- a/Agent/ActivityTracing/NRMATrace.h
+++ b/Agent/ActivityTracing/NRMATrace.h
@@ -14,10 +14,14 @@
 @interface NRMATrace : NSObject <NRMAConsumerProtocol>
 @property(nonatomic,assign) double entryTimestamp;
 @property(nonatomic,assign) double exitTimestamp;
-@property(nonatomic,strong) NSString* name;
-@property(nonatomic,strong) NSString* classLabel;
-@property(nonatomic,strong) NSString* methodLabel;
-@property(nonatomic,strong) NRMAThreadInfo* threadInfo;
+// atomic: name/classLabel/methodLabel feed -metricName, which is read on background
+// trace-completion threads while these are set on other threads. A nonatomic getter
+// would hand back an unretained pointer a concurrent setter can free before ARC retains it.
+@property(atomic,strong) NSString* name;
+@property(atomic,strong) NSString* classLabel;
+@property(atomic,strong) NSString* methodLabel;
+// atomic: threadInfo.identity is read on background trace-completion threads (completeTrace:).
+@property(atomic,strong) NRMAThreadInfo* threadInfo;
 @property(nonatomic,strong) NSMutableDictionary* parameters;
 @property(nonatomic,assign) BOOL      persistent;
 @property(nonatomic,strong) NSMutableSet* children; 

--- a/Agent/ActivityTracing/NRMATrace.m
+++ b/Agent/ActivityTracing/NRMATrace.m
@@ -108,15 +108,29 @@
 }
 
 - (void) consumeMeasurements:(NSDictionary *)measurements {
-    for (NSNumber* key in [measurements allKeys]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-selector-match"
-
-        for (NRMAMeasurement* measurement in [[measurements objectForKey:key] allObjects]) {
+    if (![measurements isKindOfClass:[NSDictionary class]]) {
+        return;
+    }
+    for (NSNumber* key in [measurements allKeys]) {
+        id value = [measurements objectForKey:key];
+        if (![value respondsToSelector:@selector(allObjects)]) {
+            continue;
+        }
+        // Defense-in-depth: snapshot inside a guard so a set mutated mid-enumeration on
+        // another thread is skipped rather than crashing on a freed element.
+        NSArray* snapshot = nil;
+        @try {
+            snapshot = [value allObjects];
+        } @catch (NSException* exception) {
+            continue;
+        }
+        for (NRMAMeasurement* measurement in snapshot) {
             [self consumeMeasurement:measurement];
         }
     }
-#pragma clang diagonstic pop
+#pragma clang diagnostic pop
 }
 
 - (NSString*) description

--- a/Agent/ActivityTracing/NRMATraceController.m
+++ b/Agent/ActivityTracing/NRMATraceController.m
@@ -110,14 +110,19 @@ static NSTimeInterval __healthyTraceTimeout;
 #pragma mark - Static Functions
 + (NSString*) getCurrentActivityName
 {
-    NRMATraceMachine* localTraceMachine = [self traceMachine];
     NSString* scope = @"";
 #ifndef  DISABLE_NRMA_EXCEPTION_WRAPPER
     @try {
 #endif
-
-        if (localTraceMachine) {
-            scope = localTraceMachine.activityTrace.name;
+        // Snapshot each object into a local strong reference before dereferencing further.
+        // traceMachine and activityTrace are atomic; name is atomic (see NRMAActivityTrace.h),
+        // so each getter returns a retained+autoreleased value that a concurrent setter on
+        // another thread cannot free before we copy it. Defensively copy to fully detach.
+        NRMATraceMachine* localTraceMachine = [self traceMachine];
+        NRMAActivityTrace* activityTrace = localTraceMachine.activityTrace;
+        NSString* name = activityTrace.name;
+        if (name.length) {
+            scope = [name copy];
         }
 #ifndef  DISABLE_NRMA_EXCEPTION_WRAPPER
     } @catch (NSException* exception) {
@@ -126,7 +131,7 @@ static NSTimeInterval __healthyTraceTimeout;
                                 selector:NSStringFromSelector(@selector(getCurrentActivityName))];
     }
 #endif
-    return scope;
+    return scope ?: @"";
 }
 
 

--- a/Agent/ActivityTracing/NRMATraceController.m
+++ b/Agent/ActivityTracing/NRMATraceController.m
@@ -352,18 +352,23 @@ static NSString *__measurementLock = @"measurementTransmittersLock";
     if ([NewRelicAgentInternal sharedInstance].isShutdown) {
         return NO;
     }
-    if (![NRMATraceController isTracingActive]) {
-        return NO;
-    }
-    NRMATrace* childTrace = [NRMATraceController registerNewTrace:newTraceName withParent:parentTrace];
-    if (!childTrace) {
-        return NO;
-    }
-    childTrace.entryTimestamp = NRMAMillisecondTimestamp();
-    
-    return [NRMATraceController newTraceSetup:childTrace
-                             parentTrace:parentTrace];
+    // Serialize against the trace lifecycle (see completeTrace:). Without this lock a stale
+    // method-entry on one thread can keep mutating an activity trace that completeActivityTrace
+    // has already queued for harvest and torn down, corrupting the heap. isTracingActive is
+    // re-checked inside the lock to close the time-of-check/time-of-use window.
+    @synchronized(kNRMAStartAndEndTracingLock) {
+        if (![NRMATraceController isTracingActive]) {
+            return NO;
+        }
+        NRMATrace* childTrace = [NRMATraceController registerNewTrace:newTraceName withParent:parentTrace];
+        if (!childTrace) {
+            return NO;
+        }
+        childTrace.entryTimestamp = NRMAMillisecondTimestamp();
 
+        return [NRMATraceController newTraceSetup:childTrace
+                                 parentTrace:parentTrace];
+    }
 }
 
 + (NRMATrace*) enterMethod:(SEL)selector
@@ -388,6 +393,11 @@ static NSString *__measurementLock = @"measurementTransmittersLock";
     if ([NewRelicAgentInternal sharedInstance].isShutdown) {
         return nil;
     }
+
+    // Serialize against the trace lifecycle (see completeTrace:). Re-check isTracingActive
+    // inside the lock so a concurrent completeActivityTrace/cleanup can't leave us mutating
+    // a torn-down, already-harvested activity trace (heap corruption).
+    @synchronized(kNRMAStartAndEndTracingLock) {
 
     if (![NRMATraceController isTracingActive]) {
         return nil;
@@ -433,6 +443,7 @@ static NSString *__measurementLock = @"measurementTransmittersLock";
 #endif
 
     return childTrace;
+    } // @synchronized(kNRMAStartAndEndTracingLock)
 }
 
 + (NRMATrace*) registerNewTrace:(NSString *)name

--- a/Agent/ActivityTracing/NRMATraceController.m
+++ b/Agent/ActivityTracing/NRMATraceController.m
@@ -494,6 +494,13 @@ static NSString *__measurementLock = @"measurementTransmittersLock";
         return;
     }
 
+    // Serialize trace completion against the trace lifecycle (startTracing*/completeActivityTrace*/
+    // cleanup), which mutate and tear down the trace machine under this same lock. Without it,
+    // completion (invoked by the method profiler on an arbitrary thread) races a concurrent
+    // teardown, dereferencing freed trace state and corrupting the heap (SIGTRAP in libsystem_malloc).
+    // The validity check below MUST run inside the lock to close the time-of-check/time-of-use window.
+    @synchronized(kNRMAStartAndEndTracingLock) {
+
     NRMATraceMachine *localTraceMachine = [self traceMachine];
 
     if (localTraceMachine == nil || ![NRMATraceController isTracingActive] || localTraceMachine != trace.traceMachine) {
@@ -578,6 +585,7 @@ static NSString *__measurementLock = @"measurementTransmittersLock";
         [localTraceMachine.activityTrace.missingChildren removeObject:trace];
         localTraceMachine.activityTrace.lastUpdated = NRMAMillisecondTimestamp();
     }
+    } // @synchronized(kNRMAStartAndEndTracingLock)
 }
 
 

--- a/Agent/Measurements/Consumers/NRMAMachineMeasurementConsumer.m
+++ b/Agent/Measurements/Consumers/NRMAMachineMeasurementConsumer.m
@@ -30,8 +30,22 @@
 
 - (void) consumeMeasurements:(NSDictionary *)measurements
 {
-    NSSet* measurementSet = [measurements objectForKey:[NSNumber numberWithInt:self.measurementType]];
-    for (NRMANamedValueMeasurement* measurement in measurementSet.allObjects) {
+    if (![measurements isKindOfClass:[NSDictionary class]]) {
+        return;
+    }
+    id measurementSet = [measurements objectForKey:[NSNumber numberWithInt:self.measurementType]];
+    if (![measurementSet respondsToSelector:@selector(allObjects)]) {
+        return;
+    }
+    // Defense-in-depth: snapshot inside a guard so a set mutated mid-enumeration on
+    // another thread is skipped rather than crashing on a freed element.
+    NSArray* snapshot = nil;
+    @try {
+        snapshot = [measurementSet allObjects];
+    } @catch (NSException* exception) {
+        return;
+    }
+    for (NRMANamedValueMeasurement* measurement in snapshot) {
         [self consumeMeasurement:measurement];
     }
 }

--- a/Agent/Measurements/Consumers/NRMAMeasurementConsumer.m
+++ b/Agent/Measurements/Consumers/NRMAMeasurementConsumer.m
@@ -31,8 +31,24 @@
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-selector-match"
-    for (NSNumber* key in measurements.allKeys){
-        for (NRMAMeasurement* measurement in [[measurements objectForKey:key] allObjects]) {
+    if (![measurements isKindOfClass:[NSDictionary class]]) {
+        return;
+    }
+    for (NSNumber* key in [measurements allKeys]){
+        id value = [measurements objectForKey:key];
+        if (![value respondsToSelector:@selector(allObjects)]) {
+            continue;
+        }
+        // Defense-in-depth: snapshot inside a guard. Callers now hand us detached sets
+        // (see NRMAMeasurementProducer/NRMAMeasurementPool), but if a set is ever mutated
+        // mid-enumeration we skip it instead of crashing on a freed element.
+        NSArray* snapshot = nil;
+        @try {
+            snapshot = [value allObjects];
+        } @catch (NSException* exception) {
+            continue;
+        }
+        for (NRMAMeasurement* measurement in snapshot) {
             [self consumeMeasurement:measurement];
         }
     }

--- a/Agent/Measurements/NRMAMeasurementPool.m
+++ b/Agent/Measurements/NRMAMeasurementPool.m
@@ -195,12 +195,16 @@
 {
     for (NSNumber* key in dictionary2) {
         id value2 = [dictionary2 objectForKey:key];
-        if (value2) {
-            if ([dictionary1.allKeys containsObject:key]) {
-                [[dictionary1 objectForKey:key] unionSet:value2];
-            } else {
-                [dictionary1 setObject:value2 forKey:key];
-            }
+        if (![value2 isKindOfClass:[NSSet class]]) {
+            continue;
+        }
+        NSMutableSet* existing = [dictionary1 objectForKey:key];
+        if (existing) {
+            [existing unionSet:value2];
+        } else {
+            // Own a private mutable set; never alias the producer's drained set instance,
+            // so the combined dictionary handed to consumers can't be mutated elsewhere.
+            [dictionary1 setObject:[value2 mutableCopy] forKey:key];
         }
     }
 }

--- a/Agent/Measurements/Producers/NRMAMeasurementProducer.m
+++ b/Agent/Measurements/Producers/NRMAMeasurementProducer.m
@@ -47,26 +47,43 @@
     }
 }
 
-// This method expects a dictionary of mutable sets.
+// This method expects a dictionary of sets.
 - (void) produceMeasurements:(NSDictionary*)measurements {
+    if (![measurements isKindOfClass:[NSDictionary class]]) {
+        return;
+    }
     @synchronized(self.producedMeasurements) {
         for (NSNumber* key in measurements.allKeys) {
             id value = [measurements objectForKey:key];
-            if (value) {
-                if ([self.producedMeasurements.allKeys containsObject:key]) {
-                    [[self.producedMeasurements objectForKey:key] unionSet:value];
-                } else {
-                    [self.producedMeasurements setObject:value forKey:key];
-                }
+            if (![value isKindOfClass:[NSSet class]]) {
+                continue;
+            }
+            NSMutableSet* existing = [self.producedMeasurements objectForKey:key];
+            if (existing) {
+                [existing unionSet:value];
+            } else {
+                // Store a private mutable copy so this producer exclusively owns the set.
+                // Never alias a set instance that another thread may still mutate — that
+                // shared-mutable-set race is what crashes consumers enumerating the set.
+                [self.producedMeasurements setObject:[value mutableCopy] forKey:key];
             }
         }
     }
 }
 - (NSDictionary*) drainMeasurements
 {
-    
+
     @synchronized(self.producedMeasurements) {
-        NSDictionary* measurements = [[NSDictionary alloc] initWithDictionary:self.producedMeasurements];
+        // Hand consumers a fully detached snapshot: copy each set so nothing a consumer
+        // iterates can be mutated by later production on another thread. A shallow
+        // initWithDictionary: would share the same NSMutableSet instances (use-after-free risk).
+        NSMutableDictionary* measurements = [[NSMutableDictionary alloc] initWithCapacity:self.producedMeasurements.count];
+        for (NSNumber* key in self.producedMeasurements.allKeys) {
+            id value = [self.producedMeasurements objectForKey:key];
+            if ([value isKindOfClass:[NSSet class]]) {
+                [measurements setObject:[value copy] forKey:key];
+            }
+        }
         [self.producedMeasurements removeAllObjects];
         return measurements;
     }


### PR DESCRIPTION
587952
```
Thread 0 name:
Thread 0 Crashed:
0   libsystem_malloc.dylib         	 0x00000001937d30a0 _xzm_xzone_malloc_freelist_outlined (libsystem_malloc.dylib)
1   CoreFoundation                 	 0x0000000188292338 _CFRuntimeCreateInstance (CoreFoundation)
2   CoreFoundation                 	 0x0000000188292a08 CFNumberCreate (CoreFoundation)
3   Foundation                     	 0x00000001862a68c4 -[NSPlaceholderNumber initWithDouble:] (Foundation)
4   Foundation                     	 0x00000001862a3574 +[NSNumber numberWithDouble:] (Foundation)
5   NewRelic                       	 0x0000000107e5ca84 +[NRMATraceController completeTrace:withExitTimestampMillis:] (NRMATraceController.m:546)
6   NewRelic                       	 0x0000000107e5c7e0 +[NRMATraceController exitMethodWithTimestampMillis:] (NRMATraceController.m:482)
7   NewRelic                       	 0x0000000107e668b0 NRMA__endMethod (NRMAMethodProfiler.m:0)
8   NewRelic                       	 0x0000000107e66d34 NRMA__boolParamHandler (NRMAMethodProfiler.m:0)
9   UIKitCore                      	 0x000000018e89b5d8 -[UINavigationController viewDidDisappear:] (UIKitCore)
10  NewRelic                       	 0x0000000107e66d20 NRMA__boolParamHandler (NRMAMethodProfiler.m:937)
11  UIKitCore                      	 0x000000018e95126c -[UIViewController _setViewAppearState:isAnimating:] (UIKitCore)
12  UIKitCore                      	 0x000000018e952100 -[UIViewController __viewDidDisappear:] (UIKitCore)
13  UIKitCore                      	 0x000000018e8711b0 -[UITabBarController viewDidDisappear:] (UIKitCore)
14  NewRelic                       	 0x0000000107e66d20 NRMA__boolParamHandler (NRMAMethodProfiler.m:937)
15  UIKitCore                      	 0x000000018e95126c -[UIViewController _setViewAppearState:isAnimating:] (UIKitCore)
16  UIKitCore                      	 0x000000018e951934 __52-[UIViewController _setViewAppearState:isAnimating:]_block_invoke_2 (UIKitCore)
17  UIKitCore                      	 0x000000018e9517d4 __52-[UIViewController _setViewAppearState:isAnimating:]_block_invoke (UIKitCore)
18  CoreFoundation                 	 0x00000001882a3f78 NSARRAY_IS_CALLING_OUT_TO_A_BLOCK (CoreFoundation)
19  CoreFoundation                 	 0x0000000188410c68 -[__NSSingleObjectArrayI enumerateObjectsWithOptions:usingBlock:] (CoreFoundation)
20  UIKitCore                      	 0x000000018e951608 -[UIViewController _setViewAppearState:isAnimating:] (UIKitCore)
21  UIKitCore                      	 0x000000018e952100 -[UIViewController __viewDidDisappear:] (UIKitCore)
22  UIKitCore                      	 0x000000018e9521fc -[UIViewController _endAppearanceTransition:] (UIKitCore)
23  UIKitCore                      	 0x000000018e85e8b0 __48-[UIPresentationController transitionDidFinish:]_block_invoke (UIKitCore)
24  UIKitCore                      	 0x000000018e85e564 -[UIPresentationController transitionDidFinish:] (UIKitCore)
25  UIKitCore                      	 0x000000018e867fb4 -[_UICurrentContextPresentationController transitionDidFinish:] (UIKitCore)
26  UIKitCore                      	 0x000000018e861e9c __77-[UIPresentationController runTransitionForCurrentStateAnimated:handoffData:]_block_invoke.106 (UIKitCore)
27  UIKitCore                      	 0x000000018e96cbb0 -[_UIViewControllerTransitionContext completeTransition:] (UIKitCore)
28  UIKitCore                      	 0x000000018f62eef4 -[UITransitionView notifyDidCompleteTransition:] (UIKitCore)
29  UIKitCore                      	 0x000000018f62ec88 -[UITransitionView _didCompleteTransition:] (UIKitCore)
30  UIKitCore                      	 0x000000018dd4d598 UIVIEW_IS_EXECUTING_ANIMATION_COMPLETION_BLOCK (UIKitCore)
31  UIKitCore                      	 0x000000018f655e58 -[UIViewAnimationBlockDelegate _didEndBlockAnimation:finished:context:] (UIKitCore)
32  UIKitCore                      	 0x000000018f6356a0 -[UIViewAnimationState sendDelegateAnimationDidStop:finished:] (UIKitCore)
33  UIKitCore                      	 0x000000018f635b04 -[UIViewAnimationState animationDidStop:finished:] (UIKitCore)
34  UIKitCore                      	 0x000000018f635b74 -[UIViewAnimationState animationDidStop:finished:] (UIKitCore)
35  QuartzCore                     	 0x0000000188d3912c run_animation_callbacks(void*) (QuartzCore)
36  libdispatch.dylib              	 0x00000001c0fd27fc _dispatch_client_callout (libdispatch.dylib)
37  libdispatch.dylib              	 0x00000001c0fefb10 _dispatch_main_queue_drain.cold.5 (libdispatch.dylib)
38  libdispatch.dylib              	 0x00000001c0fc7ec8 _dispatch_main_queue_drain (libdispatch.dylib)
39  libdispatch.dylib              	 0x00000001c0fc7e04 _dispatch_main_queue_callback_4CF (libdispatch.dylib)
40  CoreFoundation                 	 0x00000001882f92b4 CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE (CoreFoundation)
41  CoreFoundation                 	 0x00000001882acb3c __CFRunLoopRun (CoreFoundation)
42  CoreFoundation                 	 0x00000001882aba6c _CFRunLoopRunSpecificWithOptions (CoreFoundation)
43  GraphicsServices               	 0x000000022cc2d498 GSEventRunModal (GraphicsServices)
44  UIKitCore                      	 0x000000018dd5bdf8 -[UIApplication _run] (UIKitCore)
45  UIKitCore                      	 0x000000018dd04e54 UIApplicationMain (UIKitCore)
46  NPOS                           	 0x000000010472ffd8 main (/<compiler-generated>:0)
47                                 	 0x0000000185286e28 0x185286e28 + 0
```

587955
```
Thread 2 name:
Thread 2 Crashed:
0   libobjc.A.dylib                	 0x000000018a421444 objc_retain_x0 (libobjc.A.dylib)
1   NewRelic                       	 0x000000010639eef4 +[NRMAMeasurements recordBackgroundScopedMetricNamed:value:] (NRMAMeasurements.m:98)
2   NewRelic                       	 0x000000010639ca0c +[NRMATraceController completeTrace:withExitTimestampMillis:] (NRMATraceController.m:526)
3   NewRelic                       	 0x000000010639c7e0 +[NRMATraceController exitMethodWithTimestampMillis:] (NRMATraceController.m:482)
4   NewRelic                       	 0x00000001063a68b0 NRMA__endMethod (NRMAMethodProfiler.m:0)
5   NewRelic                       	 0x00000001063a6b80 NRMA__ptrIntPtrParamHandler (NRMAMethodProfiler.m:0)
6   NPOS                           	 0x00000001033e9154 SpanIngestRequest.body()
7   NPOS                           	 0x00000001033e9374 protocol witness for DeferredRequest.body() in conformance SpanIngestRequest
8   NPOS                           	 0x00000001034c8534 DeferredRequest.asURLRequest()
9   NPOS                           	 0x00000001033e9390 protocol witness for Request.asURLRequest() in conformance SpanIngestRequest
10  NPOS                           	 0x00000001034a793c URLRequestConvertibleProxy.init(request:)
11  NPOS                           	 0x00000001034b174c specialized Session.request(:options:)
12  NPOS                           	 0x00000001034afd98 specialized RequestMap.appendRequest<A>(with:closure:)
13  NPOS                           	 0x00000001034aefc8 Session.dataTask<A>(with:options:responseSerializer:completion:)
14  NPOS                           	 0x00000001034af2d8 protocol witness for DataNetworkProvider.dataTask<A>(with:options:responseSerializer:completion:) in conformance Session
15  NPOS                           	 0x00000001034c3088 DataNetworkProvider.dataTaskForDecodable<A>(with:options:valueType:decoder:completion:)
16  NPOS                           	 0x00000001033e8c0c DefaultSpanIngestWebService.pushSpansData(syncData:queue:completion:)
17  NPOS                           	 0x00000001033ed90c specialized DefaultDistributedTracingPlugin.sync(:failureCount:completion:)
18  NPOS                           	 0x0000000104a1c224 closure #1 in DefaultDatabaseSynchronizer.startSynchronousSyncProcess(isBackgroundSync:completion:)
19  NPOS                           	 0x0000000102bde7b8 thunk for @escaping @callee_guaranteed @Sendable () -> () (/<compiler-generated>:0)
20  libdispatch.dylib              	 0x00000001c61d8adc _dispatch_call_block_and_release (libdispatch.dylib)
21  libdispatch.dylib              	 0x00000001c61f27fc _dispatch_client_callout (libdispatch.dylib)
22  libdispatch.dylib              	 0x00000001c61e1468 _dispatch_lane_serial_drain (libdispatch.dylib)
23  libdispatch.dylib              	 0x00000001c61e1f44 _dispatch_lane_invoke (libdispatch.dylib)
24  libdispatch.dylib              	 0x00000001c61ec3ec _dispatch_root_queue_drain_deferred_wlh (libdispatch.dylib)
25  libdispatch.dylib              	 0x00000001c61ebce4 _dispatch_workloop_worker_thread (libdispatch.dylib)
26  libsystem_pthread.dylib        	 0x00000001ea0253b8 _pthread_wqthread (libsystem_pthread.dylib)
27  libsystem_pthread.dylib        	 0x00000001ea0248c0 start_wqthread (libsystem_pthread.dylib)
```

https://new-relic.atlassian.net/browse/NR-587944

```
Thread 11 name:
Thread 11 Crashed:
0   libobjc.A.dylib                	 0x0000000181e5144c objc_retain_x0 (libobjc.A.dylib)
1   NewRelic                       	 0x0000000104560328 -[NRMAMeasurementConsumer consumeMeasurements:] (NRMAMeasurementConsumer.m:35)
2   NewRelic                       	 0x000000010458d24c -[NRMAMeasurementPool broadcastMeasurements] (NRMAMeasurementPool.m:164)
3   NewRelic                       	 0x000000010457c0b0 -[NRMAMeasurementEngine broadcastMeasurements] (NRMAMeasurementEngine.m:91)
4   NewRelic                       	 0x00000001045441e0 +[NRMAMeasurements process] (NRMAMeasurements.m:359)
5   NewRelic                       	 0x000000010453ebb8 -[NRMATaskQueue dequeue] (NRMATaskQueue.m:154)
6   NewRelic                       	 0x000000010453e7e0 __35+[NRMATaskQueue synchronousDequeue]_block_invoke (NRMATaskQueue.m:96)
7   libdispatch.dylib              	 0x00000001bdc227fc _dispatch_client_callout (libdispatch.dylib)
8   libdispatch.dylib              	 0x00000001bdc18ce4 _dispatch_sync_invoke_and_complete_recurse (libdispatch.dylib)
9   libdispatch.dylib              	 0x00000001bdc18774 _dispatch_sync_f_slow (libdispatch.dylib)
10  NewRelic                       	 0x000000010453e7a8 +[NRMATaskQueue synchronousDequeue] (NRMATaskQueue.m:95)
11  NewRelic                       	 0x000000010457e384 __62+[NRMANetworkFacade noticeNetworkFailure:withTimer:withError:]_block_invoke ([NRMANetworkFacade.mm:364](http://nrmanetworkfacade.mm:364/))
12  libdispatch.dylib              	 0x00000001bdc08adc _dispatch_call_block_and_release (libdispatch.dylib)
13  libdispatch.dylib              	 0x00000001bdc227fc _dispatch_client_callout (libdispatch.dylib)
14  libdispatch.dylib              	 0x00000001bdc3f41c <deduplicated_symbol> (libdispatch.dylib)
15  libdispatch.dylib              	 0x00000001bdc1b0bc _dispatch_root_queue_drain (libdispatch.dylib)
16  libdispatch.dylib              	 0x00000001bdc1b6fc _dispatch_worker_thread2 (libdispatch.dylib)
17  libsystem_pthread.dylib        	 0x00000001e1a5537c _pthread_wqthread (libsystem_pthread.dylib)
18  libsystem_pthread.dylib        	 0x00000001e1a548c0 start_wqthread (libsystem_pthread.dylib)
```

587949
```
Thread 17 name:
Thread 17 Crashed:
0   libobjc.A.dylib                	 0x0000000188ced44c objc_retain_x0 (libobjc.A.dylib)
1   NewRelic                       	 0x0000000106303408 +[NRMAMeasurements recordMetric:] (NRMAMeasurements.m:174)
2   NewRelic                       	 0x00000001062fea94 -[NRMATaskQueue dequeue] (NRMATaskQueue.m:132)
3   NewRelic                       	 0x00000001062fe6ac __22+[NRMATaskQueue start]_block_invoke_2 (NRMATaskQueue.m:73)
4   libdispatch.dylib              	 0x00000001c4abe7fc _dispatch_client_callout (libdispatch.dylib)
5   libdispatch.dylib              	 0x00000001c4aa9664 _dispatch_continuation_pop (libdispatch.dylib)
6   libdispatch.dylib              	 0x00000001c4abc538 _dispatch_source_latch_and_call (libdispatch.dylib)
7   libdispatch.dylib              	 0x00000001c4abb20c _dispatch_source_invoke (libdispatch.dylib)
8   libdispatch.dylib              	 0x00000001c4aad2d0 _dispatch_lane_serial_drain (libdispatch.dylib)
9   libdispatch.dylib              	 0x00000001c4aadf44 _dispatch_lane_invoke (libdispatch.dylib)
10  libdispatch.dylib              	 0x00000001c4ab83ec _dispatch_root_queue_drain_deferred_wlh (libdispatch.dylib)
11  libdispatch.dylib              	 0x00000001c4ab7ce4 _dispatch_workloop_worker_thread (libdispatch.dylib)
12  libsystem_pthread.dylib        	 0x00000001e88f13b8 _pthread_wqthread (libsystem_pthread.dylib)
13  libsystem_pthread.dylib        	 0x00000001e88f08c0 start_wqthread (libsystem_pthread.dylib)
```