### PR TITLE
NR-417639: appVersion param added to dsym-upload-tools run-symbol-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ SCRIPT=`/usr/bin/find "${SRCROOT}" "${ARTIFACT_DIR}" -type f -name run-symbol-to
 
 - Add `--debug` as additional argument after the app token to write additional details to the `upload_dsym_results.log` file.
 
+- Add `-appVersion "<version>"` after the app token to set the reported app version explicitly (the `X-NewRelic-App-Version` header). Use this when `MARKETING_VERSION` is unset or empty — for example apps that manage versioning with `agvtool`, or multi-target apps built with `GENERATE_INFOPLIST_FILE = YES` — otherwise uploaded symbols may not match your builds. `-appVersion` and `--debug` can be combined in any order. App version precedence: `-appVersion` argument > `NEWRELIC_APP_VERSION` environment variable > `MARKETING_VERSION` environment variable.
+
 #### iOS agent 7.3.8 or lower:
 ```
 SCRIPT=`/usr/bin/find "${SRCROOT}" -name newrelic_postbuild.sh | head -n 1`

--- a/dsym-upload-tools/README_RUN_SYMBOL_TOOL.MD
+++ b/dsym-upload-tools/README_RUN_SYMBOL_TOOL.MD
@@ -20,6 +20,7 @@ Note: A few environment variables can be set to modify the behavior of the map o
 - NEWRELIC_DSYM_ENDPOINT: Dsym endpoint. default: "symbol"
 - NEWRELIC_SYMBOL_POST_KEY: Symbol Post Key used in Curl. default: "upload"
 - NEWRELIC_DSYM_POST_KEY: Dsym Post Key used in Curl. default: "dsym"
+- NEWRELIC_APP_VERSION: App version reported in the `X-NewRelic-App-Version` header. Overrides `MARKETING_VERSION`. Equivalent to passing `-appVersion` on the command line.
 
 Add "--debug" after last line of script to enable debug logs in the output `upload_dsym_results.log` file.
 
@@ -27,6 +28,24 @@ Add "--debug" after last line of script to enable debug logs in the output `uplo
     SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
     /bin/sh "${SCRIPT}" "APP_TOKEN" --debug
 ```
+
+## Setting the app version explicitly (`-appVersion`)
+
+Uploaded symbols are associated with your app's version via the `X-NewRelic-App-Version` header. By default this value comes from the `MARKETING_VERSION` build setting. Some projects don't set `MARKETING_VERSION` — for example apps that manage versioning with `agvtool`, or multi-target apps built with `GENERATE_INFOPLIST_FILE = YES`. In those cases the reported version can be empty or a placeholder, and uploaded symbol maps will not match your builds.
+
+To set the version explicitly, pass `-appVersion` after the app token. It can be combined with `--debug` in any order.
+
+```
+    SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+    /bin/sh "${SCRIPT}" "APP_TOKEN" -appVersion "7.8.2"
+```
+
+The app version is resolved with the following precedence:
+
+1. `-appVersion <version>` command-line argument
+2. `NEWRELIC_APP_VERSION` environment variable
+3. `MARKETING_VERSION` environment variable
+4. a built-in placeholder (a warning is logged in `upload_dsym_results.log` when this fallback is used)
 
 DSYM_UPLOAD_URL - define this environment variable above run script to override the New Relic server hostname
 

--- a/dsym-upload-tools/run-symbol-tool
+++ b/dsym-upload-tools/run-symbol-tool
@@ -5,12 +5,14 @@
 # run-symbol-tool 
 
 if [ ! $1 ]; then
-    echo "New Relic: usage: $0 <NEW_RELIC_APP_TOKEN> [--debug]"
+    echo "New Relic: usage: $0 <NEW_RELIC_APP_TOKEN> [--debug] [-appVersion <version>]"
     exit -1
 fi
 
 API_KEY=$1
-DEBUG_FLAG=${2:-''}
+# Consume the app token and forward any remaining optional arguments (--debug, -appVersion <version>)
+# to the Swift script verbatim. Using "$@" preserves quoting so a version value with spaces is safe.
+shift
 
 echo "New Relic: Processing dSYMs and uploading to New Relic. (In background...)"
 echo "New Relic: For troubleshooting, see upload_dsym_results.log file in project root folder. Add --debug after app token in Run Script for additional information."
@@ -18,8 +20,8 @@ echo "New Relic: For troubleshooting, see upload_dsym_results.log file in projec
 WORK_DIRECTORY=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 SCRIPT="$WORK_DIRECTORY/run-symbol-tool.swift"
 
-## Running with below command is useful for seeing output in Xcode, 
+## Running with below command is useful for seeing output in Xcode,
 ## but it will incur delays in the build process while the dSYMs process and upload.
-# /usr/bin/xcrun --sdk macosx swift "$SCRIPT" $API_KEY $DEBUG_FLAG
+# /usr/bin/xcrun --sdk macosx swift "$SCRIPT" "$API_KEY" "$@"
 
-/usr/bin/xcrun --sdk macosx swift "$SCRIPT" $API_KEY $DEBUG_FLAG > upload_dsym_results.log 2>&1 &
+/usr/bin/xcrun --sdk macosx swift "$SCRIPT" "$API_KEY" "$@" > upload_dsym_results.log 2>&1 &

