### PR TITLE
NT-323614: suppress dt w flutter calls

### DIFF
--- a/Agent.xcodeproj/project.pbxproj
+++ b/Agent.xcodeproj/project.pbxproj
@@ -1371,19 +1371,19 @@
 		348232FB2BC5F20B0070FAC3 /* NRMAHarvesterConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 02FF495C24DC628F00115469 /* NRMAHarvesterConfiguration.h */; };
 		348232FC2BC5F20B0070FAC3 /* NRMATraceConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 02FF496024DC629000115469 /* NRMATraceConfiguration.m */; };
 		348232FD2BC5F20B0070FAC3 /* NRMAHarvestData.m in Sources */ = {isa = PBXBuildFile; fileRef = 02FF495824DC628F00115469 /* NRMAHarvestData.m */; };
-		348232FE2BC5F2140070FAC3 /* (null) in Headers */ = {isa = PBXBuildFile; };
+		348232FE2BC5F2140070FAC3 /* BuildFile in Headers */ = {isa = PBXBuildFile; };
 		348232FF2BC5F2140070FAC3 /* HexUploadPublisher.mm in Sources */ = {isa = PBXBuildFile; fileRef = 02FF492724DC625A00115469 /* HexUploadPublisher.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		348233002BC5F2140070FAC3 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		348233002BC5F2140070FAC3 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		348233012BC5F2140070FAC3 /* NRMAExceptionReportAdaptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 02FF492924DC625A00115469 /* NRMAExceptionReportAdaptor.h */; };
 		348233022BC5F2140070FAC3 /* NRMARetryTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 02FF492D24DC625A00115469 /* NRMARetryTracker.h */; };
-		348233032BC5F2140070FAC3 /* (null) in Headers */ = {isa = PBXBuildFile; };
+		348233032BC5F2140070FAC3 /* BuildFile in Headers */ = {isa = PBXBuildFile; };
 		348233042BC5F2140070FAC3 /* NRMAHexUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 02FF492524DC625A00115469 /* NRMAHexUploader.m */; };
 		348233052BC5F2140070FAC3 /* NRMARetryTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 02FF492624DC625A00115469 /* NRMARetryTracker.m */; };
 		348233062BC5F2140070FAC3 /* NRMAHandledExceptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 02FF492824DC625A00115469 /* NRMAHandledExceptions.h */; };
 		348233072BC5F2140070FAC3 /* NRMAHexUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 02FF492B24DC625A00115469 /* NRMAHexUploader.h */; };
 		348233082BC5F2140070FAC3 /* NRMAExceptionReportAdaptor.mm in Sources */ = {isa = PBXBuildFile; fileRef = 02FF492A24DC625A00115469 /* NRMAExceptionReportAdaptor.mm */; };
 		348233092BC5F2140070FAC3 /* NRMAHandledExceptions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 02FF492F24DC625A00115469 /* NRMAHandledExceptions.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		3482330A2BC5F2140070FAC3 /* (null) in Sources */ = {isa = PBXBuildFile; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		3482330A2BC5F2140070FAC3 /* BuildFile in Sources */ = {isa = PBXBuildFile; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		3482330B2BC5F2140070FAC3 /* HexUploadPublisher.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 02FF492324DC625A00115469 /* HexUploadPublisher.hpp */; };
 		3482330D2BC5F21B0070FAC3 /* NRMAExceptionHandlerManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 02FF48D524DC622600115469 /* NRMAExceptionHandlerManager.h */; };
 		3482330E2BC5F21B0070FAC3 /* NRMACrashDataUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 02FF48D724DC622700115469 /* NRMACrashDataUploader.h */; };
@@ -1576,6 +1576,7 @@
 		34EA78CA2A39221E0071CC95 /* NRMACustomEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 34EA78C72A39221E0071CC95 /* NRMACustomEvent.m */; };
 		34EA78CB2A39221E0071CC95 /* NRMACustomEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 34EA78C72A39221E0071CC95 /* NRMACustomEvent.m */; };
 		34EA78E02A3924CC0071CC95 /* TestCustomEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = 34EA78DF2A3924CC0071CC95 /* TestCustomEvents.m */; };
