### PR TITLE
NR-598870 Fix for JSErrorController memory leak

### DIFF
--- a/Agent/JSError/JSErrorController.swift
+++ b/Agent/JSError/JSErrorController.swift
@@ -99,6 +99,13 @@ public class JSErrorController: NSObject {
         loadPersistedErrorsOnStartup()
     }
 
+    deinit {
+        // URLSession retains its delegate strongly, so MobileErrorsUploader.deinit is
+        // never reached via ARC alone. Invalidating here breaks the retain cycle before
+        // JSErrorController releases the uploader property.
+        uploader?.invalidate()
+    }
+
     // MARK: - Public Methods
 
     @objc public func recordJSError(_ name: String,


### PR DESCRIPTION
URLSession retains its delegate strongly, so MobileErrorsUploader and its URLSession form a retain cycle — neither's refcount ever reaches zero, and deinit (which calls session.finishTasksAndInvalidate()) is never reached via ARC alone. The invalidate() method on MobileErrorsUploader already existed exactly for this purpose; it just wasn't being called. Now JSErrorController.deinit — which is reachable since JSErrorController itself has no retain cycle — drives the teardown: invalidate() tells the URLSession to finish and release its delegate, breaking the cycle before ARC releases the uploader property.