### PR TITLE
NR-602919 Fix session replay events sorting ahead of Meta/FullSnapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ Test Harness/NRTestApp/upload_dsym_results.log
 node_modules
 derived_path
 builds/nrtestapp-ios.zip
+.worktrees

--- a/Agent.xcodeproj/project.pbxproj
+++ b/Agent.xcodeproj/project.pbxproj
@@ -1651,6 +1651,7 @@
 		F87954D529E89D5F00319FCD /* NRMAWKWebViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209ABB324E704A600E45C90 /* NRMAWKWebViewTests.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		F88801D22FC5FB780051DC67 /* SessionReplayReporterOfflineStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88801D12FC5FB780051DC67 /* SessionReplayReporterOfflineStorageTests.swift */; };
 		F88801E72FC734C90051DC67 /* SessionReplayReporterNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88801E62FC734C90051DC67 /* SessionReplayReporterNetworkTests.swift */; };
+		0EA0DA15A28C7FE0E98CD11E /* SessionReplayHarvestEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15109B42FC49AA5B0AE1D31 /* SessionReplayHarvestEndToEndTests.swift */; };
 		F88C2CF72A2FA7AC00373EFE /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = F88C2CE32A2FA7AC00373EFE /* PrivacyInfo.xcprivacy */; };
 		F89167372BC9D1270085BCFC /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = F88C2CE32A2FA7AC00373EFE /* PrivacyInfo.xcprivacy */; };
 		F89167442BCD8EA30085BCFC /* NRViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F824A43029AEAD63000886A6 /* NRViewModifier.swift */; };
@@ -2740,6 +2741,7 @@
 		F879257B2D441ACC00576F5D /* NRMAAttributeValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NRMAAttributeValidator.h; sourceTree = "<group>"; };
 		F88801D12FC5FB780051DC67 /* SessionReplayReporterOfflineStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayReporterOfflineStorageTests.swift; sourceTree = "<group>"; };
 		F88801E62FC734C90051DC67 /* SessionReplayReporterNetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayReporterNetworkTests.swift; sourceTree = "<group>"; };
+		C15109B42FC49AA5B0AE1D31 /* SessionReplayHarvestEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayHarvestEndToEndTests.swift; sourceTree = "<group>"; };
 		F88C2CE32A2FA7AC00373EFE /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		F89167382BC9D1540085BCFC /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.2.sdk/usr/lib/libc++.tbd"; sourceTree = DEVELOPER_DIR; };
 		F891A6BD2CB6F5C1007675F4 /* NRAutoLogCollector.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRAutoLogCollector.m; sourceTree = "<group>"; };
@@ -3149,6 +3151,7 @@
 				F85ABB482F1557150098A2CF /* UILabelThingyTests.swift */,
 				F88801D12FC5FB780051DC67 /* SessionReplayReporterOfflineStorageTests.swift */,
 				F88801E62FC734C90051DC67 /* SessionReplayReporterNetworkTests.swift */,
+				C15109B42FC49AA5B0AE1D31 /* SessionReplayHarvestEndToEndTests.swift */,
 				0209ACB424E747FA00E45C90 /* NewRelicAgentTests.m */,
 				F8BF154C2F3A37FB00EF5628 /* SwiftUIShapeThingyTests.swift */,
 				0209ACB224E7394B00E45C90 /* NRMAInternalTests.m */,
@@ -5658,6 +5661,7 @@
 				2B4226FB29DB9A170068BB8A /* NRMAHTTPUtilitiesTests.m in Sources */,
 				0209AC3D24E7075200E45C90 /* NRHarvestableVitalsTest.m in Sources */,
 				F88801E72FC734C90051DC67 /* SessionReplayReporterNetworkTests.swift in Sources */,
+				0EA0DA15A28C7FE0E98CD11E /* SessionReplayHarvestEndToEndTests.swift in Sources */,
 				F8BF15382F3A37C200EF5628 /* SwiftUIShapeThingy.swift in Sources */,
 				0209AC4A24E7078C00E45C90 /* NRMACrashDataUploaderTest.m in Sources */,
 				C94F51A12857832B00E81E01 /* NRMAActivityNameGeneratorTest.m in Sources */,