+		8B498242383AF7020CD36D72 /* NRMANetworkFacadeTraceHeaderTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 578D57D9E9373167EBE8C0CF /* NRMANetworkFacadeTraceHeaderTests.mm */; };
 		C94590EE289AC0EC0062A4DE /* SwiftTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0209ACA424E7393B00E45C90 /* SwiftTestHelper.swift */; };
 		C94590EF289AC0F00062A4DE /* NRMASwiftInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC8324E7393200E45C90 /* NRMASwiftInstrumentationTests.swift */; };
 		C94F518D28577E0000E81E01 /* InstrumentationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C94F518C28577E0000E81E01 /* InstrumentationTests.m */; };
@@ -2695,6 +2696,7 @@
 		34EA78C62A39221E0071CC95 /* NRMACustomEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NRMACustomEvent.h; sourceTree = "<group>"; };
 		34EA78C72A39221E0071CC95 /* NRMACustomEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRMACustomEvent.m; sourceTree = "<group>"; };
 		34EA78DF2A3924CC0071CC95 /* TestCustomEvents.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestCustomEvents.m; sourceTree = "<group>"; };
+		578D57D9E9373167EBE8C0CF /* NRMANetworkFacadeTraceHeaderTests.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = NRMANetworkFacadeTraceHeaderTests.mm; sourceTree = "<group>"; };
 		59AA4543706D6BB36459A6C5 /* NewRelicAgent.podspec.template */ = {isa = PBXFileReference; lastKnownFileType = file.podspec; name = NewRelicAgent.podspec.template; path = cocoapods/NewRelicAgent.podspec.template; sourceTree = "<group>"; };
 		59AA4F6AF53601FEA41A1303 /* dev_build_xcframework.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = dev_build_xcframework.sh; sourceTree = "<group>"; };
 		C94F518C28577E0000E81E01 /* InstrumentationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InstrumentationTests.m; sourceTree = "<group>"; };
@@ -3038,6 +3040,7 @@
 				0209AC0524E7071400E45C90 /* NewRelicTests.m */,
 				0209AC0B24E7071500E45C90 /* NRMAAPIHelperTests.m */,
 				0209AC0824E7071400E45C90 /* NRMAAppTokenTest.m */,
+				578D57D9E9373167EBE8C0CF /* NRMANetworkFacadeTraceHeaderTests.mm */,
 			);
 			path = "API-Tests";
 			sourceTree = "<group>";
@@ -4870,7 +4873,7 @@
 				348233842BC5F3120070FAC3 /* NRMALastActivityTraceController.h in Headers */,
 				348232D52BC5F2050070FAC3 /* NRMAHarvestableMethodMetric.h in Headers */,
 				348232B42BC5F1F60070FAC3 /* NRMAHarvesterConnection+GZip.h in Headers */,
-				348232FE2BC5F2140070FAC3 /* (null) in Headers */,
+				348232FE2BC5F2140070FAC3 /* BuildFile in Headers */,
 				3482336E2BC5F3040070FAC3 /* NRMANetworkResponseData+CppInterface.h in Headers */,
 				348233782BC5F3040070FAC3 /* NRMANetworkRequestData.h in Headers */,
 				348232962BC5F1D70070FAC3 /* NRMAMeasurementException.h in Headers */,
@@ -4953,7 +4956,7 @@
 				3482323E2BC5F0DC0070FAC3 /* NRMAHTTPUtilities.h in Headers */,
 				3482325A2BC5F16E0070FAC3 /* NRMAFileCleanup.h in Headers */,
 				348233832BC5F3120070FAC3 /* NRMATraceMachineAgentUserInterface.h in Headers */,
-				348233032BC5F2140070FAC3 /* (null) in Headers */,
+				348233032BC5F2140070FAC3 /* BuildFile in Headers */,
 				348233672BC5F3040070FAC3 /* NRMAAnalyticEventProtocol.h in Headers */,
 				348233072BC5F2140070FAC3 /* NRMAHexUploader.h in Headers */,
 				348233A72BC5F32B0070FAC3 /* NewRelicCustomInteractionInterface.h in Headers */,
