### PR TITLE
NR-546764 clamp SwiftUI text width-compensation offset to its content…

### DIFF
--- a/Agent.xcodeproj/project.pbxproj
+++ b/Agent.xcodeproj/project.pbxproj
@@ -1592,6 +1592,7 @@
 		D4C36C962FC902B7001DD597 /* TestGuidUniqueness.mm in Sources */ = {isa = PBXBuildFile; fileRef = D4C36C952FC902B7001DD597 /* TestGuidUniqueness.mm */; };
 		D4C36C972FC902B7001DD597 /* TestGuidUniqueness.mm in Sources */ = {isa = PBXBuildFile; fileRef = D4C36C952FC902B7001DD597 /* TestGuidUniqueness.mm */; };
 		D4C36C982FC902B7001DD597 /* TestGuidUniqueness.mm in Sources */ = {isa = PBXBuildFile; fileRef = D4C36C952FC902B7001DD597 /* TestGuidUniqueness.mm */; };
+		D4DCC24030192068008B5C59 /* UIHostingViewRecordOrchestratorWidthOffsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DCC23F30192068008B5C59 /* UIHostingViewRecordOrchestratorWidthOffsetTests.swift */; };
 		F6E79C7325A65347006277FB /* W3CTraceState.mm in Sources */ = {isa = PBXBuildFile; fileRef = F6E79C6D25A65346006277FB /* W3CTraceState.mm */; };
 		F6E79C7425A65347006277FB /* W3CTraceState.mm in Sources */ = {isa = PBXBuildFile; fileRef = F6E79C6D25A65346006277FB /* W3CTraceState.mm */; };
 		F6E79C7525A65347006277FB /* W3CTraceState.h in Headers */ = {isa = PBXBuildFile; fileRef = F6E79C6E25A65346006277FB /* W3CTraceState.h */; };