--- a/Agent/SessionReplay/NRMASessionReplay.swift
+++ b/Agent/SessionReplay/NRMASessionReplay.swift
@@ -448,9 +448,28 @@ public class NRMASessionReplay: NSObject {
         let firstTimestamp: TimeInterval = TimeInterval(firstFrame.date.timeIntervalSince1970 * 1000).rounded()
         let lastTimestamp: TimeInterval = TimeInterval(processedFrame.timestamp)
         
-        var container: [AnyRRWebEvent] = []
-        
-        // Only add meta event for first frame or when frame size changes
+        // Only add a meta event for the first frame or when frame size changes.
+        // Touches are captured on an independent timeline (UIApplication event
+        // swizzling) and can be timestamped at or before this frame, so a plain
+        // timestamp sort across meta+frame+touches can displace either of these
+        // leading events:
+        //   - Meta must be first so the rrweb player can initialize the
+        //     viewport/document (otherwise: "First event didn't include meta").
+        //   - When this frame IS a full snapshot (isFullSnapshot), processedFrame
+        //     itself is the FullSnapshot -- incremental/touch events can
+        //     reference DOM node IDs that only exist once it's been applied, so
+        //     it must never be sorted after a touch either.
+        // Both are built separately and prepended in order (meta, then full
+        // snapshot); only touches -- and, when this frame is NOT a full
+        // snapshot, the frame's own ordinary incremental update -- get sorted
+        // amongst themselves, since normal incremental mutations and touches
+        // are meant to interleave chronologically.
+        //
+        // This frame file backs crash-recovery replay (see
+        // SessionReplayManager.processSessionReplayFile), so the rrweb player
+        // hits the same failure on recovery as it would on the live upload
+        // path if this isn't preserved.
+        var leadingEvents: [AnyRRWebEvent] = []
         if lastFrameSize != frame.size || isFullSnapshot {
             NRLOG_AGENT_DEBUG("💾 [processFrameToFile] Size change detected - Adding meta event")
             let metaEventData = RRWebMetaData(
@@ -459,15 +478,22 @@ public class NRMASessionReplay: NSObject {
                 height: Int(frame.size.height)
             )
             let metaEvent = MetaEvent(timestamp: TimeInterval(lastTimestamp), data: metaEventData)
-            container.append(AnyRRWebEvent(metaEvent))
+            leadingEvents.append(AnyRRWebEvent(metaEvent))
         }
-        
-        container.append(AnyRRWebEvent(processedFrame))
-        container.append(contentsOf: processedTouches.map(AnyRRWebEvent.init))
+
+        var container: [AnyRRWebEvent]
+        if isFullSnapshot {
+            leadingEvents.append(AnyRRWebEvent(processedFrame))
+            container = processedTouches.map(AnyRRWebEvent.init)
+        } else {
+            container = [AnyRRWebEvent(processedFrame)]
+            container.append(contentsOf: processedTouches.map(AnyRRWebEvent.init))
+        }
         container.sort { (lhs: AnyRRWebEvent, rhs: AnyRRWebEvent) -> Bool in
             lhs.base.timestamp < rhs.base.timestamp
         }
-        
+        container.insert(contentsOf: leadingEvents, at: 0)
+
         //        NRLOG_AGENT_DEBUG("💾 [processFrameToFile] Container events: \(container.count)")
         
         // Extract URL generation logic from createReplayUpload

--- a/Agent/SessionReplay/RRWebModels/AnyRRWebEvent.swift
+++ b/Agent/SessionReplay/RRWebModels/AnyRRWebEvent.swift
@@ -38,3 +38,29 @@ struct AnyRRWebEvent: Codable {
         try (base as Encodable).encode(to: encoder)
     }
 }
+
+/// Test-only seams. This module builds with BUILD_LIBRARY_FOR_DISTRIBUTION
+/// (Library Evolution) enabled, under which `@testable import` cannot resolve
+/// `RRWebEvent<T>`'s conformance to `RRWebEventCommon` (a Codable-refining
+/// protocol) for a caller outside the module -- not even via a generic
+/// constraint. So these take only plain values and do the construction (and
+/// the existential boxing) entirely inside this file, where the conformance
+/// is directly visible, returning a concrete AnyRRWebEvent a test can freely
+/// inspect.
+func makeMetaAnyRRWebEvent(timestamp: TimeInterval) -> AnyRRWebEvent {
+    AnyRRWebEvent(MetaEvent(timestamp: timestamp,
+                            data: RRWebMetaData(href: "http://newrelic.com", width: 100, height: 100)))
+}
+
+func makeTouchAnyRRWebEvent(timestamp: TimeInterval) -> AnyRRWebEvent {
+    let data = RRWebIncrementalData.mouseInteraction(
+        RRWebMouseInteractionData(type: .touchStart, id: 1, x: 10, y: 10))
+    return AnyRRWebEvent(IncrementalEvent(timestamp: timestamp, data: data))
+}
+
+func makeFullSnapshotAnyRRWebEvent(timestamp: TimeInterval) -> AnyRRWebEvent {
+    let documentNode = DocumentNodeData(id: 1, childNodes: [])
+    let snapshotData = RRWebFullSnapshotData(node: .document(documentNode),
+                                              initialOffset: RRWebFullSnapshotData.InitialOffset(top: 0, left: 0))
+    return AnyRRWebEvent(FullSnapshotEvent(timestamp: timestamp, data: snapshotData))
+}

--- a/Agent/SessionReplay/SessionReplayManager.swift
+++ b/Agent/SessionReplay/SessionReplayManager.swift
@@ -257,58 +257,132 @@ public class SessionReplayManager: NSObject {
         }
         
         let frames = self.sessionReplay.getSessionReplayFrames()
-        let touches = self.sessionReplay.getSessionReplayTouches()
-        
-        if frames.isEmpty && touches.isEmpty {
-            NRLOG_AGENT_DEBUG("No session replay frames or touches to harvest.")
+
+        // A chunk with no frames has no viewport/DOM to establish Meta from, so any
+        // touches captured during this window would upload as a touches-only,
+        // completely meta-less payload (see NR-601844 -- confirmed via a real repro
+        // where a session ended, via a rapid setUserId change, before its first frame
+        // had finished capturing). Bail out WITHOUT calling getSessionReplayTouches()
+        // -- that call clears the touch capture's buffer as a side effect, so calling
+        // it here would silently discard these touches instead of leaving them to be
+        // picked up once a frame actually exists, on the next harvest.
+        guard !frames.isEmpty else {
+            NRLOG_AGENT_DEBUG("No session replay frames to harvest yet; any touches captured so far are left for the next harvest.")
             return
         }
-        
-        var container: [AnyRRWebEvent] = frames.map(AnyRRWebEvent.init)
-        container.append(contentsOf: touches.map(AnyRRWebEvent.init))
-        container.sort { (lhs: AnyRRWebEvent, rhs: AnyRRWebEvent) -> Bool in
-            lhs.base.timestamp < rhs.base.timestamp
-        }
-        
-        let firstTimestamp = TimeInterval(container.first?.base.timestamp ?? 0)
-        let lastTimestamp  = TimeInterval(container.last?.base.timestamp ?? 0)
-        
-        guard let upload = self.createReplayUpload(container: container,
-                                                   firstTimestamp: firstTimestamp,
-                                                   lastTimestamp: lastTimestamp) else {
+
+        let touches = self.sessionReplay.getSessionReplayTouches()
+
+        let boxedFrames = frames.map(AnyRRWebEvent.init)
+        let boxedTouches = touches.map(AnyRRWebEvent.init)
+
+        guard let upload = buildReplayUpload(frames: boxedFrames, touches: boxedTouches) else {
             return
         }
         self.sessionReplayReporter.enqueueSessionReplayUpload(upload: upload)
-        
-        self.sessionReplay.isFirstChunk = false
 
+        self.sessionReplay.isFirstChunk = false
     }
-    
-    private func createReplayUpload(container: [AnyRRWebEvent], firstTimestamp: TimeInterval, lastTimestamp: TimeInterval) -> SessionReplayData? {
+
+    /// Merges and sorts frame/touch events into upload order. Extracted out of
+    /// buildReplayUpload() so the real merge+sort logic -- where the "First
+    /// event didn't include meta" defect lived -- is directly testable on its
+    /// own, without needing a resolvable harvester configuration (required
+    /// further down the pipeline to build the actual upload URL).
+    ///
+    /// `frames` is never empty-first: NRMASessionReplay.getSessionReplayFrames()
+    /// always leads with a Meta event (screen size starts at .zero, so the
+    /// first real frame always triggers one), and that leading frame is
+    /// always followed by a FullSnapshot -- getSessionReplayFrames() resets
+    /// its processor's lastFullFrame to nil before processing its first raw
+    /// frame, which forces a full snapshot for it. Touches are captured on an
+    /// independent timeline (UIApplication event swizzling) and can be
+    /// timestamped at or before either of those leading events, so a plain
+    /// timestamp sort across both lists could displace either:
+    ///   - Meta must be first so the rrweb player can initialize the
+    ///     viewport/document (otherwise: "First event didn't include meta").
+    ///   - The FullSnapshot right after it establishes the DOM node IDs that
+    ///     later incremental/touch events reference, so it can't be sorted
+    ///     after a touch either -- confirmed via a real repro where a touch
+    ///     sorted ahead of it (raw frames [meta, fullSnapshot, ...] became
+    ///     [meta, touch, touch, fullSnapshot, ...] after a naive merge).
+    /// So both leading events are anchored at the front, in order; everything
+    /// else (the rest of frames + all touches) is sorted normally by
+    /// timestamp after them.
+    func mergeAndSortReplayEvents(frames: [AnyRRWebEvent], touches: [AnyRRWebEvent]) -> [AnyRRWebEvent] {
+        guard let leadingMeta = frames.first else {
+            return touches.sorted { (lhs: AnyRRWebEvent, rhs: AnyRRWebEvent) -> Bool in
+                lhs.base.timestamp < rhs.base.timestamp
+            }
+        }
+
+        var leadingEvents = [leadingMeta]
+        var rest = Array(frames.dropFirst())
+        if let leadingSnapshot = rest.first, leadingSnapshot.base.type == .fullSnapshot {
+            leadingEvents.append(leadingSnapshot)
+            rest.removeFirst()
+        }
+
+        rest.append(contentsOf: touches)
+        rest.sort { (lhs: AnyRRWebEvent, rhs: AnyRRWebEvent) -> Bool in
+            lhs.base.timestamp < rhs.base.timestamp
+        }
+
+        return leadingEvents + rest
+    }
+
+    /// Merges/sorts/encodes a chunk from already-boxed events, returning the
+    /// resulting upload (or nil if there was nothing to send). Extracted out of
+    /// harvestSessionReplayFramesAndTouches() so the real merge+sort+encode path
+    /// is directly testable with synthetic events, without needing to dispatch
+    /// (or mock) an actual upload -- this is still the real production logic,
+    /// called above with genuinely captured frames/touches.
+    func buildReplayUpload(frames: [AnyRRWebEvent], touches: [AnyRRWebEvent]) -> SessionReplayData? {
+        let container = mergeAndSortReplayEvents(frames: frames, touches: touches)
+
+        let firstTimestamp = TimeInterval(container.first?.base.timestamp ?? 0)
+        let lastTimestamp  = TimeInterval(container.last?.base.timestamp ?? 0)
+
+        return self.createReplayUpload(container: container,
+                                        firstTimestamp: firstTimestamp,
+                                        lastTimestamp: lastTimestamp)
+    }
+
+    /// Encodes and gzips a merged/sorted event container to the exact bytes
+    /// that would be uploaded, plus the pre-gzip size (needed for the upload
+    /// URL's metadata). Extracted out of createReplayUpload() so the real
+    /// encode+gzip path is directly testable without needing a resolvable
+    /// harvester configuration, which createReplayUpload() separately
+    /// requires (via uploadURL()) to build the final upload URL.
+    func encodeReplayPayload(container: [AnyRRWebEvent]) -> (data: Data, uncompressedSize: Int)? {
         let encoder = JSONEncoder()
         encoder.outputFormatting = .withoutEscapingSlashes
-        
-        // Encode container to JSON
+
         var jsonData: Data
         do {
             jsonData = try encoder.encode(container)
-//            if let jsonString = String(data: jsonData, encoding: .utf8) {
-//                NRLOG_AGENT_DEBUG(jsonString)
-//            }
         } catch {
             NRLOG_AGENT_DEBUG("Failed to encode session replay events to JSON: \(error)")
             return nil
         }
-        
+
         let uncompressedDataSize = jsonData.count
-        
+
         do {
             let gzippedData = try jsonData.gzipped()
             jsonData = gzippedData
         } catch {
             NRLOG_AGENT_DEBUG("Failed to gzip session replay data: \(error.localizedDescription)")
         }
-        
+
+        return (jsonData, uncompressedDataSize)
+    }
+
+    private func createReplayUpload(container: [AnyRRWebEvent], firstTimestamp: TimeInterval, lastTimestamp: TimeInterval) -> SessionReplayData? {
+        guard let (jsonData, uncompressedDataSize) = encodeReplayPayload(container: container) else {
+            return nil
+        }
+
         // Construct upload URL
         guard let url = sessionReplayReporter.uploadURL(
             uncompressedDataSize: uncompressedDataSize,
@@ -320,9 +394,7 @@ public class SessionReplayManager: NSObject {
             NRLOG_AGENT_DEBUG("Failed to construct upload URL for session replay.")
             return nil
         }
-        
-        // NRLOG_AGENT_DEBUG(url.absoluteString)
-        
+
         return SessionReplayData(sessionReplayFramesData: jsonData, url: url)
     }
     

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayHarvestEndToEndTests.swift
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/SessionReplayHarvestEndToEndTests.swift
@@ -1,0 +1,118 @@
+//
+//  SessionReplayHarvestEndToEndTests.swift
+//  NewRelicAgent
+//
+//  Copyright © 2026 New Relic. All rights reserved.
+//
+
+import XCTest
+import zlib
+@testable import NewRelic
+
+/// End-to-end reproduction of the "First event didn't include meta" defect,
+/// through the REAL production path: SessionReplayManager.mergeAndSortReplayEvents()
+/// + encodeReplayPayload() -- the merge+sort+encode+gzip logic extracted from
+/// the private harvestSessionReplayFramesAndTouches()/createReplayUpload(),
+/// still the exact code the real harvest timer calls. Stops short of
+/// building the final upload URL (which needs a resolvable harvester
+/// configuration -- a real singleton that requires either a full collector
+/// connect handshake or persisting matching data across two NSUserDefaults
+/// keys, neither of which this test needs to prove the actual bug).
+///
+/// Unlike SessionReplayEventOrderingTests (which mirrors the sort logic in
+/// isolation), this exercises the actual shipping methods and inspects the
+/// actual gzipped JSON payload that would be POSTed.
+class SessionReplayHarvestEndToEndTests: XCTestCase {
+
+    func testRealHarvestPathCanEncodeTouchBeforeMetaEvent() throws {
+        let reporter = SessionReplayReporter(
+            applicationToken: "test-token",
+            url: "mobile-collector.newrelic.com" as NSString
+        )
+        let manager = SessionReplayManager(reporter: reporter, url: "mobile-collector.newrelic.com" as NSString)
+
+        let meta = makeMetaAnyRRWebEvent(timestamp: 1_000)
+        let touch = makeTouchAnyRRWebEvent(timestamp: 999) // 1ms before the chunk's first frame
+
+        let container = manager.mergeAndSortReplayEvents(frames: [meta], touches: [touch])
+
+        guard let (payload, _) = manager.encodeReplayPayload(container: container) else {
+            XCTFail("encodeReplayPayload returned nil -- expected real encoded+gzipped bytes to inspect")
+            return
+        }
+
+        let decompressed = try gunzip(payload)
+        let jsonArray = try JSONSerialization.jsonObject(with: decompressed) as? [[String: Any]]
+        let firstEventType = jsonArray?.first?["type"] as? Int
+
+        XCTAssertEqual(firstEventType, RRWebEventType.meta.rawValue,
+            "The real end-to-end harvest path (merge, sort, JSON-encode, gzip) should never " +
+            "produce an encoded chunk whose first event isn't Meta; got type \(String(describing: firstEventType)). " +
+            "This is the exact payload shape that causes the rrweb player's " +
+            "\"First event didn't include meta\" error.")
+    }
+
+    /// Reproduces a second, distinct defect in the same merge path: a raw
+    /// frames array of [Meta, FullSnapshot, ...] (what getSessionReplayFrames()
+    /// always produces) had only its Meta anchored -- the FullSnapshot right
+    /// after it was sorted in with touches like any other event, so a touch
+    /// timestamped at or before it could displace it. Confirmed via a real
+    /// device repro where navigating across several screens (each forcing a
+    /// fresh full snapshot) turned a raw [meta, fullSnapshot, ...] sequence
+    /// into a merged [meta, touch, touch, fullSnapshot, ...] one.
+    func testRealHarvestPathCanEncodeTouchBeforeFullSnapshotEvent() throws {
+        let reporter = SessionReplayReporter(
+            applicationToken: "test-token",
+            url: "mobile-collector.newrelic.com" as NSString
+        )
+        let manager = SessionReplayManager(reporter: reporter, url: "mobile-collector.newrelic.com" as NSString)
+
+        let meta = makeMetaAnyRRWebEvent(timestamp: 1_000)
+        let fullSnapshot = makeFullSnapshotAnyRRWebEvent(timestamp: 1_000) // same timestamp as meta, as production always produces
+        let touch = makeTouchAnyRRWebEvent(timestamp: 999) // 1ms before the chunk's leading events
+
+        let container = manager.mergeAndSortReplayEvents(frames: [meta, fullSnapshot], touches: [touch])
+
+        XCTAssertEqual(container.map { $0.base.type }, [.meta, .fullSnapshot, .incrementalSnapshot],
+            "The FullSnapshot immediately following Meta establishes the DOM node IDs that later " +
+            "incremental/touch events reference, so it must stay pinned right after Meta -- got " +
+            "\(container.map { $0.base.type }). A touch sorting ahead of it produces a payload the " +
+            "rrweb player can't apply its own later mutations against.")
+    }
+
+    private func gunzip(_ data: Data) throws -> Data {
+        var stream = z_stream()
+        var status = inflateInit2_(&stream, 15 + 16, ZLIB_VERSION, Int32(MemoryLayout<z_stream>.size))
+        guard status == Z_OK else {
+            throw NSError(domain: "gunzip", code: Int(status), userInfo: nil)
+        }
+        defer { inflateEnd(&stream) }
+
+        var output = Data()
+        try data.withUnsafeBytes { (inputBuffer: UnsafeRawBufferPointer) in
+            stream.next_in = UnsafeMutablePointer(mutating: inputBuffer.baseAddress!.assumingMemoryBound(to: Bytef.self))
+            stream.avail_in = uInt(data.count)
+
+            repeat {
+                let chunkSize = 16384
+                var outputBuffer = [UInt8](repeating: 0, count: chunkSize)
+                try outputBuffer.withUnsafeMutableBytes { (outputBufferPointer: UnsafeMutableRawBufferPointer) in
+                    let typedPointer = outputBufferPointer.baseAddress!.assumingMemoryBound(to: Bytef.self)
+                    stream.next_out = typedPointer
+                    stream.avail_out = uInt(chunkSize)
+
+                    status = inflate(&stream, Z_NO_FLUSH)
+                    guard status == Z_OK || status == Z_STREAM_END else {
+                        throw NSError(domain: "gunzip", code: Int(status), userInfo: nil)
+                    }
+
+                    let bytesWritten = chunkSize - Int(stream.avail_out)
+                    if bytesWritten > 0 {
+                        output.append(typedPointer, count: bytesWritten)
+                    }
+                }
+            } while status != Z_STREAM_END
+        }
+        return output
+    }
+}


### PR DESCRIPTION
**Bugs found and fixed**

1. Meta event displaced by an early touch — the rrweb player requires Meta to be the first event in the stream to initialize the viewport. A touch sorted ahead of it produced "First event didn't include meta" in the player.
2. FullSnapshot displaced by an early touch — FullSnapshot establishes the DOM node IDs that later touch/incremental events reference. A touch sorted ahead of it broke replay for the same reason.
3. Empty-frame harvest producing a touches-only payload — if a harvest boundary (60s timer, backgrounding, or a setUserId-triggered new session) fires before the first frame has finished its async capture, touches were being uploaded with no frame/meta at all to anchor them to.

Both the live-harvest path (SessionReplayManager.mergeAndSortReplayEvents) and the crash-recovery path (NRMASessionReplay.processFrameToFile) had the same displacement issue and were fixed the same way: anchor Meta (and FullSnapshot, when present) at the front of the merged event list, then sort everything else normally.

**Testing**

- Added regression tests (SessionReplayHarvestEndToEndTests.swift) covering touch-before-meta and touch-before-fullsnapshot through the real harvest path.
- Manually reproduced all three bugs on-device against the staging collector and confirmed each is fixed, including a deterministic repro for bug 3 (rapid back-to-back setUserId calls before the first frame captures).

Fixes NR-602919.