@@ -5731,6 +5734,7 @@
 				0209AC9424E7393300E45C90 /* NRMethodProfilerTests.m in Sources */,
 				0209AC2124E7071F00E45C90 /* MachineMeasurementsTest.m in Sources */,
 				0209ABF424E706FA00E45C90 /* NRThreadInfoTests.m in Sources */,
+				8B498242383AF7020CD36D72 /* NRMANetworkFacadeTraceHeaderTests.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6581,7 +6585,7 @@
 				3482325D2BC5F16E0070FAC3 /* NRMABool.m in Sources */,
 				348233212BC5F2270070FAC3 /* NRMACrashReport_CodeType.m in Sources */,
 				3482328B2BC5F1B30070FAC3 /* NRMAMetric.m in Sources */,
-				348233002BC5F2140070FAC3 /* (null) in Sources */,
+				348233002BC5F2140070FAC3 /* BuildFile in Sources */,
 				3482337E2BC5F3120070FAC3 /* NRMAActivityTrace.m in Sources */,
 				348232732BC5F1A80070FAC3 /* NRMAMeasurementEngine.m in Sources */,
 				348232462BC5F0F60070FAC3 /* NRMAPayloadContainer.mm in Sources */,
@@ -6626,7 +6630,7 @@
 				348232E92BC5F2050070FAC3 /* NRMAHTTPTransactions.m in Sources */,
 				348232C62BC5F1FE0070FAC3 /* NRMAHarvestable.m in Sources */,
 				348233142BC5F21B0070FAC3 /* NRMAUncaughtExceptionHandler.m in Sources */,
-				3482330A2BC5F2140070FAC3 /* (null) in Sources */,
+				3482330A2BC5F2140070FAC3 /* BuildFile in Sources */,
 				348233622BC5F2DD0070FAC3 /* NRMANetworkErrorEvent.m in Sources */,
 				2B3BA8522EF1C7B0007B798A /* SessionReplayFrame.swift in Sources */,
 				348232972BC5F1D70070FAC3 /* NRMAMethodSummaryMeasurement.m in Sources */,