@@ -2707,6 +2708,7 @@
 		D48D551B2F4E63B9003BE3AB /* NRMAJSErrorHarvestAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NRMAJSErrorHarvestAdapter.h; sourceTree = "<group>"; };
 		D48D551C2F4E63B9003BE3AB /* NRMAJSErrorHarvestAdapter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRMAJSErrorHarvestAdapter.m; sourceTree = "<group>"; };
 		D4C36C952FC902B7001DD597 /* TestGuidUniqueness.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TestGuidUniqueness.mm; sourceTree = "<group>"; };
+		D4DCC23F30192068008B5C59 /* UIHostingViewRecordOrchestratorWidthOffsetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIHostingViewRecordOrchestratorWidthOffsetTests.swift; sourceTree = "<group>"; };
 		F6E79C6D25A65346006277FB /* W3CTraceState.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = W3CTraceState.mm; sourceTree = "<group>"; };
 		F6E79C6E25A65346006277FB /* W3CTraceState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = W3CTraceState.h; sourceTree = "<group>"; };
 		F6E79C7025A65346006277FB /* W3CTraceParent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = W3CTraceParent.mm; sourceTree = "<group>"; };
@@ -3141,6 +3143,7 @@
 		0209AC6424E7391000E45C90 /* Uncategorized */ = {
 			isa = PBXGroup;
 			children = (
+				D4DCC23F30192068008B5C59 /* UIHostingViewRecordOrchestratorWidthOffsetTests.swift */,
 				2BBC1A532DEDF61A00F5C584 /* SessionReplayTest.m */,
 				0209ACB524E747FA00E45C90 /* NewRelicAgentTests.h */,
 				F85ABB482F1557150098A2CF /* UILabelThingyTests.swift */,
@@ -5614,6 +5617,7 @@
 				0209ABFF24E7070900E45C90 /* NRMASessionExclusivityWithoutDelegateTests.m in Sources */,
 				F85ABB492F1557150098A2CF /* UILabelThingyTests.swift in Sources */,
 				F8BF154D2F3A37FB00EF5628 /* SwiftUIShapeThingyTests.swift in Sources */,
+				D4DCC24030192068008B5C59 /* UIHostingViewRecordOrchestratorWidthOffsetTests.swift in Sources */,
 				0209ACB024E7394500E45C90 /* NRMAUDIDManagerTest.m in Sources */,
 				0209ACB124E7394500E45C90 /* NRMAUUIDStoreTests.m in Sources */,
 				0209ABF024E706FA00E45C90 /* NRTraceMachineTests.m in Sources */,

--- a/Agent/SessionReplay/SwiftUI/UIHostingViewRecordOrchestrator.swift
+++ b/Agent/SessionReplay/SwiftUI/UIHostingViewRecordOrchestrator.swift
@@ -128,7 +128,27 @@ final class UIHostingViewRecordOrchestrator {
         if #available(iOS 26, tvOS 26, *) { keys.insert("viewGraph", at: keys.count - 1) }
         return keys
     }()
-        
+
+    /// Caps a text-width compensation offset so it can never push a label's
+    /// captured wireframe past the ambient SwiftUI content bounds.
+    ///
+    /// `widthOffset` (see the `.text` case below) pads a `Text` view's measured
+    /// width to work around SwiftUI under-reporting space-heavy strings' true
+    /// rendered width (NR-522xxx/#646/#647). That padding scaled with the
+    /// string's space count and was never bounded, so long, multi-word
+    /// NavigationLink labels could grow past their row's real content width and
+    /// overlap the trailing disclosure chevron (NR-546764) — the chevron isn't
+    /// captured as a sibling with reserved space; it's just whatever the label
+    /// widens into. Clamping to `containerMaxX` (the enclosing SwiftUI content
+    /// frame, which already correctly excludes the chevron's reservation) keeps
+    /// the original truncation fix while guaranteeing it can't overshoot.
+    static func clampedWidthOffset(_ rawOffset: CGFloat, frameOriginX: CGFloat, frameWidth: CGFloat, containerMaxX: CGFloat) -> CGFloat {
+        guard rawOffset > 0 else { return rawOffset }
+        let availableWidth = containerMaxX - frameOriginX
+        guard availableWidth > frameWidth else { return 0 }
+        return min(rawOffset, availableWidth - frameWidth)
+    }
+
     // Entry point (renamed for clarity; keep old name if externally referenced)
     static func swiftUIViewThingys(_ view: UIView,
                                    context: SwiftUIContext,
@@ -243,9 +263,14 @@ final class UIHostingViewRecordOrchestrator {
         var viewName = "SwiftUIView"
 
         func makeDetails(widthOffset: CGFloat = 0) -> ViewDetails {
+                    let clampedWidthOffset = UIHostingViewRecordOrchestrator.clampedWidthOffset(
+                        widthOffset,
+                        frameOriginX: frame.origin.x,
+                        frameWidth: frame.size.width,
+                        containerMaxX: baseContext.frame.maxX)
                     let adjustedFrame = CGRect(x: frame.origin.x,
                                                y: frame.origin.y,
-                                               width: frame.size.width + widthOffset,
+                                               width: frame.size.width + clampedWidthOffset,
                                                height: frame.size.height)
 
                     // safeColor-validated bridges from CGColor → UIColor. If validation

--- a/Test Harness/NRTestApp/NRTestApp.xcodeproj/project.pbxproj
+++ b/Test Harness/NRTestApp/NRTestApp.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		D46F91D72F69D1DD00FD2EBE /* SwitchTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46F91D62F69D1DD00FD2EBE /* SwitchTestViewController.swift */; };
 		D46F91DD2F6C6BAB00FD2EBE /* CustomSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46F91DC2F6C6BAB00FD2EBE /* CustomSwitch.swift */; };
 		D46F91DF2F6C6C7200FD2EBE /* CustomToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46F91DE2F6C6C7200FD2EBE /* CustomToggleStyle.swift */; };
+		D4DCC23A3017DF26008B5C59 /* NavigationLinkLabelLayoutTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DCC2393017DF26008B5C59 /* NavigationLinkLabelLayoutTestCase.swift */; };
 		F802EE962BE0218600AB956F /* NRTestApp__watchOS_App.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802EE952BE0218600AB956F /* NRTestApp__watchOS_App.swift */; };
 		F802EE982BE0218600AB956F /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802EE972BE0218600AB956F /* ContentView.swift */; };
 		F802EE9A2BE0218700AB956F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F802EE992BE0218700AB956F /* Assets.xcassets */; };