--- a/dsym-upload-tools/run-symbol-tool.swift
+++ b/dsym-upload-tools/run-symbol-tool.swift
@@ -25,6 +25,16 @@
 //  /bin/sh "${SCRIPT}" "APP_TOKEN" --debug
 // ```
 //
+// Optional: pass "-appVersion" to set the reported app version (X-NewRelic-App-Version) explicitly.
+// Use this when MARKETING_VERSION is unset or empty (e.g. apps versioned with agvtool, or
+// multi-target apps that set GENERATE_INFOPLIST_FILE = YES). App version precedence:
+//   -appVersion arg  >  NEWRELIC_APP_VERSION env  >  MARKETING_VERSION env  >  default.
+//
+// ```
+//  SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+//  /bin/sh "${SCRIPT}" "APP_TOKEN" -appVersion "7.8.2"
+// ```
+//
 // DSYM_UPLOAD_URL - define this environment variable above run script to override the New Relic server hostname
 //
 // - Due to limitations with Swift scripting run-symbol-tool.swift is one file.
@@ -83,17 +93,36 @@ func start() {
     }
 
     guard CommandLine.arguments.count > 1 else {
-        // Must contain at least one argument: $APP_TOKEN. (--debug is optional)
-        print("Invalid Usage: Ex: Swift: run-symbol-tool.swift $APP_TOKEN [--debug]")
+        // Must contain at least one argument: $APP_TOKEN. (--debug and -appVersion are optional)
+        print("Invalid Usage: Ex: Swift: run-symbol-tool.swift $APP_TOKEN [--debug] [-appVersion <version>]")
         exit(1)
     }
     let apiKey = CommandLine.arguments[1]
     