--- a/Agent/Network/NRMANetworkFacade.mm
+++ b/Agent/Network/NRMANetworkFacade.mm
@@ -200,10 +200,10 @@
         if ([NRMANetworkFacade statusCode:response] >= NRMA_HTTP_STATUS_CODE_ERROR_THRESHOLD) {
             if([NRMAFlags shouldEnableNewEventSystem]){
                 if(traceHeaders) {
-                    if(retrievedPayload == nil) {
-                        retrievedPayload = [NRMAHTTPUtilities generateNRMAPayload];
-                    }
-                    [NRMANetworkFacade configureNRMAPayloadWithTraceHeaders:retrievedPayload traceHeaders:traceHeaders];
+                    // NR-586680: the trace context was supplied by a cross-platform
+                    // caller (e.g. the Flutter agent), which owns the distributed
+                    // trace. Do not attach a native NRMAPayload to the event.
+                    retrievedPayload = nil;
                 }
 
                 [[[NewRelicAgentInternal sharedInstance] analyticsController] addHTTPErrorEvent:networkRequestData
@@ -212,10 +212,9 @@
             } else {
                 std::unique_ptr<NewRelic::Connectivity::Payload> retrievedPayload = [NRMAHTTPUtilities retrievePayload:request];
                 if(traceHeaders) {
-                    if(retrievedPayload == nullptr) {
-                        retrievedPayload = NewRelic::Connectivity::Facade::getInstance().newPayload();
-                    }
-                    [NRMANetworkFacade configureCppPayloadWithTraceHeaders:retrievedPayload traceHeaders:traceHeaders];
+                    // NR-586680: caller (e.g. Flutter) owns the distributed trace;
+                    // suppress the native payload so no DT context is attached.
+                    retrievedPayload = nullptr;
                 }
 
                 [[[NewRelicAgentInternal sharedInstance] analyticsController] addHTTPErrorEvent:networkRequestData
@@ -226,10 +225,10 @@
         } else {
             if([NRMAFlags shouldEnableNewEventSystem]){
                 if(traceHeaders) {
-                    if(retrievedPayload == nil) {
-                        retrievedPayload = [NRMAHTTPUtilities generateNRMAPayload];
-                    }
-                    [NRMANetworkFacade configureNRMAPayloadWithTraceHeaders:retrievedPayload traceHeaders:traceHeaders];
+                    // NR-586680: the trace context was supplied by a cross-platform
+                    // caller (e.g. the Flutter agent), which owns the distributed
+                    // trace. Do not attach a native NRMAPayload to the event.
+                    retrievedPayload = nil;
                 }
 
                 [[[NewRelicAgentInternal sharedInstance] analyticsController] addNetworkRequestEvent:networkRequestData
@@ -238,10 +237,9 @@
             } else {
                 std::unique_ptr<NewRelic::Connectivity::Payload> retrievedPayload = [NRMAHTTPUtilities retrievePayload:request];
                 if(traceHeaders) {
-                    if(retrievedPayload == nullptr) {
-                        retrievedPayload = NewRelic::Connectivity::Facade::getInstance().newPayload();
-                    }
-                    [NRMANetworkFacade configureCppPayloadWithTraceHeaders:retrievedPayload traceHeaders:traceHeaders];
+                    // NR-586680: caller (e.g. Flutter) owns the distributed trace;
+                    // suppress the native payload so no DT context is attached.
+                    retrievedPayload = nullptr;
                 }
 
                 [[[NewRelicAgentInternal sharedInstance] analyticsController] addNetworkRequestEvent:networkRequestData

--- a/Tests/Unit-Tests/NewRelicAgentTests/API-Tests/NRMANetworkFacadeTraceHeaderTests.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/API-Tests/NRMANetworkFacadeTraceHeaderTests.mm
@@ -1,0 +1,199 @@
+//
+//  NRMANetworkFacadeTraceHeaderTests.mm
+//  Agent
+//
+//  Copyright © 2026 New Relic. All rights reserved.
+//
+//  Coverage for NR-586680: when an HTTP transaction is reported with
+//  distributed-tracing headers supplied by a cross-platform (e.g. Flutter)
+//  caller, the native iOS agent must NOT attach its own distributed-trace
+//  context (the `payload` attribute or the guid/traceId linkage) to the
+//  resulting MobileRequest / MobileRequestError events. Native (auto-
+//  instrumented) requests, which pass traceHeaders:nil, must be unaffected.
+//
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "NRMANetworkFacade.h"
+#import "NewRelicAgentInternal.h"
+#import "NRMAAppToken.h"
+#import "NRMAHarvestController.h"
+#import "NRTestConstants.h"
+#import "NRMAFlags.h"
+#import "NRMAHTTPUtilities.h"
+#import "NRMAPayload.h"
+#import "NRTimer.h"
+#import "NRMAAnalytics.h"
+
+static NewRelicAgentInternal* _sharedInstance;
+
+@interface NRMANetworkFacadeTraceHeaderTests : XCTestCase {
+    NRMAFeatureFlags _originalFlags;
+}
+@property id mockNewRelicInternals;
+@end
+
+@implementation NRMANetworkFacadeTraceHeaderTests
+
+- (void)setUp {
+    [super setUp];
+    _originalFlags = [NRMAFlags featureFlags];
+    [NRMAFlags enableFeatures:NRFeatureFlag_NetworkRequestEvents | NRFeatureFlag_RequestErrorEvents | NRFeatureFlag_NewEventSystem];
+
+    // Route the facade's [[NewRelicAgentInternal sharedInstance] analyticsController]
+    // to a real, inspectable NRMAAnalytics instance.
+    self.mockNewRelicInternals = [OCMockObject mockForClass:[NewRelicAgentInternal class]];
+    _sharedInstance = [[NewRelicAgentInternal alloc] init];
+    _sharedInstance.analyticsController = [[NRMAAnalytics alloc] initWithSessionStartTimeMS:0.0];
+    [[[[self.mockNewRelicInternals stub] classMethod] andReturn:_sharedInstance] sharedInstance];
+
+    NRMAAgentConfiguration *config = [[NRMAAgentConfiguration alloc] initWithAppToken:[[NRMAAppToken alloc] initWithApplicationToken:kNRMA_ENABLED_STAGING_APP_TOKEN]
+                                                                     collectorAddress:KNRMA_TEST_COLLECTOR_HOST
+                                                                         crashAddress:nil];
+    [NRMAHarvestController initialize:config];
+    NRMAHarvestController* controller = [NRMAHarvestController harvestController];
+    NRMAHarvesterConfiguration* harvesterConfig = [NRMAHarvesterConfiguration defaultHarvesterConfiguration];
+    [harvesterConfig setTrusted_account_key:@"777"];
+    harvesterConfig.account_id = 1234567;
+    harvesterConfig.application_id = 1234567;
+    [[controller harvester] configureHarvester:harvesterConfig];
+}
+
+- (void)tearDown {
+    [self.mockNewRelicInternals stopMocking];
+    [NRMAFlags setFeatureFlags:_originalFlags];
+    [super tearDown];
+}
+
+#pragma mark - Helpers
+
+// A request that already carries a native NRMAPayload, as an auto-instrumented
+// (native DT) request would. retrieveNRMAPayload: returns this in the facade.
+- (NSMutableURLRequest*) requestWithAttachedPayload {
+    NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://www.example.com/api/v1/data"]];
+    [request setHTTPMethod:@"GET"];
+
+    NRMAPayload* payload = [[NRMAPayload alloc] initWithTimestamp:[[NSDate date] timeIntervalSince1970]
+                                                        accountID:@"1"
+                                                            appID:@"1"
+                                                          traceID:@"2938058093e048d19c0979691ff765c0"
+                                                         parentID:@""
+                                                trustedAccountKey:@"1"];
+    payload.dtEnabled = true;
+    [NRMAHTTPUtilities attachNRMAPayload:payload to:request];
+    return request;
+}
+
+// Distributed-tracing headers as a cross-platform (Flutter) caller would supply.
+- (NSDictionary<NSString*,NSString*>*) callerSuppliedTraceHeaders {
+    return @{ @"traceparent": @"00-2938058093e048d19c0979691ff765c0-f1f4f8b63d9b4870-01",
+              @"tracestate":  @"1@nr=0-2-1-601344132-f1f4f8b63d9b4870----1783361525671",
+              @"newrelic":    @"eyJ2IjpbMCwyXX0=" };
+}
+
+// The facade records events asynchronously; poll the analytics controller until
+// a network event (identified by requestUrl) is present.
+- (NSDictionary*) pollForNetworkEvent {
+    NSDate *timeoutDate = [NSDate dateWithTimeIntervalSinceNow:10.0];
+    while ([timeoutDate timeIntervalSinceNow] > 0) {
+        NSString* json = [[NewRelicAgentInternal sharedInstance].analyticsController analyticsJSONString];
+        if (json.length) {
+            NSArray* decode = [NSJSONSerialization JSONObjectWithData:[json dataUsingEncoding:NSUTF8StringEncoding]
+                                                              options:0
+                                                                error:nil];
+            for (NSDictionary* event in decode) {
+                if (event[@"requestUrl"] != nil) {
+                    return event;
+                }
+            }
+        }
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+    }
+    return nil;
+}
+
+#pragma mark - New event system: caller-supplied trace headers (Flutter)
+
+- (void) testCallerSuppliedTraceHeadersOmitPayloadOnSuccess {
+    NSMutableURLRequest* request = [self requestWithAttachedPayload];
+    NSHTTPURLResponse* response = [[NSHTTPURLResponse alloc] initWithURL:request.URL
+                                                             statusCode:200
+                                                            HTTPVersion:@"1.1"
+                                                           headerFields:nil];
+
+    [NRMANetworkFacade noticeNetworkRequest:request
+                                   response:response
+                                  withTimer:[[NRTimer alloc] initWithStartTime:6000 andEndTime:10000]
+                                  bytesSent:10
+                              bytesReceived:20
+                               responseData:nil
+                               traceHeaders:[self callerSuppliedTraceHeaders]
+                                     params:nil];
+
+    NSDictionary* event = [self pollForNetworkEvent];
+    XCTAssertNotNil(event, @"expected a MobileRequest event to be recorded");
+    XCTAssertNil(event[@"payload"], @"native DT payload must be omitted for caller-supplied traces");
+    XCTAssertNil(event[@"guid"], @"native DT guid must be omitted for caller-supplied traces");
+    XCTAssertNil(event[@"traceId"], @"native DT traceId must be omitted for caller-supplied traces");
+    XCTAssertNil(event[@"trace.id"], @"native DT trace.id must be omitted for caller-supplied traces");
+}
+
+- (void) testCallerSuppliedTraceHeadersOmitPayloadOnHTTPError {
+    NSMutableURLRequest* request = [self requestWithAttachedPayload];
+    NSHTTPURLResponse* response = [[NSHTTPURLResponse alloc] initWithURL:request.URL
+                                                             statusCode:403
+                                                            HTTPVersion:@"1.1"
+                                                           headerFields:nil];
+
+    [NRMANetworkFacade noticeNetworkRequest:request
+                                   response:response
+                                  withTimer:[[NRTimer alloc] initWithStartTime:6000 andEndTime:10000]
+                                  bytesSent:10
+                              bytesReceived:20
+                               responseData:[@"unauthorized" dataUsingEncoding:NSUTF8StringEncoding]
+                               traceHeaders:[self callerSuppliedTraceHeaders]
+                                     params:nil];
+
+    NSDictionary* event = [self pollForNetworkEvent];
+    XCTAssertNotNil(event, @"expected a MobileRequestError event to be recorded");
+    XCTAssertTrue([event[@"statusCode"] isEqual:@403], @"expected the HTTP error event");
+    XCTAssertNil(event[@"payload"], @"native DT payload must be omitted on MobileRequestError for caller-supplied traces");
+    XCTAssertNil(event[@"guid"], @"native DT guid must be omitted on MobileRequestError for caller-supplied traces");
+}
+
+#pragma mark - New event system: native (auto-instrumented) request regression
+
+- (void) testNativeDTRequestStillIncludesPayload {
+    NSMutableURLRequest* request = [self requestWithAttachedPayload];
+    NSHTTPURLResponse* response = [[NSHTTPURLResponse alloc] initWithURL:request.URL
+                                                             statusCode:200
+                                                            HTTPVersion:@"1.1"
+                                                           headerFields:nil];
+
+    // Native auto-instrumentation passes traceHeaders:nil.
+    [NRMANetworkFacade noticeNetworkRequest:request
+                                   response:response
+                                  withTimer:[[NRTimer alloc] initWithStartTime:6000 andEndTime:10000]
+                                  bytesSent:10
+                              bytesReceived:20
+                               responseData:nil
+                               traceHeaders:nil
+                                     params:nil];
+
+    NSDictionary* event = [self pollForNetworkEvent];
+    XCTAssertNotNil(event, @"expected a MobileRequest event to be recorded");
+    XCTAssertNotNil(event[@"payload"], @"native DT-instrumented request must still include the payload attribute");
+    XCTAssertNotNil(event[@"guid"], @"native DT-instrumented request must still include guid");
+    XCTAssertNotNil(event[@"traceId"], @"native DT-instrumented request must still include traceId");
+}
+
+// Note: the legacy (C++) event system does not emit the `payload` attribute (it
+// carries DT as guid/traceId intrinsics), so the reported bug is new-event-system
+// only. The legacy path receives the identical `traceHeaders => suppress payload`
+// fix in NRMANetworkFacade; it is not covered by an end-to-end test here because
+// pushing a populated C++ Connectivity::Payload through the legacy analytics
+// controller in isolation (outside a fully-initialized agent) segfaults in this
+// unit-test harness — a pre-existing harness limitation unrelated to this change.
+
+@end


### PR DESCRIPTION
This PR handles 2 cases for each event system. 

Whenever traceHeaders are passed to noticeNetworkRequest directly that means the Flutter, ReactNative, or another hybrid agent owns the distributed trace and we don't need to attach one from the native agent.
This handles the MobileRequest and MobileRequestError case for the New event system and the old event system.