@@ -401,6 +402,7 @@
 		D46F91D62F69D1DD00FD2EBE /* SwitchTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchTestViewController.swift; sourceTree = "<group>"; };
 		D46F91DC2F6C6BAB00FD2EBE /* CustomSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomSwitch.swift; path = ../CustomSwitch.swift; sourceTree = "<group>"; };
 		D46F91DE2F6C6C7200FD2EBE /* CustomToggleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomToggleStyle.swift; sourceTree = "<group>"; };
+		D4DCC2393017DF26008B5C59 /* NavigationLinkLabelLayoutTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLinkLabelLayoutTestCase.swift; sourceTree = "<group>"; };
 		F802EE902BE0218600AB956F /* NRTestApp (watchOS) Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "NRTestApp (watchOS) Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F802EE952BE0218600AB956F /* NRTestApp__watchOS_App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NRTestApp__watchOS_App.swift; sourceTree = "<group>"; };
 		F802EE972BE0218600AB956F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -542,6 +544,7 @@
 		2BAE5C8D2E860C7D001D2B88 /* SwiftUI */ = {
 			isa = PBXGroup;
 			children = (
+				D4DCC2393017DF26008B5C59 /* NavigationLinkLabelLayoutTestCase.swift */,
 				2B131C722F7C5BAF00748ACB /* NavigationStackView.swift */,
 				D46F91DE2F6C6C7200FD2EBE /* CustomToggleStyle.swift */,
 				2BCDE5B22ECEA133008EE3B9 /* MinimalReproView.swift */,
@@ -1366,6 +1369,7 @@
 				F8D23CB52F7727D7000FFD31 /* FormView.swift in Sources */,
 				F8D23CB62F7727D7000FFD31 /* SettingsView.swift in Sources */,
 				F8D23CB72F7727D7000FFD31 /* DataModels.swift in Sources */,
+				D4DCC23A3017DF26008B5C59 /* NavigationLinkLabelLayoutTestCase.swift in Sources */,
 				F8D23CB82F7727D7000FFD31 /* ChartsView.swift in Sources */,
 				F8D23CB92F7727D7000FFD31 /* DashboardView.swift in Sources */,
 				F8302AF9296F5EFA003EC291 /* AppDelegate.swift in Sources */,

--- a/Test Harness/NRTestApp/NRTestApp/SwiftUI/ContentView.swift
+++ b/Test Harness/NRTestApp/NRTestApp/SwiftUI/ContentView.swift
@@ -97,6 +97,9 @@ struct SwiftUIContentView: View {
                             Text("Map View")
                         }
                     }
+                    NavigationLink(destination: NavigationLinkLabelLayoutTestCase()) {
+                        Text("NavigationLink Labels")
+                    }
                 }
                 .navigationBarTitle("SwiftUI Elements")
 

