### PR TITLE
Add telemetry fallback for oversized RN sourcemaps, fix HTTP 409 handling 

### DIFF
--- a/dsym-upload-tools/README_REACT_NATIVE_SOURCEMAP.md
+++ b/dsym-upload-tools/README_REACT_NATIVE_SOURCEMAP.md
@@ -143,6 +143,24 @@ Compressed size: 12.67MB (85.2% reduction)
 ✅ Source map uploaded successfully!
 ```
 
+### Oversized Source Maps (Telemetry Fallback)
+
+If the source map is still over the 200MB limit, the file is **not** uploaded at all —
+uploading would fail regardless of compression. Instead, the script sends a lightweight
+`x-telemetry-data` header (Base64-encoded JSON with the sourcemap and JS bundle sizes)
+with no file body, so New Relic can track the attempt. This does not fail the build:
+
+```
+New Relic: Source map exceeds 200MB limit. Sending telemetry data instead of the file.
+New Relic: Telemetry data sent (server returned 400).
+New Relic: New Relic currently supports source map files up to 200MB. The source map for this build exceeds that limit.
+New Relic: JavaScript errors for this build will not be symbolicated.
+```
+
+A non-2xx response to the telemetry request (e.g. 400) is expected, since no source map
+file is attached — the header is the payload, not the file. This mirrors the New Relic
+Android agent's handling of oversized React Native source maps.
+
 ## Uploaded Metadata
 
 The following data is sent with each source map upload:
@@ -216,6 +234,12 @@ The upload script provides detailed error messages for all API responses:
 **Meaning:** Source map file exceeds 200MB limit (even after compression)
 
 **Error message:** `"Sourcemap file is too large"`
+
+**Note:** If the *raw, uncompressed* source map already exceeds 200MB, the script now
+skips the upload entirely and sends telemetry metadata instead — see
+[Oversized Source Maps](#oversized-source-maps-telemetry-fallback) above. A 413 from the
+server itself would only occur if a compressed file just under the raw limit is still
+rejected server-side.
 
 **The script automatically:**
 - Compresses files over 50MB to `.zip` format

--- a/dsym-upload-tools/upload-react-native-sourcemap.swift
+++ b/dsym-upload-tools/upload-react-native-sourcemap.swift
@@ -52,6 +52,7 @@ var debug = false
 
 var sourcemapEndpointPath = "v1/react-native/sourcemaps"
 var sourcemapUploadDataPostKey = "sourcemap"
+let telemetryDataHeader = "x-telemetry-data"
 
 // Maximum file size: 200MB
 let maxFileSizeBytes: UInt64 = 209715200
@@ -143,17 +144,13 @@ func start() {
     print("New Relic: Found source map at: \(sourcemapPath)")
 
     // Check file size
+    var sourcemapFileSize: UInt64 = 0
     do {
         let attributes = try fileManager.attributesOfItem(atPath: sourcemapPath)
         if let fileSize = attributes[.size] as? UInt64 {
+            sourcemapFileSize = fileSize
             let fileSizeMB = Double(fileSize) / 1024.0 / 1024.0
             print("New Relic: Source map size: \(String(format: "%.2f", fileSizeMB))MB")
-
-            if fileSize > maxFileSizeBytes {
-                print("Error: Source map exceeds 200MB limit")
-                print("Consider enabling minification or using code splitting")
-                exit(1)
-            }
         }
     } catch {
         print("Warning: Could not determine file size: \(error)")
@@ -198,6 +195,23 @@ func start() {
 
     // Upload source map
     let uploadURL = "\(url)/\(sourcemapEndpointPath)"
+
+    // If the source map exceeds the 200MB limit, skip the upload entirely and send
+    // telemetry metadata instead, rather than failing the build. Mirrors the Android
+    // agent's oversized-source-map handling (ReactNativeSourceMap.sendTelemetryOnly).
+    if sourcemapFileSize > maxFileSizeBytes {
+        sendTelemetryOnly(
+            apiKey: apiKey,
+            appToken: appToken,
+            url: uploadURL,
+            jsBundleId: jsBundleId,
+            appVersion: appVersion,
+            sourcemapName: sourcemapName,
+            sourcemapSize: sourcemapFileSize
+        )
+        exit(0)
+    }
+
     print("New Relic: Uploading to: \(uploadURL)")
 
     do {
@@ -489,6 +503,89 @@ func uploadSourceMap(
     if let error = uploadError {
         throw error
     }
+}
+
+// Sends telemetry metadata instead of the actual source map when the map exceeds the
+// 200MB limit. No file body is included -- the x-telemetry-data header (Base64-encoded
+// JSON) is the payload. A non-2xx response is expected (there's no file for the server
+// to validate) and is logged, not treated as a failure -- this function never throws,
+// mirroring the Android agent's non-fatal telemetry send (ReactNativeSourceMap.sendTelemetryOnly).
+func sendTelemetryOnly(
+    apiKey: String,
+    appToken: String,
+    url: String,
+    jsBundleId: String,
+    appVersion: String,
+    sourcemapName: String,
+    sourcemapSize: UInt64
+) {
+    print("New Relic: Source map exceeds 200MB limit. Sending telemetry data instead of the file.")
+
+    let bundlePath = "\(environment["BUILT_PRODUCTS_DIR"] ?? "")/main.jsbundle"
+    var bundleSize: UInt64 = 0
+    if let attributes = try? fileManager.attributesOfItem(atPath: bundlePath),
+       let size = attributes[.size] as? UInt64 {
+        bundleSize = size
+    }
+    let bundleName = sourcemapName.replacingOccurrences(of: ".map", with: "")
+
+    let telemetryJSON = "{\"bundler\":\"metro\",\"bundles\":[{\"name\":\"\(bundleName)\",\"size\":\(bundleSize)}],"
+        + "\"sourcemaps\":[{\"name\":\"\(sourcemapName)\",\"size\":\(sourcemapSize)}]}"
+    let encodedTelemetry = Data(telemetryJSON.utf8).base64EncodedString()
+
+    if debug {
+        print("========== Telemetry JSON = \(telemetryJSON)")
+    }
+
+    guard let telemetryURL = URL(string: url) else {
+        print("Warning: Could not build telemetry request URL (non-critical).")
+        print("New Relic: JavaScript errors for this build will not be symbolicated.")
+        return
+    }
+
+    let boundary = "Boundary-\(UUID().uuidString)"
+    var request = URLRequest(url: telemetryURL)
+    request.httpMethod = "POST"
+    request.setValue(apiKey, forHTTPHeaderField: "Api-Key")
+    request.setValue(appToken, forHTTPHeaderField: "X-APP-LICENSE-KEY")
+    request.setValue(encodedTelemetry, forHTTPHeaderField: telemetryDataHeader)
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+    var body = Data()
+    let textFields = [
+        "jsBundleId": jsBundleId,
+        "appVersion": appVersion,
+        "sourcemapName": sourcemapName
+    ]
+    for (key, value) in textFields {
+        body.append("--\(boundary)\r\n")
+        body.append("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n")
+        body.append("\(value)\r\n")
+    }
+    body.append("--\(boundary)--\r\n")
+    request.httpBody = body
+
+    let semaphore = DispatchSemaphore(value: 0)
+    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+        defer { semaphore.signal() }
+
+        if let error = error {
+            print("Note: Telemetry send encountered an error (non-critical): \(error.localizedDescription)")
+            return
+        }
+        guard let httpResponse = response as? HTTPURLResponse else { return }
+        // A non-2xx response is expected here since no source map file is attached --
+        // the telemetry header is the payload, not the response status.
+        print("New Relic: Telemetry data sent (server returned \(httpResponse.statusCode)).")
+        if debug, let data = data, let responseString = String(data: data, encoding: .utf8) {
+            print("Response body: \(responseString)")
+        }
+    }
+    task.resume()
+    semaphore.wait()
+
+    print("New Relic: New Relic currently supports source map files up to 200MB. The source map for this build exceeds that limit.")
+    print("New Relic: JavaScript errors for this build will not be symbolicated.")
 }
 
 // MARK: - Region Parsing

--- a/dsym-upload-tools/upload-react-native-sourcemap.swift
+++ b/dsym-upload-tools/upload-react-native-sourcemap.swift
@@ -395,6 +395,14 @@ func uploadSourceMap(
             errorMessage = json["message"] as? String ?? json["errorMessage"] as? String
         }
 
+        // 409 means a source map for this jsBundleId has already been stored -- this is
+        // expected/harmless (e.g. a rebuild without a version bump), not a failure.
+        // Matches the Android agent's HTTP_CONFLICT handling.
+        if httpStatusCode == 409 {
+            print("New Relic: A source map for this build (jsBundleId: \(jsBundleId)) has already been stored.")
+            return
+        }
+
         guard (200...299).contains(httpStatusCode) else {
             print("Error: Source map upload failed (HTTP \(httpStatusCode))")
 


### PR DESCRIPTION
Two fixes to the RN sourcemap upload script, found while comparing against Android's implementation:

1. **Oversized (>200MB) sourcemaps** now send a `x-telemetry-data` header instead of just failing — mirrors Android's `sendTelemetryOnly`.
2. **HTTP 409** was misclassified as a failure; now treated as informational (sourcemap already stored), matching Android's `HTTP_CONFLICT` handling.