-    if CommandLine.arguments.count == 3 {
-        let debugFlag = CommandLine.arguments[2]
-        if debugFlag == "--debug" {
+    // Optional CLI app-version override (e.g. -appVersion 7.8.2). Takes precedence over MARKETING_VERSION.
+    // NR-417639: agvtool / multi-target apps often leave MARKETING_VERSION unset or empty.
+    var appVersionOverride: String? = nil
+
+    // Parse the remaining optional arguments in an order-independent way so that --debug and
+    // -appVersion can appear in any order (and future flags can be added without breaking parsing).
+    let arguments = CommandLine.arguments
+    var argIndex = 2
+    while argIndex < arguments.count {
+        let arg = arguments[argIndex]
+        switch arg {
+        case "--debug":
             debug = true
+        case "-appVersion", "--appVersion", "--app-version":
+            guard argIndex + 1 < arguments.count else {
+                print("New Relic: Invalid Usage: \(arg) requires a value, e.g. -appVersion 7.8.2. Exiting.")
+                exit(1)
+            }
+            argIndex += 1
+            appVersionOverride = arguments[argIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+        default:
+            print("New Relic: Ignoring unrecognized argument: \(arg)")
         }
+        argIndex += 1
     }
 
 // Start Configure Env Vars //
@@ -106,7 +135,23 @@ func start() {
     symbolUploadDataPostKey = environment["NEWRELIC_SYMBOL_POST_KEY"] ?? "upload"
     dsymUploadDataPostKey   = environment["NEWRELIC_DSYM_POST_KEY"] ?? "dsym"
 
-    appVersionNumber = environment["MARKETING_VERSION"] ?? "1.2.3"
+    // App-version precedence: -appVersion arg > NEWRELIC_APP_VERSION env > MARKETING_VERSION env > default.
+    // Each source is treated as unresolved when empty so a present-but-empty MARKETING_VERSION
+    // no longer produces an empty X-NewRelic-App-Version header. (NR-417639)
+    if let overrideVersion = appVersionOverride, !overrideVersion.isEmpty {
+        appVersionNumber = overrideVersion
+        print("New Relic: Using app version \(appVersionNumber) (source: -appVersion argument)")
+    } else if let envAppVersion = environment["NEWRELIC_APP_VERSION"], !envAppVersion.isEmpty {
+        appVersionNumber = envAppVersion
+        print("New Relic: Using app version \(appVersionNumber) (source: NEWRELIC_APP_VERSION)")
+    } else if let marketingVersion = environment["MARKETING_VERSION"], !marketingVersion.isEmpty {
+        appVersionNumber = marketingVersion
+        print("New Relic: Using app version \(appVersionNumber) (source: MARKETING_VERSION)")
+    } else {
+        // No usable app version was found. Symbols would otherwise be tagged with a placeholder
+        // that will not match real builds, so warn loudly instead of failing silently. (NR-417639)
+        print("New Relic: WARNING - No app version found (MARKETING_VERSION is unset/empty and no -appVersion argument was provided). Using placeholder \"\(appVersionNumber)\"; uploaded symbol maps may not match your build's version. Pass -appVersion <version> or set MARKETING_VERSION / NEWRELIC_APP_VERSION.")
+    }
 // End Configure Env Vars //
 
 

--- a/examples/cocoapods/CocoapodsExample/dsym-upload-tools/README_RUN_SYMBOL_TOOL.MD
+++ b/examples/cocoapods/CocoapodsExample/dsym-upload-tools/README_RUN_SYMBOL_TOOL.MD
@@ -20,6 +20,7 @@ Note: A few environment variables can be set to modify the behavior of the map o
 - NEWRELIC_DSYM_ENDPOINT: Dsym endpoint. default: "symbol"
 - NEWRELIC_SYMBOL_POST_KEY: Symbol Post Key used in Curl. default: "upload"
 - NEWRELIC_DSYM_POST_KEY: Dsym Post Key used in Curl. default: "dsym"
+- NEWRELIC_APP_VERSION: App version reported in the `X-NewRelic-App-Version` header. Overrides `MARKETING_VERSION`. Equivalent to passing `-appVersion` on the command line.
 
 Add "--debug" after last line of script to enable debug logs in the output `upload_dsym_results.log` file.
 
@@ -27,6 +28,24 @@ Add "--debug" after last line of script to enable debug logs in the output `uplo
     SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
     /bin/sh "${SCRIPT}" "APP_TOKEN" --debug
 ```
+
+## Setting the app version explicitly (`-appVersion`)
+
+Uploaded symbols are associated with your app's version via the `X-NewRelic-App-Version` header. By default this value comes from the `MARKETING_VERSION` build setting. Some projects don't set `MARKETING_VERSION` — for example apps that manage versioning with `agvtool`, or multi-target apps built with `GENERATE_INFOPLIST_FILE = YES`. In those cases the reported version can be empty or a placeholder, and uploaded symbol maps will not match your builds.
+
+To set the version explicitly, pass `-appVersion` after the app token. It can be combined with `--debug` in any order.
+
+```
+    SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+    /bin/sh "${SCRIPT}" "APP_TOKEN" -appVersion "7.8.2"
+```
+
+The app version is resolved with the following precedence:
+
+1. `-appVersion <version>` command-line argument
+2. `NEWRELIC_APP_VERSION` environment variable
+3. `MARKETING_VERSION` environment variable
+4. a built-in placeholder (a warning is logged in `upload_dsym_results.log` when this fallback is used)
 
 DSYM_UPLOAD_URL - define this environment variable above run script to override the New Relic server hostname
 

--- a/examples/cocoapods/CocoapodsExample/dsym-upload-tools/run-symbol-tool
+++ b/examples/cocoapods/CocoapodsExample/dsym-upload-tools/run-symbol-tool
@@ -5,12 +5,14 @@
 # run-symbol-tool 
 
 if [ ! $1 ]; then
-    echo "New Relic: usage: $0 <NEW_RELIC_APP_TOKEN> [--debug]"
+    echo "New Relic: usage: $0 <NEW_RELIC_APP_TOKEN> [--debug] [-appVersion <version>]"
     exit -1
 fi
 
 API_KEY=$1
-DEBUG_FLAG=${2:-''}
+# Consume the app token and forward any remaining optional arguments (--debug, -appVersion <version>)
+# to the Swift script verbatim. Using "$@" preserves quoting so a version value with spaces is safe.
+shift
 
 echo "New Relic: Processing dSYMs and uploading to New Relic. (In background...)"
 echo "New Relic: For troubleshooting, see upload_dsym_results.log file in project root folder. Add --debug after app token in Run Script for additional information."
@@ -18,8 +20,8 @@ echo "New Relic: For troubleshooting, see upload_dsym_results.log file in projec
 WORK_DIRECTORY=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 SCRIPT="$WORK_DIRECTORY/run-symbol-tool.swift"
 
-## Running with below command is useful for seeing output in Xcode, 
+## Running with below command is useful for seeing output in Xcode,
 ## but it will incur delays in the build process while the dSYMs process and upload.
-# /usr/bin/xcrun --sdk macosx swift "$SCRIPT" $API_KEY $DEBUG_FLAG
+# /usr/bin/xcrun --sdk macosx swift "$SCRIPT" "$API_KEY" "$@"
 
-/usr/bin/xcrun --sdk macosx swift "$SCRIPT" $API_KEY $DEBUG_FLAG > upload_dsym_results.log 2>&1 &
+/usr/bin/xcrun --sdk macosx swift "$SCRIPT" "$API_KEY" "$@" > upload_dsym_results.log 2>&1 &

--- a/examples/cocoapods/CocoapodsExample/dsym-upload-tools/run-symbol-tool.swift
+++ b/examples/cocoapods/CocoapodsExample/dsym-upload-tools/run-symbol-tool.swift
@@ -25,6 +25,16 @@
 //  /bin/sh "${SCRIPT}" "APP_TOKEN" --debug
 // ```
 //
+// Optional: pass "-appVersion" to set the reported app version (X-NewRelic-App-Version) explicitly.
+// Use this when MARKETING_VERSION is unset or empty (e.g. apps versioned with agvtool, or
+// multi-target apps that set GENERATE_INFOPLIST_FILE = YES). App version precedence:
+//   -appVersion arg  >  NEWRELIC_APP_VERSION env  >  MARKETING_VERSION env  >  default.
+//
+// ```
+//  SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+//  /bin/sh "${SCRIPT}" "APP_TOKEN" -appVersion "7.8.2"
+// ```
+//
 // DSYM_UPLOAD_URL - define this environment variable above run script to override the New Relic server hostname
 //
 // - Due to limitations with Swift scripting run-symbol-tool.swift is one file.
@@ -55,6 +65,9 @@ var osName = "iOS"
 var platformName = "Native"
 var appVersionNumber = "1.2.3"
 
+// Maximum zipped source map size (in bytes) before falling back to telemetry upload (200 MB).
+let sourceMapSizeThreshold: UInt64 = 209_715_200
+
 enum SymbolToolError: Error {
     case failedToConvert
     case failedToUpload
@@ -80,17 +93,36 @@ func start() {
     }
 
     guard CommandLine.arguments.count > 1 else {
-        // Must contain at least one argument: $APP_TOKEN. (--debug is optional)
-        print("Invalid Usage: Ex: Swift: run-symbol-tool.swift $APP_TOKEN [--debug]")
+        // Must contain at least one argument: $APP_TOKEN. (--debug and -appVersion are optional)
+        print("Invalid Usage: Ex: Swift: run-symbol-tool.swift $APP_TOKEN [--debug] [-appVersion <version>]")
         exit(1)
     }
     let apiKey = CommandLine.arguments[1]
     
-    if CommandLine.arguments.count == 3 {
-        let debugFlag = CommandLine.arguments[2]
-        if debugFlag == "--debug" {
+    // Optional CLI app-version override (e.g. -appVersion 7.8.2). Takes precedence over MARKETING_VERSION.
+    // NR-417639: agvtool / multi-target apps often leave MARKETING_VERSION unset or empty.
+    var appVersionOverride: String? = nil
+
+    // Parse the remaining optional arguments in an order-independent way so that --debug and
+    // -appVersion can appear in any order (and future flags can be added without breaking parsing).
+    let arguments = CommandLine.arguments
+    var argIndex = 2
+    while argIndex < arguments.count {
+        let arg = arguments[argIndex]
+        switch arg {
+        case "--debug":
             debug = true
+        case "-appVersion", "--appVersion", "--app-version":
+            guard argIndex + 1 < arguments.count else {
+                print("New Relic: Invalid Usage: \(arg) requires a value, e.g. -appVersion 7.8.2. Exiting.")
+                exit(1)
+            }
+            argIndex += 1
+            appVersionOverride = arguments[argIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+        default:
+            print("New Relic: Ignoring unrecognized argument: \(arg)")
         }
+        argIndex += 1
     }
 
 // Start Configure Env Vars //
@@ -103,7 +135,23 @@ func start() {
     symbolUploadDataPostKey = environment["NEWRELIC_SYMBOL_POST_KEY"] ?? "upload"
     dsymUploadDataPostKey   = environment["NEWRELIC_DSYM_POST_KEY"] ?? "dsym"
 
-    appVersionNumber = environment["MARKETING_VERSION"] ?? "1.2.3"
+    // App-version precedence: -appVersion arg > NEWRELIC_APP_VERSION env > MARKETING_VERSION env > default.
+    // Each source is treated as unresolved when empty so a present-but-empty MARKETING_VERSION
+    // no longer produces an empty X-NewRelic-App-Version header. (NR-417639)
+    if let overrideVersion = appVersionOverride, !overrideVersion.isEmpty {
+        appVersionNumber = overrideVersion
+        print("New Relic: Using app version \(appVersionNumber) (source: -appVersion argument)")
+    } else if let envAppVersion = environment["NEWRELIC_APP_VERSION"], !envAppVersion.isEmpty {
+        appVersionNumber = envAppVersion
+        print("New Relic: Using app version \(appVersionNumber) (source: NEWRELIC_APP_VERSION)")
+    } else if let marketingVersion = environment["MARKETING_VERSION"], !marketingVersion.isEmpty {
+        appVersionNumber = marketingVersion
+        print("New Relic: Using app version \(appVersionNumber) (source: MARKETING_VERSION)")
+    } else {
+        // No usable app version was found. Symbols would otherwise be tagged with a placeholder
+        // that will not match real builds, so warn loudly instead of failing silently. (NR-417639)
+        print("New Relic: WARNING - No app version found (MARKETING_VERSION is unset/empty and no -appVersion argument was provided). Using placeholder \"\(appVersionNumber)\"; uploaded symbol maps may not match your build's version. Pass -appVersion <version> or set MARKETING_VERSION / NEWRELIC_APP_VERSION.")
+    }
 // End Configure Env Vars //
 
 
@@ -313,24 +361,38 @@ func processDsym(_ path: String, _ apiKey: String, _ url: String) throws {
 
             if let archiveUrl = archiveUrl {
 
-                // get size @ archiveUrl 
-                guard let size = getSizeAtURL(archiveUrl) else { 
+                // get size @ archiveUrl
+                guard let size = getSizeAtURL(archiveUrl) else {
                     print("Failed to get fileSize. --failing")
-                    return 
+                    return
                 }
                 if debug {
-                    print("Detected zipped map file size = \(size). Uploading...")
-                }
-                // Now that we have archiveUrl with the combined map files zipped up, upload the map file.
-                let mapUploadResult = try uploadFile(archiveUrl.path, apiKey, url, false, size)
-                if mapUploadResult == "201" {
-                    print("Successfully uploaded map: \(archiveUrl.path)")
-                }
-                else {
-                    print("*** Failed w/ error: \(mapUploadResult ?? "NO ERROR") when upload \(archiveUrl.path)")
+                    print("Detected zipped map file size = \(size).")
                 }
 
-                // Remove moved map file and zipped map file and temporary folder.
+                // Check if the zipped source map exceeds the 200MB upload threshold.
+                // Because source maps are highly compressible, only the zipped size is evaluated.
+                if size > sourceMapSizeThreshold {
+                    // File is too large to upload directly; send telemetry metadata instead.
+                    if debug { print("Zipped map (\(size) bytes) exceeds 200MB threshold. Using telemetry fallback.") }
+                    let telemetryResult = try uploadViaTelemetry(archiveUrl.path, apiKey, url, size)
+                    if telemetryResult == "200" || telemetryResult == "201" {
+                        print("Successfully sent telemetry for oversized map: \(archiveUrl.path)")
+                    } else {
+                        print("*** Failed w/ error: \(telemetryResult ?? "NO ERROR") sending telemetry for \(archiveUrl.path)")
+                    }
+                } else {
+                    if debug { print("Uploading zipped map file (\(size) bytes)...") }
+                    // Now that we have archiveUrl with the combined map files zipped up, upload the map file.
+                    let mapUploadResult = try uploadFile(archiveUrl.path, apiKey, url, false, size)
+                    if mapUploadResult == "201" {
+                        print("Successfully uploaded map: \(archiveUrl.path)")
+                    } else {
+                        print("*** Failed w/ error: \(mapUploadResult ?? "NO ERROR") when upload \(archiveUrl.path)")
+                    }
+                }
+
+                // Remove moved map file, zipped map file, and temporary folder.
                 try fileManager.removeItem(at: tempDirURL)
             }
         } catch {
@@ -501,6 +563,29 @@ func uploadFile(_ path: String, _ apiKey: String, _ url: String, _ isDsym: Bool,
         throw SymbolToolError.failedToUpload
     }
 
+    return resultFromCurl
+}
+
+// Telemetry fallback: sends a Base64-encoded JSON metadata payload via the x-telemetry-data header
+// instead of uploading the source map file directly. Used when the zipped map exceeds 200MB.
+func uploadViaTelemetry(_ path: String, _ apiKey: String, _ url: String, _ size: UInt64) throws -> String? {
+    var resultFromCurl: String? = nil
+    do {
+        let jsonString = "{\"type\":\"sourcemap\",\"size\":\(size),\"appVersion\":\"\(appVersionNumber)\",\"agentVersion\":\"\(versionNumber)\",\"osName\":\"\(osName)\",\"platform\":\"\(platformName)\",\"reason\":\"file_size_exceeded\"}"
+        guard let jsonData = jsonString.data(using: .utf8) else {
+            print("Failed to encode telemetry JSON.")
+            throw SymbolToolError.failedToUpload
+        }
+        let telemetryB64 = jsonData.base64EncodedString()
+
+        let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -H \"x-app-license-key: \(apiKey)\" -H \"X-NewRelic-Agent-Version: \(versionNumber)\" -H \"X-NewRelic-OS-Name: \(osName)\" -H \"X-NewRelic-Platform: \(platformName)\" -H \"X-NewRelic-App-Version: \(appVersionNumber)\" -H \"X-File-Size: \(size)\" -H \"x-telemetry-data: \(telemetryB64)\" \(url)/\(symbolEndpointPath)"
+
+        if debug { print("Executing $ \(command)") }
+        resultFromCurl = try shell(command)
+    } catch {
+        print("curl telemetry \(error). Exiting upload process.")
+        throw SymbolToolError.failedToUpload
+    }
     return resultFromCurl
 }
 

--- a/examples/manual/FrameworkExample/dsym-upload-tools/README_RUN_SYMBOL_TOOL.MD
+++ b/examples/manual/FrameworkExample/dsym-upload-tools/README_RUN_SYMBOL_TOOL.MD
@@ -20,6 +20,7 @@ Note: A few environment variables can be set to modify the behavior of the map o
 - NEWRELIC_DSYM_ENDPOINT: Dsym endpoint. default: "symbol"
 - NEWRELIC_SYMBOL_POST_KEY: Symbol Post Key used in Curl. default: "upload"
 - NEWRELIC_DSYM_POST_KEY: Dsym Post Key used in Curl. default: "dsym"
+- NEWRELIC_APP_VERSION: App version reported in the `X-NewRelic-App-Version` header. Overrides `MARKETING_VERSION`. Equivalent to passing `-appVersion` on the command line.
 
 Add "--debug" after last line of script to enable debug logs in the output `upload_dsym_results.log` file.
 
@@ -27,6 +28,24 @@ Add "--debug" after last line of script to enable debug logs in the output `uplo
     SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
     /bin/sh "${SCRIPT}" "APP_TOKEN" --debug
 ```
+
+## Setting the app version explicitly (`-appVersion`)
+
+Uploaded symbols are associated with your app's version via the `X-NewRelic-App-Version` header. By default this value comes from the `MARKETING_VERSION` build setting. Some projects don't set `MARKETING_VERSION` — for example apps that manage versioning with `agvtool`, or multi-target apps built with `GENERATE_INFOPLIST_FILE = YES`. In those cases the reported version can be empty or a placeholder, and uploaded symbol maps will not match your builds.
+
+To set the version explicitly, pass `-appVersion` after the app token. It can be combined with `--debug` in any order.
+
+```
+    SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+    /bin/sh "${SCRIPT}" "APP_TOKEN" -appVersion "7.8.2"
+```
+
+The app version is resolved with the following precedence:
+
+1. `-appVersion <version>` command-line argument
+2. `NEWRELIC_APP_VERSION` environment variable
+3. `MARKETING_VERSION` environment variable
+4. a built-in placeholder (a warning is logged in `upload_dsym_results.log` when this fallback is used)
 
 DSYM_UPLOAD_URL - define this environment variable above run script to override the New Relic server hostname
 

--- a/examples/manual/FrameworkExample/dsym-upload-tools/run-symbol-tool
+++ b/examples/manual/FrameworkExample/dsym-upload-tools/run-symbol-tool
@@ -5,12 +5,14 @@
 # run-symbol-tool 
 
 if [ ! $1 ]; then
-    echo "New Relic: usage: $0 <NEW_RELIC_APP_TOKEN> [--debug]"
+    echo "New Relic: usage: $0 <NEW_RELIC_APP_TOKEN> [--debug] [-appVersion <version>]"
     exit -1
 fi
 
 API_KEY=$1
-DEBUG_FLAG=${2:-''}
+# Consume the app token and forward any remaining optional arguments (--debug, -appVersion <version>)
+# to the Swift script verbatim. Using "$@" preserves quoting so a version value with spaces is safe.
+shift
 
 echo "New Relic: Processing dSYMs and uploading to New Relic. (In background...)"
 echo "New Relic: For troubleshooting, see upload_dsym_results.log file in project root folder. Add --debug after app token in Run Script for additional information."
@@ -18,8 +20,8 @@ echo "New Relic: For troubleshooting, see upload_dsym_results.log file in projec
 WORK_DIRECTORY=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 SCRIPT="$WORK_DIRECTORY/run-symbol-tool.swift"
 
-## Running with below command is useful for seeing output in Xcode, 
+## Running with below command is useful for seeing output in Xcode,
 ## but it will incur delays in the build process while the dSYMs process and upload.
-# /usr/bin/xcrun --sdk macosx swift "$SCRIPT" $API_KEY $DEBUG_FLAG
+# /usr/bin/xcrun --sdk macosx swift "$SCRIPT" "$API_KEY" "$@"
 
-/usr/bin/xcrun --sdk macosx swift "$SCRIPT" $API_KEY $DEBUG_FLAG > upload_dsym_results.log 2>&1 &
+/usr/bin/xcrun --sdk macosx swift "$SCRIPT" "$API_KEY" "$@" > upload_dsym_results.log 2>&1 &

--- a/examples/manual/FrameworkExample/dsym-upload-tools/run-symbol-tool.swift
+++ b/examples/manual/FrameworkExample/dsym-upload-tools/run-symbol-tool.swift
@@ -25,6 +25,16 @@
 //  /bin/sh "${SCRIPT}" "APP_TOKEN" --debug
 // ```
 //
+// Optional: pass "-appVersion" to set the reported app version (X-NewRelic-App-Version) explicitly.
+// Use this when MARKETING_VERSION is unset or empty (e.g. apps versioned with agvtool, or
+// multi-target apps that set GENERATE_INFOPLIST_FILE = YES). App version precedence:
+//   -appVersion arg  >  NEWRELIC_APP_VERSION env  >  MARKETING_VERSION env  >  default.
+//
+// ```
+//  SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+//  /bin/sh "${SCRIPT}" "APP_TOKEN" -appVersion "7.8.2"
+// ```
+//
 // DSYM_UPLOAD_URL - define this environment variable above run script to override the New Relic server hostname
 //
 // - Due to limitations with Swift scripting run-symbol-tool.swift is one file.
@@ -55,6 +65,9 @@ var osName = "iOS"
 var platformName = "Native"
 var appVersionNumber = "1.2.3"
 
+// Maximum zipped source map size (in bytes) before falling back to telemetry upload (200 MB).
+let sourceMapSizeThreshold: UInt64 = 209_715_200
+
 enum SymbolToolError: Error {
     case failedToConvert
     case failedToUpload
@@ -80,17 +93,36 @@ func start() {
     }
 
     guard CommandLine.arguments.count > 1 else {
-        // Must contain at least one argument: $APP_TOKEN. (--debug is optional)
-        print("Invalid Usage: Ex: Swift: run-symbol-tool.swift $APP_TOKEN [--debug]")
+        // Must contain at least one argument: $APP_TOKEN. (--debug and -appVersion are optional)
+        print("Invalid Usage: Ex: Swift: run-symbol-tool.swift $APP_TOKEN [--debug] [-appVersion <version>]")
         exit(1)
     }
     let apiKey = CommandLine.arguments[1]
     
-    if CommandLine.arguments.count == 3 {
-        let debugFlag = CommandLine.arguments[2]
-        if debugFlag == "--debug" {
+    // Optional CLI app-version override (e.g. -appVersion 7.8.2). Takes precedence over MARKETING_VERSION.
+    // NR-417639: agvtool / multi-target apps often leave MARKETING_VERSION unset or empty.
+    var appVersionOverride: String? = nil
+
+    // Parse the remaining optional arguments in an order-independent way so that --debug and
+    // -appVersion can appear in any order (and future flags can be added without breaking parsing).
+    let arguments = CommandLine.arguments
+    var argIndex = 2
+    while argIndex < arguments.count {
+        let arg = arguments[argIndex]
+        switch arg {
+        case "--debug":
             debug = true
+        case "-appVersion", "--appVersion", "--app-version":
+            guard argIndex + 1 < arguments.count else {
+                print("New Relic: Invalid Usage: \(arg) requires a value, e.g. -appVersion 7.8.2. Exiting.")
+                exit(1)
+            }
+            argIndex += 1
+            appVersionOverride = arguments[argIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+        default:
+            print("New Relic: Ignoring unrecognized argument: \(arg)")
         }
+        argIndex += 1
     }
 
 // Start Configure Env Vars //
@@ -103,7 +135,23 @@ func start() {
     symbolUploadDataPostKey = environment["NEWRELIC_SYMBOL_POST_KEY"] ?? "upload"
     dsymUploadDataPostKey   = environment["NEWRELIC_DSYM_POST_KEY"] ?? "dsym"
 
-    appVersionNumber = environment["MARKETING_VERSION"] ?? "1.2.3"
+    // App-version precedence: -appVersion arg > NEWRELIC_APP_VERSION env > MARKETING_VERSION env > default.
+    // Each source is treated as unresolved when empty so a present-but-empty MARKETING_VERSION
+    // no longer produces an empty X-NewRelic-App-Version header. (NR-417639)
+    if let overrideVersion = appVersionOverride, !overrideVersion.isEmpty {
+        appVersionNumber = overrideVersion
+        print("New Relic: Using app version \(appVersionNumber) (source: -appVersion argument)")
+    } else if let envAppVersion = environment["NEWRELIC_APP_VERSION"], !envAppVersion.isEmpty {
+        appVersionNumber = envAppVersion
+        print("New Relic: Using app version \(appVersionNumber) (source: NEWRELIC_APP_VERSION)")
+    } else if let marketingVersion = environment["MARKETING_VERSION"], !marketingVersion.isEmpty {
+        appVersionNumber = marketingVersion
+        print("New Relic: Using app version \(appVersionNumber) (source: MARKETING_VERSION)")
+    } else {
+        // No usable app version was found. Symbols would otherwise be tagged with a placeholder
+        // that will not match real builds, so warn loudly instead of failing silently. (NR-417639)
+        print("New Relic: WARNING - No app version found (MARKETING_VERSION is unset/empty and no -appVersion argument was provided). Using placeholder \"\(appVersionNumber)\"; uploaded symbol maps may not match your build's version. Pass -appVersion <version> or set MARKETING_VERSION / NEWRELIC_APP_VERSION.")
+    }
 // End Configure Env Vars //
 
 
@@ -313,24 +361,38 @@ func processDsym(_ path: String, _ apiKey: String, _ url: String) throws {
 
             if let archiveUrl = archiveUrl {
 
-                // get size @ archiveUrl 
-                guard let size = getSizeAtURL(archiveUrl) else { 
+                // get size @ archiveUrl
+                guard let size = getSizeAtURL(archiveUrl) else {
                     print("Failed to get fileSize. --failing")
-                    return 
+                    return
                 }
                 if debug {
-                    print("Detected zipped map file size = \(size). Uploading...")
-                }
-                // Now that we have archiveUrl with the combined map files zipped up, upload the map file.
-                let mapUploadResult = try uploadFile(archiveUrl.path, apiKey, url, false, size)
-                if mapUploadResult == "201" {
-                    print("Successfully uploaded map: \(archiveUrl.path)")
-                }
-                else {
-                    print("*** Failed w/ error: \(mapUploadResult ?? "NO ERROR") when upload \(archiveUrl.path)")
+                    print("Detected zipped map file size = \(size).")
                 }
 
-                // Remove moved map file and zipped map file and temporary folder.
+                // Check if the zipped source map exceeds the 200MB upload threshold.
+                // Because source maps are highly compressible, only the zipped size is evaluated.
+                if size > sourceMapSizeThreshold {
+                    // File is too large to upload directly; send telemetry metadata instead.
+                    if debug { print("Zipped map (\(size) bytes) exceeds 200MB threshold. Using telemetry fallback.") }
+                    let telemetryResult = try uploadViaTelemetry(archiveUrl.path, apiKey, url, size)
+                    if telemetryResult == "200" || telemetryResult == "201" {
+                        print("Successfully sent telemetry for oversized map: \(archiveUrl.path)")
+                    } else {
+                        print("*** Failed w/ error: \(telemetryResult ?? "NO ERROR") sending telemetry for \(archiveUrl.path)")
+                    }
+                } else {
+                    if debug { print("Uploading zipped map file (\(size) bytes)...") }
+                    // Now that we have archiveUrl with the combined map files zipped up, upload the map file.
+                    let mapUploadResult = try uploadFile(archiveUrl.path, apiKey, url, false, size)
+                    if mapUploadResult == "201" {
+                        print("Successfully uploaded map: \(archiveUrl.path)")
+                    } else {
+                        print("*** Failed w/ error: \(mapUploadResult ?? "NO ERROR") when upload \(archiveUrl.path)")
+                    }
+                }
+
+                // Remove moved map file, zipped map file, and temporary folder.
                 try fileManager.removeItem(at: tempDirURL)
             }
         } catch {
@@ -501,6 +563,29 @@ func uploadFile(_ path: String, _ apiKey: String, _ url: String, _ isDsym: Bool,
         throw SymbolToolError.failedToUpload
     }
 
+    return resultFromCurl
+}
+
+// Telemetry fallback: sends a Base64-encoded JSON metadata payload via the x-telemetry-data header
+// instead of uploading the source map file directly. Used when the zipped map exceeds 200MB.
+func uploadViaTelemetry(_ path: String, _ apiKey: String, _ url: String, _ size: UInt64) throws -> String? {
+    var resultFromCurl: String? = nil
+    do {
+        let jsonString = "{\"type\":\"sourcemap\",\"size\":\(size),\"appVersion\":\"\(appVersionNumber)\",\"agentVersion\":\"\(versionNumber)\",\"osName\":\"\(osName)\",\"platform\":\"\(platformName)\",\"reason\":\"file_size_exceeded\"}"
+        guard let jsonData = jsonString.data(using: .utf8) else {
+            print("Failed to encode telemetry JSON.")
+            throw SymbolToolError.failedToUpload
+        }
+        let telemetryB64 = jsonData.base64EncodedString()
+
+        let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -H \"x-app-license-key: \(apiKey)\" -H \"X-NewRelic-Agent-Version: \(versionNumber)\" -H \"X-NewRelic-OS-Name: \(osName)\" -H \"X-NewRelic-Platform: \(platformName)\" -H \"X-NewRelic-App-Version: \(appVersionNumber)\" -H \"X-File-Size: \(size)\" -H \"x-telemetry-data: \(telemetryB64)\" \(url)/\(symbolEndpointPath)"
+
+        if debug { print("Executing $ \(command)") }
+        resultFromCurl = try shell(command)
+    } catch {
+        print("curl telemetry \(error). Exiting upload process.")
+        throw SymbolToolError.failedToUpload
+    }
     return resultFromCurl
 }
 

--- a/fastlane/TestFastfile
+++ b/fastlane/TestFastfile
@@ -183,7 +183,19 @@ platform :ios do
         sh("export DWARF_DSYM_FOLDER_PATH=\".\" && /usr/bin/xcrun --sdk macosx swift \"./dsym-upload-tools/run-symbol-tool.swift\" \"API-KEY\" --debug")
 
         # shouldn't fail
-        sh("./dsym-upload-tools/run-symbol-tool \"API-KEY\"")        
+        sh("./dsym-upload-tools/run-symbol-tool \"API-KEY\"")
+
+        # NR-417639: verify the optional -appVersion argument overrides the reported app version.
+        # A block is passed to sh so a non-zero exit (e.g. when no dSYM is present locally) does not
+        # fail the lane; the resolved-version line is printed before dSYM processing regardless.
+        appVersionOutput = ""
+        sh("export DWARF_DSYM_FOLDER_PATH=\".\" && /usr/bin/xcrun --sdk macosx swift \"./dsym-upload-tools/run-symbol-tool.swift\" \"API-KEY\" --debug -appVersion 9.9.9") do |status, result, command|
+          appVersionOutput = result
+        end
+        unless appVersionOutput.include?("Using app version 9.9.9 (source: -appVersion argument)")
+          UI.user_error!("run-symbol-tool did not honor -appVersion override (NR-417639). Output:\n#{appVersionOutput}")
+        end
+        UI.success("run-symbol-tool honored -appVersion override (NR-417639).")        
     end
   end
 end


### PR DESCRIPTION
NR-417639 is implemented and verified. Here's the summary.

What changed

Core (canonical, shipped in the xcframework via FrameworkFastfile:50):
- dsym-upload-tools/run-symbol-tool.swift — replaced the brittle positional --debug check with an order-independent argument loop that also parses -appVersion (aliases --appVersion/--app-version, consumes the next token as its value, errors + exit(1) if the value is missing). Rewrote the app-version resolution with clear precedence and empty-string guards, plus a loud warning when it falls back to the placeholder.
- dsym-upload-tools/run-symbol-tool (sh wrapper) — shifts the app token and forwards "$@" so -appVersion "x.y.z" passes through intact (quoting-safe).

App-version precedence now:
-appVersion arg  >  NEWRELIC_APP_VERSION env  >  MARKETING_VERSION env  >  "1.2.3" placeholder (warns) (The NEWRELIC_APP_VERSION env was your "both" choice — parity with the existing NEWRELIC_* override pattern.)

Docs (task per the ticket's explicit request): dsym-upload-tools/README_RUN_SYMBOL_TOOL.MD and root README.md — documented -appVersion, NEWRELIC_APP_VERSION, the precedence, and the agvtool / GENERATE_INFOPLIST_FILE=YES gotcha.

Sync + test: re-synced both examples/*/dsym-upload-tools/ copies from canonical (they were also stale on the 200 MB telemetry feature — now identical); added a -appVersion assertion to runDsymUploadToolsTests in fastlane/TestFastfile (ruby -c passes).

Verification (ran the real script/wrapper)

┌──────────────────────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│                           Case                           │                            Result                            │
├──────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ -appVersion 9.9.9 (no MARKETING_VERSION)                 │ ✅ Using app version 9.9.9 (source: -appVersion argument)    │
├──────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ -appVersion 9.9.9 + MARKETING_VERSION=5.5.5              │ ✅ 9.9.9 (arg wins)                                          │
├──────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ NEWRELIC_APP_VERSION=8.8.8 + MARKETING_VERSION=5.5.5     │ ✅ 8.8.8 (env wins over marketing)                           │
├──────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ MARKETING_VERSION=5.5.5 only                             │ ✅ 5.5.5                                                     │
├──────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ nothing set / present-but-empty MARKETING_VERSION=""     │ ✅ WARNING + placeholder (fixes the "empty version" failure  │
│                                                          │ mode)                                                        │
├──────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ -appVersion with no value                                │ ✅ usage error, real exit 1                                  │
├──────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ order-independence (-appVersion before --debug), unknown │ ✅ resolves correctly; unknown arg ignored gracefully        │
│  arg                                                     │                                                              │
├──────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ wrapper end-to-end incl. value with a space ("1.0 beta") │ ✅ forwarded as one arg; backward-compat token-only still    │
│                                                          │ works                                                        │
└──────────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