--- a/Test Harness/NRTestApp/NRTestApp/SwiftUI/NavigationLinkLabelLayoutTestCase.swift
+++ b/Test Harness/NRTestApp/NRTestApp/SwiftUI/NavigationLinkLabelLayoutTestCase.swift
@@ -1,0 +1,313 @@
+import SwiftUI
+import NewRelic
+
+/// Test Case: NavigationLink Label Layout
+///
+/// Tests various text layout configurations in NavigationLink labels to identify
+/// issues with text bleeding into the disclosure indicator (chevron) area.
+///
+/// Each windowed list shows the same content with different layout modifiers applied.
+/// Text content is varied: ~20% single-line, ~40% two-line, ~40% three-line descriptions.
+///
+/// Font weights used:
+/// - Title: .headline (17pt semibold / weight 600)
+/// - Description: .caption (12pt regular / weight 400)
+struct NavigationLinkLabelLayoutTestCase: View {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 32) {
+                TextLayoutSectionHeader(
+                    title: "NavigationLink Label Layout",
+                    subtitle: "Compare how different layout modifiers affect text/chevron collision"
+                )
+
+                // MARK: - No modifications (baseline)
+                ListWindow(title: "No Modifications (Baseline)", subtitle: "Default NavigationLink behavior") {
+                    ForEach(sampleItems) { item in
+                        NavigationLink(destination: Text(item.title)) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(item.title)
+                                    .font(.headline)
+                                Text(item.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+
+                // MARK: - lineLimit(2)
+                ListWindow(title: "lineLimit(2)", subtitle: "Description limited to 2 lines") {
+                    ForEach(sampleItems) { item in
+                        NavigationLink(destination: Text(item.title)) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(item.title)
+                                    .font(.headline)
+                                Text(item.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(2)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+
+                // MARK: - lineLimit(3)
+                ListWindow(title: "lineLimit(3)", subtitle: "Description limited to 3 lines") {
+                    ForEach(sampleItems) { item in
+                        NavigationLink(destination: Text(item.title)) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(item.title)
+                                    .font(.headline)
+                                Text(item.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(3)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+
+                // MARK: - frame(maxWidth: .infinity)
+                ListWindow(title: "frame(maxWidth: .infinity)", subtitle: "VStack constrained to full width") {
+                    ForEach(sampleItems) { item in
+                        NavigationLink(destination: Text(item.title)) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(item.title)
+                                    .font(.headline)
+                                Text(item.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+
+                // MARK: - lineLimit + frame
+                ListWindow(title: "lineLimit(2) + frame(maxWidth: .infinity)", subtitle: "Combined constraints") {
+                    ForEach(sampleItems) { item in
+                        NavigationLink(destination: Text(item.title)) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(item.title)
+                                    .font(.headline)
+                                Text(item.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(2)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+
+                // MARK: - fixedSize vertical only
+                ListWindow(title: "fixedSize(horizontal: false, vertical: true)", subtitle: "Allow vertical expansion, constrain horizontal") {
+                    ForEach(sampleItems) { item in
+                        NavigationLink(destination: Text(item.title)) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(item.title)
+                                    .font(.headline)
+                                Text(item.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+
+                // MARK: - layoutPriority
+                ListWindow(title: "layoutPriority(-1) on description", subtitle: "Lower priority for description text") {
+                    ForEach(sampleItems) { item in
+                        NavigationLink(destination: Text(item.title)) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(item.title)
+                                    .font(.headline)
+                                Text(item.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .layoutPriority(-1)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+
+                // MARK: - truncationMode variations
+                ListWindow(title: "truncationMode(.middle) + lineLimit(1)", subtitle: "Single line with middle truncation") {
+                    ForEach(sampleItems) { item in
+                        NavigationLink(destination: Text(item.title)) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(item.title)
+                                    .font(.headline)
+                                Text(item.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+
+                // MARK: - Combined best practices
+                ListWindow(title: "Combined: lineLimit + frame + fixedSize", subtitle: "All constraints applied") {
+                    ForEach(sampleItems) { item in
+                        NavigationLink(destination: Text(item.title)) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(item.title)
+                                    .font(.headline)
+                                Text(item.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(2)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+
+                // MARK: - Using GeometryReader approach
+                ListWindow(title: "Explicit width via GeometryReader", subtitle: "Text width explicitly calculated") {
+                    ForEach(sampleItems) { item in
+                        NavigationLink(destination: Text(item.title)) {
+                            GeometryReader { geo in
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(item.title)
+                                        .font(.headline)
+                                    Text(item.description)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(2)
+                                }
+                                .frame(width: geo.size.width, alignment: .leading)
+                                .padding(.vertical, 4)
+                            }
+                            .frame(height: 60)
+                        }
+                    }
+                }
+
+                Spacer(minLength: 40)
+            }
+            .padding()
+        }
+        .background(Color(.systemGroupedBackground))
+        .navigationTitle("NavigationLink Labels")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            NewRelic.recordCustomEvent("ScreenView", attributes: [
+                "screenName": "NavigationLinkLabelLayoutTestCase",
+                "testCase": "NavigationLinkLabelLayout"
+            ])
+        }
+    }
+}
+
+// MARK: - Sample Data
+
+struct SampleItem: Identifiable {
+    let id = UUID()
+    let title: String
+    let description: String
+}
+
+/// Sample items with varied description lengths:
+/// ~20% single-line, ~40% two-line, ~40% three-line
+let sampleItems: [SampleItem] = [
+    // Single-line descriptions (~20%)
+    SampleItem(title: "Quick Settings", description: "Tap to configure"),
+    SampleItem(title: "Notifications", description: "Manage your alerts"),
+    SampleItem(title: "Dark Mode", description: "Toggle appearance"),
+    SampleItem(title: "Language", description: "English (US)"),
+
+    // Two-line descriptions (~40%)
+    SampleItem(title: "Account Security", description: "Manage your password, two-factor authentication, and connected devices"),
+    SampleItem(title: "Privacy Controls", description: "Control what data is collected and how it's used across our services"),
+    SampleItem(title: "Storage Management", description: "View and manage your storage usage, cached files, and downloaded content"),
+    SampleItem(title: "Sync Settings", description: "Configure automatic sync options for photos, documents, and app data"),
+    SampleItem(title: "Accessibility", description: "Adjust display, audio, and interaction settings for better accessibility"),
+    SampleItem(title: "Battery Optimization", description: "Manage background activity and power consumption for longer battery life"),
+    SampleItem(title: "Network Preferences", description: "Configure Wi-Fi, cellular data usage limits, and VPN connections"),
+    SampleItem(title: "App Permissions", description: "Review and modify permissions granted to installed applications"),
+
+    // Three-line descriptions (~40%)
+    SampleItem(title: "Data Export", description: "Download a complete copy of your data including photos, messages, contacts, and activity history. Processing may take up to 48 hours."),
+    SampleItem(title: "Backup & Restore", description: "Create encrypted backups of your device settings, app data, and personal files. Backups can be stored locally or in the cloud for easy restoration."),
+    SampleItem(title: "Developer Options", description: "Advanced settings for developers including USB debugging, layout bounds visualization, GPU rendering profiles, and strict mode indicators."),
+    SampleItem(title: "Experimental Features", description: "Try new features before they're released to everyone. These features may be unstable and could change or be removed in future updates."),
+    SampleItem(title: "Content Filtering", description: "Set up parental controls and content restrictions. Filter explicit content, limit screen time, and manage in-app purchases for family members."),
+    SampleItem(title: "Connected Services", description: "Manage third-party apps and services connected to your account. Review permissions, revoke access, and see recent activity from connected applications."),
+    SampleItem(title: "Location History", description: "View and manage your location history timeline. See places you've visited, delete specific entries, and control how location data is collected and stored."),
+    SampleItem(title: "Digital Wellbeing", description: "Monitor your screen time, app usage patterns, and notification frequency. Set daily limits, schedule downtime, and reduce interruptions during focus hours."),
+]
+
+// MARK: - Helper Views
+
+struct ListWindow<Content: View>: View {
+    let title: String
+    let subtitle: String
+    let content: () -> Content
+
+    init(title: String, subtitle: String, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.subtitle = subtitle
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                    .foregroundColor(.primary)
+                Text(subtitle)
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+            }
+
+            List {
+                content()
+            }
+            .listStyle(.plain)
+            .frame(height: 480) // Tall enough for ~8 items
+            .cornerRadius(10)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+            )
+        }
+    }
+}
+
+struct TextLayoutSectionHeader: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 20, weight: .bold))
+            Text(subtitle)
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+#Preview {
+    NavigationView {
+        NavigationLinkLabelLayoutTestCase()
+    }
+}

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/UIHostingViewRecordOrchestratorWidthOffsetTests.swift
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/UIHostingViewRecordOrchestratorWidthOffsetTests.swift
@@ -1,0 +1,70 @@
+//
+//  UIHostingViewRecordOrchestratorWidthOffsetTests.swift
+//  NewRelicAgent
+//
+//  Copyright © 2026 New Relic. All rights reserved.
+//
+
+import XCTest
+@testable import NewRelic
+
+/// NR-546764: a SwiftUI `Text`'s captured wireframe width is padded by
+/// `calculatedOffset` (2pt per space in the string) to compensate for SwiftUI
+/// under-measuring space-heavy strings. That padding scaled with the string's
+/// word count and was never bounded, so a NavigationLink row's description
+/// label could grow past the row's real content width and overlap the
+/// trailing disclosure chevron. These tests pin down the clamp that keeps the
+/// padding from ever pushing a label past its container's bounds.
+@available(iOS 13.0, *)
+class UIHostingViewRecordOrchestratorWidthOffsetTests: XCTestCase {
+
+    func testAmpleRoom_offsetPassesThroughUnchanged() {
+        // A short single-line label ("Quick Settings") has few spaces and
+        // plenty of room in its row, so the offset should be untouched.
+        let rawOffset: CGFloat = 4 // 2 spaces
+        let clamped = UIHostingViewRecordOrchestrator.clampedWidthOffset(
+            rawOffset, frameOriginX: 32, frameWidth: 50, containerMaxX: 375)
+
+        XCTAssertEqual(clamped, rawOffset)
+        XCTAssertLessThanOrEqual(32 + 50 + clamped, 375)
+    }
+
+    func testNavigationLinkDescription_wouldOverlapChevronWithoutClamp() {
+        // Reproduces NR-546764: a near-full-width description row where the
+        // real content boundary (containerMaxX) sits where the disclosure
+        // chevron begins. "Try new features before they're released to
+        // everyone. These features may be unstable..." has 21 spaces, so the
+        // pre-fix offset (spaces * 2 = 42) overshoots the row's real bound.
+        let frameOriginX: CGFloat = 32
+        let frameWidth: CGFloat = 330
+        let containerMaxX: CGFloat = 375 // row's real content boundary, before the chevron
+        let rawOffset: CGFloat = 42
+
+        let unclampedMaxX = frameOriginX + frameWidth + rawOffset
+        XCTAssertGreaterThan(unclampedMaxX, containerMaxX,
+                              "sanity check: the raw offset does overshoot the row bound")
+
+        let clamped = UIHostingViewRecordOrchestrator.clampedWidthOffset(
+            rawOffset, frameOriginX: frameOriginX, frameWidth: frameWidth, containerMaxX: containerMaxX)
+
+        XCTAssertEqual(frameOriginX + frameWidth + clamped, containerMaxX,
+                        "clamped offset should fill exactly up to the row's real bound, not past it")
+    }
+
+    func testNoRoomLeft_offsetClampsToZero() {
+        // The raw frame already reaches (or exceeds) the container bound —
+        // there's no room to add any compensation, and we must never produce
+        // a negative-width adjustment.
+        let clamped = UIHostingViewRecordOrchestrator.clampedWidthOffset(
+            10, frameOriginX: 32, frameWidth: 343, containerMaxX: 375)
+
+        XCTAssertEqual(clamped, 0)
+    }
+
+    func testZeroRawOffset_passesThroughUnchanged() {
+        let clamped = UIHostingViewRecordOrchestrator.clampedWidthOffset(
+            0, frameOriginX: 32, frameWidth: 100, containerMaxX: 375)
+
+        XCTAssertEqual(clamped, 0)
+    }
+}


### PR DESCRIPTION
… bounds

The space-compensation offset added to a captured SwiftUI Text's wireframe width scaled with the string's space count and was never bounded, letting long NavigationLink labels grow past their row's real content width and overlap the trailing disclosure chevron in session replay. Clamp it to the ambient SwiftUI content frame so it can widen a label only as far as its container actually allows.

Adds a NavigationLink Labels test case to NRTestApp to reproduce the issue.