### PR TITLE
Added the ability to send errors from the server and to update the config

### DIFF
--- a/Test Harness/NRTestApp/NRTestApp.xcodeproj/project.pbxproj
+++ b/Test Harness/NRTestApp/NRTestApp.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		AA0001302F9000000000AA01 /* CapturedRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001202F9000000000AA01 /* CapturedRequest.swift */; };
 		AA0001312F9000000000AA01 /* NRCaptureServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001212F9000000000AA01 /* NRCaptureServer.swift */; };
 		AA0001322F9000000000AA01 /* CaptureViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001222F9000000000AA01 /* CaptureViewerView.swift */; };
+		AA0001332F9000000000AA01 /* ConnectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001232F9000000000AA01 /* ConnectConfig.swift */; };
 		AA0001602F9000000000AA01 /* VerificationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001502F9000000000AA01 /* VerificationResult.swift */; };
 		AA0001612F9000000000AA01 /* PayloadVerifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001512F9000000000AA01 /* PayloadVerifiers.swift */; };
 		CD0001011CD000000000CD00 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0001001CD000000000CD00 /* MapViewController.swift */; };
@@ -429,6 +430,7 @@
 		AA0001202F9000000000AA01 /* CapturedRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedRequest.swift; sourceTree = "<group>"; };
 		AA0001212F9000000000AA01 /* NRCaptureServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NRCaptureServer.swift; sourceTree = "<group>"; };
 		AA0001222F9000000000AA01 /* CaptureViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureViewerView.swift; sourceTree = "<group>"; };
+		AA0001232F9000000000AA01 /* ConnectConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectConfig.swift; sourceTree = "<group>"; };
 		AA0001502F9000000000AA01 /* VerificationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationResult.swift; sourceTree = "<group>"; };
 		AA0001512F9000000000AA01 /* PayloadVerifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayloadVerifiers.swift; sourceTree = "<group>"; };
 		CD0001001CD000000000CD00 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
@@ -668,6 +670,7 @@
 				AA0001202F9000000000AA01 /* CapturedRequest.swift */,
 				AA0001212F9000000000AA01 /* NRCaptureServer.swift */,
 				AA0001222F9000000000AA01 /* CaptureViewerView.swift */,
+				AA0001232F9000000000AA01 /* ConnectConfig.swift */,
 				AA0001502F9000000000AA01 /* VerificationResult.swift */,
 				AA0001512F9000000000AA01 /* PayloadVerifiers.swift */,
 			);
@@ -1466,6 +1469,7 @@
 				AA0001302F9000000000AA01 /* CapturedRequest.swift in Sources */,
 				AA0001312F9000000000AA01 /* NRCaptureServer.swift in Sources */,
 				AA0001322F9000000000AA01 /* CaptureViewerView.swift in Sources */,
+				AA0001332F9000000000AA01 /* ConnectConfig.swift in Sources */,
 				AA0001602F9000000000AA01 /* VerificationResult.swift in Sources */,
 				AA0001612F9000000000AA01 /* PayloadVerifiers.swift in Sources */,
 			);

--- a/Test Harness/NRTestApp/NRTestApp/CaptureServer/CaptureViewerView.swift
+++ b/Test Harness/NRTestApp/NRTestApp/CaptureServer/CaptureViewerView.swift
@@ -3,18 +3,56 @@ import SwiftUI
 struct CaptureViewerView: View {
     @ObservedObject private var store = NRCaptureServer.shared
     @State private var verifySummary: NRCaptureServer.VerifySummary?
+    @State private var listedCaptures: [CapturedRequest] = []
+    @State private var detailVisible = false
+    @State private var showingInjectSheet = false
+    @State private var showingConfigSheet = false
 
     var body: some View {
         NavigationView {
             Group {
-                if store.captures.isEmpty {
+                if listedCaptures.isEmpty {
                     emptyState
                 } else {
                     captureList
                 }
             }
+            .onReceive(store.$captures) { incoming in
+                // Don't update the list while a detail view is open — it would pop navigation.
+                // Sync happens in captureList's onDisappear when the user returns.
+                if !detailVisible {
+                    listedCaptures = incoming
+                }
+            }
             .navigationTitle("Captures")
             .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    HStack(spacing: 10) {
+                        let armed = store.injection != nil
+                        Button { showingInjectSheet = true } label: {
+                            Text(armed ? store.injection!.override.label : "Inject")
+                                .font(.system(.caption2, design: .monospaced).weight(.semibold))
+                                .foregroundColor(armed ? .white : .orange)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(armed ? Color.orange : Color.orange.opacity(0.15))
+                                .cornerRadius(6)
+                        }
+                        .sheet(isPresented: $showingInjectSheet) {
+                            InjectErrorSheet(injection: $store.injection)
+                        }
+
+                        Button { showingConfigSheet = true } label: {
+                            Image(systemName: store.connectConfigMutated
+                                  ? "slider.horizontal.3"
+                                  : "slider.horizontal.3")
+                                .foregroundColor(store.connectConfigMutated ? .orange : .primary)
+                        }
+                        .sheet(isPresented: $showingConfigSheet) {
+                            ConnectConfigSheet()
+                        }
+                    }
+                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     HStack(spacing: 16) {
                         Button("Verify All") {
@@ -22,9 +60,12 @@ struct CaptureViewerView: View {
                                 verifySummary = summary
                             }
                         }
-                        .disabled(store.captures.isEmpty)
-                        Button("Clear") { store.captures.removeAll() }
-                            .disabled(store.captures.isEmpty)
+                        .disabled(listedCaptures.isEmpty)
+                        Button("Clear") {
+                            store.captures.removeAll()
+                            listedCaptures = []
+                        }
+                        .disabled(listedCaptures.isEmpty)
                     }
                 }
             }
@@ -69,22 +110,34 @@ struct CaptureViewerView: View {
     }
 
     private var captureList: some View {
-        List(store.captures) { capture in
-            NavigationLink(destination: CaptureDetailView(capture: capture)) {
+        List(listedCaptures) { capture in
+            NavigationLink(destination: CaptureDetailView(capture: capture)
+                .onAppear  { detailVisible = true }
+                .onDisappear {
+                    detailVisible = false
+                    listedCaptures = store.captures  // catch up on any captures that arrived while in detail
+                }
+            ) {
                 HStack(alignment: .top, spacing: 10) {
                     VerificationBadge(result: capture.verification)
                         .padding(.top, 3)
                     VStack(alignment: .leading, spacing: 3) {
                         Text(capture.endpoint)
-                            .font(.system(.subheadline, design: .monospaced))
-                            .fontWeight(.semibold)
+                            .font(.system(.subheadline, design: .monospaced).weight(.semibold))
                         Text(capture.timestamp, style: .time)
                             .font(.caption)
                             .foregroundColor(.secondary)
-                        Text(capture.summary)
-                            .font(.system(.caption2, design: .monospaced))
-                            .foregroundColor(.secondary)
-                            .lineLimit(2)
+                        if capture.endpoint == "/mobile/blobs" {
+                            Text(capture.fullURL)
+                                .font(.system(.caption2, design: .monospaced))
+                                .foregroundColor(.secondary)
+                                .lineLimit(3)
+                        } else {
+                            Text(capture.summary)
+                                .font(.system(.caption2, design: .monospaced))
+                                .foregroundColor(.secondary)
+                                .lineLimit(2)
+                        }
                     }
                 }
                 .padding(.vertical, 2)
@@ -96,56 +149,54 @@ struct CaptureViewerView: View {
 struct CaptureDetailView: View {
     let capture: CapturedRequest
     @State private var copied = false
-    @State private var bodyRequested = false
-    @State private var bodyReady = false
+    @State private var bodyRevealed = false
 
     private var isLargePayload: Bool { capture.prettyJSON.count > 10_000 }
+    private var bodyLines: [String] { capture.prettyJSON.components(separatedBy: "\n") }
 
     var body: some View {
+        // LazyVStack so body lines are rendered on-demand as the user scrolls,
+        // avoiding the CoreGraphics bogus-layer-size crash on large payloads.
         ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                headerInfo
-                    .padding(.horizontal)
-                    .padding(.bottom, 12)
-
-                if let result = capture.verification {
-                    Divider()
-                    VerificationSection(result: result)
+            LazyVStack(alignment: .leading, spacing: 0) {
+                // Header and verification are small — group them as one eager block.
+                VStack(alignment: .leading, spacing: 0) {
+                    headerInfo
                         .padding(.horizontal)
-                        .padding(.vertical, 12)
+                        .padding(.bottom, 12)
+
+                    if let result = capture.verification {
+                        Divider()
+                        VerificationSection(result: result)
+                            .padding(.horizontal)
+                            .padding(.vertical, 12)
+                    }
+                    Divider()
                 }
 
-                Divider()
-                if isLargePayload && !bodyReady {
-                    if bodyRequested {
-                        HStack(spacing: 10) {
-                            ProgressView()
-                            Text("Loading \(capture.prettyJSON.count / 1024) KB…")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                        }
-                        .padding(.horizontal)
-                        .padding(.vertical, 12)
-                        // Defer the heavy Text render to the next frame so the spinner
-                        // is committed to the display list before layout is blocked.
-                        .onAppear {
-                            DispatchQueue.main.async { bodyReady = true }
-                        }
-                    } else {
-                        Button {
-                            bodyRequested = true
-                        } label: {
-                            Label("Show body (\(capture.prettyJSON.count / 1024) KB)", systemImage: "chevron.down.circle")
-                                .font(.subheadline)
-                        }
-                        .padding(.horizontal)
-                        .padding(.vertical, 12)
+                if !capture.queryParams.isEmpty {
+                    QueryParamsSection(endpoint: capture.endpoint, queryParams: capture.queryParams)
+                    Divider()
+                }
+
+                if isLargePayload && !bodyRevealed {
+                    Button {
+                        bodyRevealed = true
+                    } label: {
+                        Label("Show body (\(capture.prettyJSON.count / 1024) KB)", systemImage: "chevron.down.circle")
+                            .font(.subheadline)
                     }
+                    .padding(.horizontal)
+                    .padding(.vertical, 12)
                 } else {
-                    Text(capture.prettyJSON)
-                        .font(.system(.caption, design: .monospaced))
-                        .padding(.horizontal)
-                        .padding(.vertical, 12)
+                    ForEach(Array(bodyLines.enumerated()), id: \.offset) { index, line in
+                        Text(verbatim: line.isEmpty ? " " : line)
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal)
+                            .padding(.top, index == 0 ? 12 : 0)
+                    }
+                    Color.clear.frame(height: 12)
                 }
             }
         }
@@ -167,11 +218,9 @@ struct CaptureDetailView: View {
             Label(capture.endpoint, systemImage: "network")
                 .font(.system(.subheadline, design: .monospaced))
                 .foregroundColor(.accentColor)
-            if #available(iOS 15.0, *) {
-                Text(capture.timestamp.formatted(date: .abbreviated, time: .complete))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
+            Text(capture.timestamp.formatted(date: .abbreviated, time: .complete))
+                .font(.caption)
+                .foregroundColor(.secondary)
         }
         .padding(.top, 12)
     }
@@ -229,3 +278,378 @@ struct VerificationSection: View {
         }
     }
 }
+
+// MARK: - URL query params disclosure
+
+private struct QueryParamsSection: View {
+    let endpoint: String
+    let queryParams: [(String, String)]
+    @State private var expanded = false
+    @State private var urlCopied = false
+
+    private var fullURL: String {
+        guard !queryParams.isEmpty else { return endpoint }
+        let qs = queryParams.map { "\($0.0)=\($0.1)" }.joined(separator: "&")
+        return "\(endpoint)?\(qs)"
+    }
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $expanded) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .top, spacing: 8) {
+                    Text(fullURL)
+                        .font(.system(.caption2, design: .monospaced))
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer()
+                    Button(urlCopied ? "Copied!" : "Copy") {
+                        UIPasteboard.general.string = fullURL
+                        urlCopied = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { urlCopied = false }
+                    }
+                    .font(.caption2)
+                }
+                .padding(.bottom, 4)
+                Divider()
+                ForEach(Array(queryParams.enumerated()), id: \.offset) { _, pair in
+                    if pair.0 == "attributes" {
+                        AttributesRow(raw: pair.1)
+                    } else {
+                        paramRow(pair.0, pair.1)
+                    }
+                }
+            }
+            .padding(.top, 6)
+            .padding(.bottom, 4)
+        } label: {
+            Text("URL Parameters")
+                .font(.caption.weight(.semibold))
+                .foregroundColor(.secondary)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private func paramRow(_ key: String, _ value: String) -> some View {
+        HStack(alignment: .top, spacing: 4) {
+            Text(key)
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundColor(.secondary)
+                .frame(width: 130, alignment: .leading)
+            Text(value)
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundColor(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private struct AttributesRow: View {
+    let raw: String
+    @State private var expanded = false
+
+    private var pairs: [(String, String)] {
+        let decoded = raw.removingPercentEncoding ?? raw
+        return decoded.components(separatedBy: "&").compactMap { pair in
+            let parts = pair.components(separatedBy: "=")
+            guard parts.count >= 2 else { return nil }
+            return (parts[0], parts[1...].joined(separator: "="))
+        }.sorted { $0.0 < $1.0 }
+    }
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $expanded) {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(Array(pairs.enumerated()), id: \.offset) { _, pair in
+                    HStack(alignment: .top, spacing: 4) {
+                        Text(pair.0)
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundColor(.secondary)
+                            .frame(width: 160, alignment: .leading)
+                        Text(pair.1)
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundColor(.primary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .padding(.top, 4)
+        } label: {
+            HStack(spacing: 4) {
+                Text("attributes")
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .frame(width: 130, alignment: .leading)
+                Text("(\(pairs.count) keys)")
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}
+
+// MARK: - Connect config JSON editor
+
+/// Pushed onto InjectErrorSheet's NavigationView stack — no NavigationView wrapper needed.
+private struct ConnectConfigEditorView: View {
+    let onSave: (ConnectConfig) -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var config: ConnectConfig
+
+    init(initial: ConnectConfig, onSave: @escaping (ConnectConfig) -> Void) {
+        self.onSave = onSave
+        _config = State(initialValue: initial)
+    }
+
+    private static let logLevels = ["DEBUG", "INFO", "WARN", "ERROR", "VERBOSE", "AUDIT"]
+    @State private var selectedRuleIndex: Int? = nil
+
+    var body: some View {
+        Form {
+            Section("Session Replay") {
+                Toggle("Enabled", isOn: $config.configuration.sessionReplay.enabled)
+                Stepper(
+                    "Sampling rate: \(Int(config.configuration.sessionReplay.samplingRate))%",
+                    value: $config.configuration.sessionReplay.samplingRate,
+                    in: 0...100, step: 10
+                )
+                Stepper(
+                    "Error sampling rate: \(Int(config.configuration.sessionReplay.errorSamplingRate))%",
+                    value: $config.configuration.sessionReplay.errorSamplingRate,
+                    in: 0...100, step: 10
+                )
+                Picker("Mode", selection: $config.configuration.sessionReplay.mode) {
+                    Text("custom").tag("custom")
+                    Text("default").tag("default")
+                }
+                Toggle("Mask application text", isOn: $config.configuration.sessionReplay.maskApplicationText)
+                Toggle("Mask user input text",  isOn: $config.configuration.sessionReplay.maskUserInputText)
+                Toggle("Mask all images",       isOn: $config.configuration.sessionReplay.maskAllImages)
+                Toggle("Mask all touches",      isOn: $config.configuration.sessionReplay.maskAllUserTouches)
+            }
+
+            Section("Logs") {
+                Toggle("Enabled", isOn: $config.configuration.logs.enabled)
+                Picker("Level", selection: $config.configuration.logs.level) {
+                    ForEach(Self.logLevels, id: \.self) { Text($0).tag($0) }
+                }
+                Stepper(
+                    "Sampling rate: \(Int(config.configuration.logs.samplingRate))%",
+                    value: $config.configuration.logs.samplingRate,
+                    in: 0...100, step: 10
+                )
+            }
+
+            Section("Custom Masking Rules") {
+                ForEach(config.configuration.sessionReplay.customMaskingRules.indices, id: \.self) { i in
+                    NavigationLink(tag: i, selection: $selectedRuleIndex) {
+                        MaskingRuleEditorView(
+                            rule: $config.configuration.sessionReplay.customMaskingRules[i]
+                        )
+                    } label: {
+                        maskingRuleLabel(config.configuration.sessionReplay.customMaskingRules[i])
+                    }
+                }
+                .onDelete {
+                    config.configuration.sessionReplay.customMaskingRules.remove(atOffsets: $0)
+                    selectedRuleIndex = nil
+                }
+                Button("Add Rule") {
+                    let newIndex = config.configuration.sessionReplay.customMaskingRules.count
+                    config.configuration.sessionReplay.customMaskingRules.append(
+                        .init(identifier: "class", type: "mask", name: [])
+                    )
+                    selectedRuleIndex = newIndex
+                }
+            }
+        }
+        .navigationTitle("Connect Config")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button { onSave(config); dismiss() } label: {
+                    Text("Apply").fontWeight(.semibold)
+                }
+            }
+        }
+        .onChange(of: selectedRuleIndex) { newValue in
+            guard newValue == nil else { return }
+            config.configuration.sessionReplay.customMaskingRules.removeAll {
+                $0.name.first?.isEmpty != false
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func maskingRuleLabel(_ rule: ConnectConfig.MaskingRule) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 6) {
+                Text(rule.type)
+                    .font(.caption.weight(.semibold))
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(rule.type == "mask" ? Color.orange.opacity(0.2) : Color.green.opacity(0.2))
+                    .cornerRadius(4)
+                Text(rule.identifier)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            Text(rule.name.isEmpty ? "(no names)" : rule.name.joined(separator: ", "))
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+// MARK: - Masking rule editor
+
+private struct MaskingRuleEditorView: View {
+    @Binding var rule: ConnectConfig.MaskingRule
+    @State private var draft: ConnectConfig.MaskingRule
+    @Environment(\.dismiss) private var dismiss
+
+    init(rule: Binding<ConnectConfig.MaskingRule>) {
+        _rule = rule
+        _draft = State(initialValue: rule.wrappedValue)
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("Identifier", selection: $draft.identifier) {
+                    Text("class").tag("class")
+                    Text("tag").tag("tag")
+                }
+                Picker("Type", selection: $draft.type) {
+                    Text("mask").tag("mask")
+                    Text("unmask").tag("unmask")
+                }
+            }
+
+            Section("Name") {
+                TextField("e.g. UITextField", text: Binding(
+                    get: { draft.name.first ?? "" },
+                    set: { draft.name = [$0] }
+                ))
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .font(.system(.body, design: .monospaced))
+            }
+        }
+        .navigationTitle("Masking Rule")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button { rule = draft; dismiss() } label: {
+                    Text("Save").fontWeight(.semibold)
+                }
+                .disabled(draft.name.first?.isEmpty != false)
+            }
+        }
+    }
+}
+
+// MARK: - Connect config sheet
+
+private struct ConnectConfigSheet: View {
+    @ObservedObject private var store = NRCaptureServer.shared
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationView {
+            ConnectConfigEditorView(
+                initial: store.connectConfig,
+                onSave: { store.setConnectConfig($0) }
+            )
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Reset", role: .destructive) {
+                        store.resetConnectConfig()
+                        dismiss()
+                    }
+                    .disabled(!store.connectConfigMutated)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Error injection sheet
+
+private struct InjectErrorSheet: View {
+    @Binding var injection: StatusInjection?
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedPreset   = ResponseOverride.presets[0]
+    @State private var selectedEndpoint = StatusInjection.Endpoint.all
+    @State private var count       = 1
+    @State private var unlimited   = false
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Response") {
+                    Picker("Error", selection: $selectedPreset) {
+                        ForEach(ResponseOverride.presets, id: \.label) { preset in
+                            Text(preset.label).tag(preset)
+                        }
+                    }
+                    .pickerStyle(.inline)
+                    .labelsHidden()
+                }
+
+                Section("Endpoint") {
+                    Picker("Endpoint", selection: $selectedEndpoint) {
+                        ForEach(StatusInjection.Endpoint.allCases) { ep in
+                            Text(ep.rawValue).tag(ep)
+                        }
+                    }
+                    .pickerStyle(.inline)
+                    .labelsHidden()
+                }
+
+                Section("Repeat") {
+                    Toggle("Unlimited", isOn: $unlimited)
+                    if !unlimited {
+                        Stepper("Count: \(count)", value: $count, in: 1...100)
+                    }
+                }
+
+                if let active = injection {
+                    Section("Active injection") {
+                        Text(active.label)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundColor(.orange)
+                        Button("Disarm", role: .destructive) {
+                            injection = nil
+                            dismiss()
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Inject Error")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Arm") {
+                        injection = StatusInjection(
+                            override: selectedPreset,
+                            endpoint: selectedEndpoint,
+                            remaining: count,
+                            unlimited: unlimited
+                        )
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/Test Harness/NRTestApp/NRTestApp/CaptureServer/CapturedRequest.swift
+++ b/Test Harness/NRTestApp/NRTestApp/CaptureServer/CapturedRequest.swift
@@ -9,8 +9,16 @@ struct CapturedRequest: Identifiable {
     let decodedBody: Data
     let prettyJSON: String
     var verification: VerificationResult?
+    // The connect response config the server actually served (nil when a 4xx/5xx was injected).
+    var serverConnectResponse: ConnectConfig? = nil
 
     var summary: String { String(prettyJSON.prefix(150)) }
+
+    var fullURL: String {
+        guard !queryParams.isEmpty else { return endpoint }
+        let qs = queryParams.map { "\($0.0)=\($0.1)" }.joined(separator: "&")
+        return "\(endpoint)?\(qs)"
+    }
 
     func queryValue(_ name: String) -> String? {
         queryParams.first(where: { $0.0 == name })?.1

--- a/Test Harness/NRTestApp/NRTestApp/CaptureServer/ConnectConfig.swift
+++ b/Test Harness/NRTestApp/NRTestApp/CaptureServer/ConnectConfig.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+// MARK: - ConnectConfig
+
+/// Typed model of the /connect response body. All fields map 1-to-1 to the JSON the server
+/// sends to the agent. Codable lets the UI edit the config as pretty-printed JSON and re-parse it.
+///
+/// `at_capture` ([Int, [Any]]) is a heterogeneous array that can't be expressed cleanly in
+/// Swift's type system — it is injected separately by `toServerDict()`.
+struct ConnectConfig: Codable {
+    var serverTimestamp: Int = 1656525980
+    var dataReportPeriod: Int = 60
+    var reportMaxTransactionCount: Int = 1000
+    var reportMaxTransactionAge: Int = 600
+    var collectNetworkErrors: Bool = true
+    var errorLimit: Int = 50
+    var responseBodyLimit: Int = 2048
+    var stackTraceLimit: Int = 100
+    var dataToken: [Int] = [111111111, 222222222]
+    var crossProcessId: String = "AAAAAAAAAAAAAAAAAAAAAA=="
+    var encodingKey: String = "0000000000000000000000000000000000000000"
+    var accountId: String = "1"
+    var applicationId: String = "1"
+    var entityGuid: String = "AAAAAAAAAAAAAAAAAAAAAA=="
+    var configuration: Configuration = .init()
+
+    struct Configuration: Codable {
+        var sessionReplay: SessionReplay = .init()
+        var logs: Logs = .init()
+
+        enum CodingKeys: String, CodingKey {
+            case sessionReplay = "session_replay"
+            case logs
+        }
+    }
+
+    struct SessionReplay: Codable {
+        var enabled: Bool = true
+        var samplingRate: Double = 100.0
+        var errorSamplingRate: Double = 100.0
+        var mode: String = "custom"
+        var maskApplicationText: Bool = false
+        var maskUserInputText: Bool = false
+        var maskAllImages: Bool = false
+        var maskAllUserTouches: Bool = false
+        var customMaskingRules: [MaskingRule] = [
+            .init(identifier: "tag",   type: "mask",   name: ["sensitiveField"]),
+            .init(identifier: "class", type: "mask",   name: ["UITextField"]),
+            .init(identifier: "class", type: "unmask", name: ["NRUnmaskedLabel"]),
+        ]
+
+        enum CodingKeys: String, CodingKey {
+            case enabled, mode
+            case samplingRate = "sampling_rate"
+            case errorSamplingRate = "error_sampling_rate"
+            case maskApplicationText = "mask_application_text"
+            case maskUserInputText = "mask_user_input_text"
+            case maskAllImages = "mask_all_images"
+            case maskAllUserTouches = "mask_all_user_touches"
+            case customMaskingRules = "custom_masking_rules"
+        }
+    }
+
+    struct Logs: Codable {
+        var enabled: Bool = true
+        var level: String = "DEBUG"
+        var samplingRate: Double = 100.0
+
+        enum CodingKeys: String, CodingKey {
+            case enabled, level
+            case samplingRate = "sampling_rate"
+        }
+    }
+
+    struct MaskingRule: Codable {
+        var identifier: String
+        var type: String
+        var name: [String]
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case serverTimestamp = "server_timestamp"
+        case dataReportPeriod = "data_report_period"
+        case reportMaxTransactionCount = "report_max_transaction_count"
+        case reportMaxTransactionAge = "report_max_transaction_age"
+        case collectNetworkErrors = "collect_network_errors"
+        case errorLimit = "error_limit"
+        case responseBodyLimit = "response_body_limit"
+        case stackTraceLimit = "stack_trace_limit"
+        case dataToken = "data_token"
+        case crossProcessId = "cross_process_id"
+        case encodingKey = "encoding_key"
+        case accountId = "account_id"
+        case applicationId = "application_id"
+        case entityGuid = "entity_guid"
+        case configuration
+    }
+}
+
+// MARK: - Helpers
+
+extension ConnectConfig {
+    static let `default` = ConnectConfig()
+
+    /// Returns a [String: Any] dict ready to hand to HttpServer as the connect response body.
+    /// Injects `at_capture` ([1, []]) which can't be round-tripped through Codable cleanly.
+    func toServerDict() -> [String: Any] {
+        let enc = JSONEncoder()
+        guard let data = try? enc.encode(self),
+              var dict = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            return [:]
+        }
+        dict["at_capture"] = [1, []] as [Any]
+        return dict
+    }
+}

--- a/Test Harness/NRTestApp/NRTestApp/CaptureServer/NRCaptureServer.swift
+++ b/Test Harness/NRTestApp/NRTestApp/CaptureServer/NRCaptureServer.swift
@@ -1,71 +1,165 @@
 import Foundation
 
+// MARK: - ResponseOverride
+
+struct ResponseOverride: Equatable, Hashable {
+    let statusCode: Int
+    let headers: [String: String]
+
+    static let presets: [ResponseOverride] = [
+        .init(statusCode: 429, headers: [:]),
+        .init(statusCode: 429, headers: ["Retry-After": "30"]),
+        .init(statusCode: 500, headers: [:]),
+        .init(statusCode: 502, headers: [:]),
+        .init(statusCode: 503, headers: [:]),
+        .init(statusCode: 504, headers: [:]),
+    ]
+
+    var label: String {
+        switch statusCode {
+        case 409: return "409 Config Update"
+        case 429: return headers["Retry-After"].map { "429 – Retry-After: \($0)s" } ?? "429 Too Many Requests"
+        case 500: return "500 Internal Server Error"
+        case 502: return "502 Bad Gateway"
+        case 503: return "503 Service Unavailable"
+        case 504: return "504 Gateway Timeout"
+        default:  return "\(statusCode) \(HTTPURLResponse.localizedString(forStatusCode: statusCode).capitalized)"
+        }
+    }
+
+    func httpResponse() -> HttpResponse {
+        let phrase: String
+        switch statusCode {
+        case 409: phrase = "Conflict"
+        case 429: phrase = "Too Many Requests"
+        case 500: phrase = "Internal Server Error"
+        case 502: phrase = "Bad Gateway"
+        case 503: phrase = "Service Unavailable"
+        case 504: phrase = "Gateway Timeout"
+        default:  phrase = HTTPURLResponse.localizedString(forStatusCode: statusCode)
+        }
+        return .raw(statusCode, phrase, headers.isEmpty ? nil : headers, nil)
+    }
+}
+
+// MARK: - StatusInjection
+
+struct StatusInjection {
+    enum Endpoint: String, CaseIterable, Identifiable {
+        case all     = "All"
+        case connect = "/connect"
+        case data    = "/data"
+        case f       = "/mobile/f"
+        case blobs   = "/mobile/blobs"
+        case logs    = "/mobile/logs"
+        case errors  = "/mobile/errors"
+
+        var id: String { rawValue }
+
+        func matches(_ requestEndpoint: String) -> Bool {
+            switch self {
+            case .all:     return true
+            case .connect: return requestEndpoint.hasSuffix("/connect")
+            case .data:    return requestEndpoint.hasSuffix("/data")
+            default:       return requestEndpoint == rawValue
+            }
+        }
+    }
+
+    var override: ResponseOverride
+    var endpoint: Endpoint
+    var remaining: Int   // ignored when unlimited == true
+    var unlimited: Bool
+
+    var statusCode: Int { override.statusCode }
+
+    func matches(_ requestEndpoint: String) -> Bool {
+        endpoint.matches(requestEndpoint)
+    }
+
+    var label: String {
+        let count = unlimited ? "∞" : "×\(remaining)"
+        return "\(override.label)  \(count)  \(endpoint.rawValue)"
+    }
+}
+
+// MARK: -
+
 final class NRCaptureServer: ObservableObject {
     static let shared = NRCaptureServer()
     static let port: UInt16 = 8080
 
     @Published var captures: [CapturedRequest] = []
+    @Published var injection: StatusInjection? = nil
+    /// True when the connect response config differs from the default.
+    @Published var connectConfigMutated: Bool = false
+
+    /// Applies `config` as the connect response and queues a 409 on /data so the agent
+    /// reconnects and picks up the new settings on its next harvest cycle.
+    func setConnectConfig(_ config: ConnectConfig) {
+        connectConfig = config
+        connectConfigMutated = true
+        armConfigUpdate409()
+    }
+
+    /// Resets the connect response config to defaults and queues a 409 on /data so the
+    /// agent reconnects and picks up the default settings.
+    func resetConnectConfig() {
+        connectConfig = .default
+        connectConfigMutated = false
+        armConfigUpdate409()
+    }
+
+    private func armConfigUpdate409() {
+        injection = StatusInjection(
+            override: .init(statusCode: 409, headers: [:]),
+            endpoint: .data,
+            remaining: 1,
+            unlimited: false
+        )
+    }
+
+    /// Atomically consumes one shot of the active injection if it matches `endpoint`.
+    /// Returns the HttpResponse to send, or nil if no injection applies.
+    /// Safe to call from any background thread.
+    func consumeInjection(for endpoint: String) -> HttpResponse? {
+        var response: HttpResponse? = nil
+        DispatchQueue.main.sync {
+            guard var inj = injection, inj.matches(endpoint) else { return }
+            response = inj.override.httpResponse()
+            guard !inj.unlimited else { return }
+            inj.remaining -= 1
+            injection = inj.remaining > 0 ? inj : nil
+        }
+        return response
+    }
 
     private let server = HttpServer()
+    @Published private(set) var connectConfig: ConnectConfig = .default
 
     private init() {}
 
     func start() {
-        let connectResponse: [String: Any] = [
-            "server_timestamp": 1656525980,
-            "data_report_period": 60,
-            "report_max_transaction_count": 1000,
-            "report_max_transaction_age": 600,
-            "collect_network_errors": true,
-            "error_limit": 50,
-            "response_body_limit": 2048,
-            "stack_trace_limit": 100,
-            "at_capture": [1, []],
-            "data_token": [111111111, 222222222],
-            "cross_process_id": "AAAAAAAAAAAAAAAAAAAAAA==",
-            "encoding_key": "0000000000000000000000000000000000000000",
-            "account_id": "1",
-            "application_id": "1",
-            // Required by SessionReplayReporter.uploadURL() to build a non-empty entityGuid attribute.
-            "entity_guid": "AAAAAAAAAAAAAAAAAAAAAA==",
-            "configuration": [
-                // Enable session replay at 100% sample rate so it records unconditionally in capture mode.
-                "session_replay": [
-                    "enabled": true,
-                    "sampling_rate": 100.0,
-                    "error_sampling_rate": 100.0,
-                    // "default" masks text and images; "custom" uses the explicit flags below.
-                    "mode": "custom",
-                    "mask_application_text": false,
-                    "mask_user_input_text": false,
-                    "mask_all_images": false,
-                    "mask_all_user_touches": false,
-                    // Each rule: identifier ("tag" | "class"), type ("mask" | "unmask"),
-                    // name is an NSArray — pass as a JSON array even for a single value.
-                    "custom_masking_rules": [
-                        ["identifier": "tag",   "type": "mask",   "name": ["sensitiveField"]],
-                        ["identifier": "class", "type": "mask",   "name": ["UITextField"]],
-                        ["identifier": "class", "type": "unmask", "name": ["NRUnmaskedLabel"]]
-                    ]
-                ],
-                // Enable log reporting so /mobile/logs uploads are captured.
-                "logs": [
-                    "enabled": true,
-                    "level": "DEBUG",
-                    "sampling_rate": 100.0
-                ]
-            ]
-        ]
+        // connectConfig is a typed ConnectConfig stored property.
+        // The connect handler snapshots it, optionally replaces it, then serves.
 
         server.POST["/mobile/:version/connect"] = { [weak self] request in
             let ep = "/mobile/\(request.params[":version"] ?? "v?")/connect"
-            self?.capture(request, endpoint: ep)
-            return .ok(.json(connectResponse as AnyObject))
+            // Snapshot the live config before checking for an injection so the config
+            // set via setConnectConfig() is always what a successful connect returns.
+            var configSnapshot: ConnectConfig = .default
+            DispatchQueue.main.sync { configSnapshot = self?.connectConfig ?? .default }
+            let injected = self?.consumeInjection(for: ep)
+            // Store the served config only for successful (non-injected) connects.
+            self?.capture(request, endpoint: ep,
+                          serverResponse: injected == nil ? configSnapshot : nil)
+            return injected ?? .ok(.json(configSnapshot.toServerDict() as AnyObject))
         }
 
         server.POST["/mobile/:version/data"] = { [weak self] request in
             let ep = "/mobile/\(request.params[":version"] ?? "v?")/data"
             self?.capture(request, endpoint: ep)
+            if let injected = self?.consumeInjection(for: ep) { return injected }
             return .ok(.json([:] as AnyObject))
         }
 
@@ -76,6 +170,7 @@ final class NRCaptureServer: ObservableObject {
             let ep = path
             server.POST[path] = { [weak self] request in
                 self?.capture(request, endpoint: ep)
+                if let injected = self?.consumeInjection(for: ep) { return injected }
                 return .ok(.json([:] as AnyObject))
             }
         }
@@ -84,6 +179,7 @@ final class NRCaptureServer: ObservableObject {
         server.POST["/:path"] = { [weak self] request in
             let ep = "/\(request.params[":path"] ?? "unknown")"
             self?.capture(request, endpoint: ep)
+            if let injected = self?.consumeInjection(for: ep) { return injected }
             return .ok(.json([:] as AnyObject))
         }
 
@@ -123,6 +219,11 @@ final class NRCaptureServer: ObservableObject {
             var duplicateOf: [UUID: Date] = [:]             // timestamp of the original upload
 
             for capture in snapshot.reversed() {
+                // Connect payloads are structurally identical across sessions — skip duplicate detection.
+                guard !capture.endpoint.hasSuffix("/connect") else {
+                    isDuplicate[capture.id] = false
+                    continue
+                }
                 let key = capture.endpoint
                 if seenBodies[key, default: []].contains(capture.decodedBody) {
                     isDuplicate[capture.id] = true
@@ -134,9 +235,21 @@ final class NRCaptureServer: ObservableObject {
                 }
             }
 
+            // Compute the effective ConnectConfig at each capture's moment (chronological walk).
+            // Used to verify the agent respects configuration settings (e.g. session_replay.enabled).
+            var configAtCapture: [UUID: ConnectConfig] = [:]
+            var runningConfig: ConnectConfig? = nil
+            for capture in snapshot.reversed() {
+                if let resp = capture.serverConnectResponse {
+                    runningConfig = resp
+                }
+                configAtCapture[capture.id] = runningConfig
+            }
+
             let updated = snapshot.map { capture -> CapturedRequest in
                 var c = capture
                 let payloadChecks = verify(data: capture.decodedBody, endpoint: capture.endpoint, queryParams: capture.queryParams, headers: capture.headers)?.checks ?? []
+                let configChecks  = self.configBehaviorChecks(capture: capture, config: configAtCapture[capture.id])
                 let detail: String?
                 if isDuplicate[capture.id] == true {
                     if let original = duplicateOf[capture.id] {
@@ -154,7 +267,7 @@ final class NRCaptureServer: ObservableObject {
                     passed: isDuplicate[capture.id] == false,
                     detail: detail
                 )
-                c.verification = VerificationResult(checks: payloadChecks + [dupCheck])
+                c.verification = VerificationResult(checks: payloadChecks + configChecks + [dupCheck])
                 return c
             }
 
@@ -177,7 +290,32 @@ final class NRCaptureServer: ObservableObject {
 
     // MARK: - Private
 
-    private func capture(_ request: HttpRequest, endpoint: String) {
+    /// Checks that the agent respected the active ConnectConfig when it made this upload.
+    /// Returns a failing check if a feature was disabled in the config but the agent uploaded anyway.
+    private func configBehaviorChecks(capture: CapturedRequest, config: ConnectConfig?) -> [VerificationCheck] {
+        guard let config else { return [] }
+        let sr   = config.configuration.sessionReplay
+        let logs = config.configuration.logs
+        var checks: [VerificationCheck] = []
+
+        if capture.endpoint == "/mobile/blobs" && !sr.enabled {
+            checks.append(VerificationCheck(
+                name: "config: session_replay.enabled=false — unexpected SR upload",
+                passed: false,
+                detail: "Agent uploaded session replay after connect config disabled it"
+            ))
+        }
+        if capture.endpoint == "/mobile/logs" && !logs.enabled {
+            checks.append(VerificationCheck(
+                name: "config: logs.enabled=false — unexpected log upload",
+                passed: false,
+                detail: "Agent uploaded logs after connect config disabled them"
+            ))
+        }
+        return checks
+    }
+
+    private func capture(_ request: HttpRequest, endpoint: String, serverResponse: ConnectConfig? = nil) {
         let bodyData = Data(request.body)
         let isGzip = request.headers["content-encoding"] == "gzip"
         let decoded = isGzip ? bodyData.gunzipped() ?? bodyData : bodyData
@@ -191,7 +329,7 @@ final class NRCaptureServer: ObservableObject {
             prettyJSON = String(data: decoded, encoding: .utf8) ?? "(binary data, \(decoded.count) bytes)"
         }
 
-        let captured = CapturedRequest(
+        var captured = CapturedRequest(
             timestamp: Date(),
             endpoint: endpoint,
             headers: request.headers,
@@ -199,6 +337,7 @@ final class NRCaptureServer: ObservableObject {
             decodedBody: decoded,
             prettyJSON: prettyJSON
         )
+        captured.serverConnectResponse = serverResponse
 
         DispatchQueue.main.async { [weak self] in
             self?.captures.insert(captured, at: 0)

--- a/Test Harness/NRTestApp/NRTestApp/CaptureServer/PayloadVerifiers.swift
+++ b/Test Harness/NRTestApp/NRTestApp/CaptureServer/PayloadVerifiers.swift
@@ -24,25 +24,37 @@ private func h(_ headers: [String: String], _ name: String) -> String? {
     headers[name.lowercased()]
 }
 
+/// Returns a detail string for the first event in `items` that fails `test`, or nil when all pass.
+/// Reports the event's `eventType` and the raw value of `key` so a failing check points at
+/// the specific item rather than just collapsing to false.
+private func firstFailing(_ items: [[String: Any]], key: String, test: (Any?) -> Bool) -> String? {
+    guard let bad = items.first(where: { !test($0[key]) }) else { return nil }
+    let evt = (bad["eventType"] as? String) ?? "unknown"
+    if let val = bad[key] { return "\(key)=\(val) in \(evt)" }
+    return "\(key) missing in \(evt)"
+}
+
 // Session attributes required by both data.md and jserror_data.md.
 // Returns checks against a flat [String: Any] dict (data harvest) or
 // [String: String] dict (session replay URL attributes, JS error events).
 private func sessionAttributeChecks(from attrs: [String: Any]) -> [VerificationCheck] {
     func str(_ key: String) -> String? { attrs[key] as? String }
     // memUsageMb arrives as NSNumber in JSON dicts and as a numeric string in URL attribute dicts.
-    func numericPresent(_ key: String) -> Bool {
-        if attrs[key] is NSNumber { return true }
-        return (attrs[key] as? String).flatMap(Double.init) != nil
+    // The field may be absent (e.g. memory info unavailable) — only fail if present but non-numeric.
+    func numericIfPresent(_ key: String) -> Bool {
+        guard let val = attrs[key] else { return true }
+        if val is NSNumber { return true }
+        return (val as? String).flatMap(Double.init) != nil
     }
     return [
         check("sessionAttrs: sessionId non-empty",          str("sessionId")?.isEmpty         == false, detail: str("sessionId")),
         check("sessionAttrs: osName non-empty",             str("osName")?.isEmpty             == false, detail: str("osName")),
         check("sessionAttrs: osVersion non-empty",          str("osVersion")?.isEmpty          == false, detail: str("osVersion")),
-        check("sessionAttrs: osMajorVersion non-empty",     str("osMajorVersion")?.isEmpty     == false),
-        check("sessionAttrs: deviceManufacturer non-empty", str("deviceManufacturer")?.isEmpty == false),
-        check("sessionAttrs: deviceModel non-empty",        str("deviceModel")?.isEmpty        == false),
+        check("sessionAttrs: osMajorVersion non-empty",     str("osMajorVersion")?.isEmpty     == false, detail: str("osMajorVersion")),
+        check("sessionAttrs: deviceManufacturer non-empty", str("deviceManufacturer")?.isEmpty == false, detail: str("deviceManufacturer")),
+        check("sessionAttrs: deviceModel non-empty",        str("deviceModel")?.isEmpty        == false, detail: str("deviceModel")),
         check("sessionAttrs: newRelicVersion non-empty",    str("newRelicVersion")?.isEmpty    == false, detail: str("newRelicVersion")),
-        check("sessionAttrs: memUsageMb is numeric",        numericPresent("memUsageMb"),       detail: str("memUsageMb")),
+        check("sessionAttrs: memUsageMb is numeric",        numericIfPresent("memUsageMb"),     detail: str("memUsageMb")),
         check("sessionAttrs: carrier non-empty",            str("carrier")?.isEmpty            == false, detail: str("carrier")),
     ]
 }
@@ -53,13 +65,14 @@ private func sessionAttributeChecks(from attrs: [String: Any]) -> [VerificationC
 private func analyticsEventChecks(events: [[String: Any]], httpCount: Int) -> [VerificationCheck] {
     let timestampsValid = events.allSatisfy { $0["timestamp"] is NSNumber }
 
-    let mobileRequestEvts = events.filter { $0["eventType"] as? String == "MobileRequest" }
+    let mobileRequestEvts  = events.filter { $0["eventType"] as? String == "MobileRequest" }
     let mobileErrEvts     = events.filter { $0["eventType"] as? String == "MobileRequestError" }
     let mobileActionEvts  = events.filter { $0["eventType"] as? String == "MobileAction" }
     let mobileSessionEvts = events.filter { ["Mobile", "MobileSession"].contains($0["eventType"] as? String) }
 
     var result: [VerificationCheck] = [
-        check("analyticsEvents: all have timestamp (NSNumber)", timestampsValid),
+        check("analyticsEvents: all have timestamp (NSNumber)", timestampsValid,
+              detail: firstFailing(events, key: "timestamp") { $0 is NSNumber }),
     ]
 
     // If the agent recorded HTTP transactions, there must be corresponding MobileRequest events.
@@ -73,32 +86,51 @@ private func analyticsEventChecks(events: [[String: Any]], httpCount: Int) -> [V
 
     if !mobileRequestEvts.isEmpty {
         result += [
-            check("MobileRequest: requestUrl is String",      mobileRequestEvts.allSatisfy { $0["requestUrl"]    is String }),
-            check("MobileRequest: statusCode is NSNumber",    mobileRequestEvts.allSatisfy { $0["statusCode"]    is NSNumber }),
-            check("MobileRequest: responseTime is NSNumber",  mobileRequestEvts.allSatisfy { $0["responseTime"]  is NSNumber }),
-            check("MobileRequest: bytesReceived is NSNumber", mobileRequestEvts.allSatisfy { $0["bytesReceived"] is NSNumber }),
+            check("MobileRequest: requestUrl is String",
+                  mobileRequestEvts.allSatisfy { $0["requestUrl"] is String },
+                  detail: firstFailing(mobileRequestEvts, key: "requestUrl") { $0 is String }),
+            check("MobileRequest: statusCode is NSNumber",
+                  mobileRequestEvts.allSatisfy { $0["statusCode"] is NSNumber },
+                  detail: firstFailing(mobileRequestEvts, key: "statusCode") { $0 is NSNumber }),
+            check("MobileRequest: responseTime is NSNumber",
+                  mobileRequestEvts.allSatisfy { $0["responseTime"] is NSNumber },
+                  detail: firstFailing(mobileRequestEvts, key: "responseTime") { $0 is NSNumber }),
+            check("MobileRequest: bytesReceived is NSNumber when present",
+                  mobileRequestEvts.allSatisfy { $0["bytesReceived"] == nil || $0["bytesReceived"] is NSNumber },
+                  detail: firstFailing(mobileRequestEvts, key: "bytesReceived") { $0 == nil || $0 is NSNumber }),
             check("MobileRequest: bytesSent is NSNumber when present",
-                  mobileRequestEvts.allSatisfy { $0["bytesSent"] == nil || $0["bytesSent"] is NSNumber }),
+                  mobileRequestEvts.allSatisfy { $0["bytesSent"] == nil || $0["bytesSent"] is NSNumber },
+                  detail: firstFailing(mobileRequestEvts, key: "bytesSent") { $0 == nil || $0 is NSNumber }),
         ]
     }
 
     if !mobileErrEvts.isEmpty {
         result += [
-            check("MobileRequestError: requestUrl is String",        mobileErrEvts.allSatisfy { $0["requestUrl"] is String }),
-            check("MobileRequestError: statusCode or networkError",  mobileErrEvts.allSatisfy { $0["statusCode"] is NSNumber || $0["networkError"] is String }),
+            check("MobileRequestError: requestUrl is String",
+                  mobileErrEvts.allSatisfy { $0["requestUrl"] is String },
+                  detail: firstFailing(mobileErrEvts, key: "requestUrl") { $0 is String }),
+            check("MobileRequestError: statusCode or networkError",
+                  mobileErrEvts.allSatisfy { $0["statusCode"] is NSNumber || $0["networkError"] is String },
+                  detail: firstFailing(mobileErrEvts, key: "statusCode") { $0 is NSNumber || ($0 as? String) != nil }),
         ]
     }
 
     if !mobileActionEvts.isEmpty {
         result += [
-            check("MobileAction: actionType is String", mobileActionEvts.allSatisfy { $0["actionType"] is String }),
-            check("MobileAction: name is String",       mobileActionEvts.allSatisfy { $0["name"] is String }),
+            check("MobileAction: actionType is String",
+                  mobileActionEvts.allSatisfy { $0["actionType"] is String },
+                  detail: firstFailing(mobileActionEvts, key: "actionType") { $0 is String }),
+            check("MobileAction: name is String",
+                  mobileActionEvts.allSatisfy { $0["name"] is String },
+                  detail: firstFailing(mobileActionEvts, key: "name") { $0 is String }),
         ]
     }
 
     if !mobileSessionEvts.isEmpty {
         result += [
-            check("Mobile/MobileSession: timeSinceLoad is NSNumber",   mobileSessionEvts.allSatisfy { $0["timeSinceLoad"]   is NSNumber }),
+            check("Mobile/MobileSession: timeSinceLoad is NSNumber",
+                  mobileSessionEvts.allSatisfy { $0["timeSinceLoad"] is NSNumber },
+                  detail: firstFailing(mobileSessionEvts, key: "timeSinceLoad") { $0 is NSNumber }),
         ]
     }
 
@@ -295,28 +327,38 @@ private enum JSErrorsVerifier {
 
             // Per-event required fields (jserror_data.md §MobileJSError)
             check("all events: eventType == MobileJSError",
-                  events?.allSatisfy { $0["eventType"] as? String == "MobileJSError" } == true)
+                  events?.allSatisfy { $0["eventType"] as? String == "MobileJSError" } == true,
+                  detail: events.flatMap { firstFailing($0, key: "eventType") { $0 as? String == "MobileJSError" } })
             check("all events: errorId present",
-                  events?.allSatisfy { $0["errorId"] is String } == true)
+                  events?.allSatisfy { $0["errorId"] is String } == true,
+                  detail: events.flatMap { firstFailing($0, key: "errorId") { $0 is String } })
             check("all events: errorName present",
-                  events?.allSatisfy { $0["errorName"] is String } == true)
+                  events?.allSatisfy { $0["errorName"] is String } == true,
+                  detail: events.flatMap { firstFailing($0, key: "errorName") { $0 is String } })
             check("all events: errorMessage present",
-                  events?.allSatisfy { $0["errorMessage"] is String } == true)
+                  events?.allSatisfy { $0["errorMessage"] is String } == true,
+                  detail: events.flatMap { firstFailing($0, key: "errorMessage") { $0 is String } })
 
             // Per jserror_data.md, session attributes are flattened into every event.
             // Verify each event carries the required system attributes.
             check("all events: sessionId non-empty",
-                  events?.allSatisfy { ($0["sessionId"] as? String)?.isEmpty == false } == true)
+                  events?.allSatisfy { ($0["sessionId"] as? String)?.isEmpty == false } == true,
+                  detail: events.flatMap { firstFailing($0, key: "sessionId") { ($0 as? String)?.isEmpty == false } })
             check("all events: osName non-empty",
-                  events?.allSatisfy { ($0["osName"] as? String)?.isEmpty == false } == true)
+                  events?.allSatisfy { ($0["osName"] as? String)?.isEmpty == false } == true,
+                  detail: events.flatMap { firstFailing($0, key: "osName") { ($0 as? String)?.isEmpty == false } })
             check("all events: osVersion non-empty",
-                  events?.allSatisfy { ($0["osVersion"] as? String)?.isEmpty == false } == true)
+                  events?.allSatisfy { ($0["osVersion"] as? String)?.isEmpty == false } == true,
+                  detail: events.flatMap { firstFailing($0, key: "osVersion") { ($0 as? String)?.isEmpty == false } })
             check("all events: newRelicVersion non-empty",
-                  events?.allSatisfy { ($0["newRelicVersion"] as? String)?.isEmpty == false } == true)
+                  events?.allSatisfy { ($0["newRelicVersion"] as? String)?.isEmpty == false } == true,
+                  detail: events.flatMap { firstFailing($0, key: "newRelicVersion") { ($0 as? String)?.isEmpty == false } })
             check("all events: deviceModel non-empty",
-                  events?.allSatisfy { ($0["deviceModel"] as? String)?.isEmpty == false } == true)
+                  events?.allSatisfy { ($0["deviceModel"] as? String)?.isEmpty == false } == true,
+                  detail: events.flatMap { firstFailing($0, key: "deviceModel") { ($0 as? String)?.isEmpty == false } })
             check("all events: memUsageMb is number",
-                  events?.allSatisfy { $0["memUsageMb"] is NSNumber } == true)
+                  events?.allSatisfy { $0["memUsageMb"] is NSNumber } == true,
+                  detail: events.flatMap { firstFailing($0, key: "memUsageMb") { $0 is NSNumber } })
         }
     }
 }
@@ -334,10 +376,10 @@ private enum JSErrorsVerifier {
 //   [{ "common": { "attributes": { entity.guid, sessionId, instrumentation.*, appId, … } },
 //      "logs":   [ { "level", "message", "timestamp", "file", "lineNumber", "method" }, … ] }]
 //
-// Valid levels: ERROR, WARNING, INFO, VERBOSE, AUDIT, DEBUG (NRLogger.levelToString)
+// Valid levels: ERROR, WARN, INFO, VERBOSE, AUDIT, DEBUG (NRLogger.levelToString)
 
 private enum LogsVerifier {
-    private static let validLevels: Set<String> = ["ERROR", "WARNING", "INFO", "VERBOSE", "AUDIT", "DEBUG"]
+    private static let validLevels: Set<String> = ["ERROR", "WARN", "INFO", "VERBOSE", "AUDIT", "DEBUG"]
 
     static func verify(_ data: Data, headers: [String: String]) -> VerificationResult {
         // kNRMAGZipHeader = @"deflate" — the agent uses zlib/deflate format, not gzip.
@@ -359,9 +401,10 @@ private enum LogsVerifier {
         let commonAttrs = common?["attributes"] as? [String: Any]
         let logs        = batch?["logs"] as? [[String: Any]]
 
-        let levelsValid = logs?.allSatisfy {
-            ($0["level"] as? String).map { validLevels.contains($0) } ?? false
-        } ?? true
+        let badLevelEntry = logs?.first {
+            ($0["level"] as? String).map { !validLevels.contains($0) } ?? true
+        }
+        let levelsValid = badLevelEntry == nil
         let timestampsValid = logs?.allSatisfy { $0["timestamp"] is NSNumber } ?? true
 
         return .make {
@@ -399,7 +442,11 @@ private enum LogsVerifier {
             // Per-entry checks
             check("all entries have level",             logs?.allSatisfy { $0["level"] is String } == true)
             check("all entries have valid level",       levelsValid,
-                  detail: levelsValid ? nil : "expected one of: \(validLevels.sorted().joined(separator: ", "))")
+                  detail: badLevelEntry.map { entry in
+                      let level = entry["level"] as? String ?? "(missing)"
+                      let msg   = (entry["message"] as? String ?? "").prefix(80)
+                      return "level=\"\(level)\" message=\"\(msg)\" — valid: \(validLevels.sorted().joined(separator: ", "))"
+                  })
             check("all entries have message",           logs?.allSatisfy { $0["message"] is String } == true)
             check("all entries have timestamp",         timestampsValid)
         }
@@ -533,11 +580,21 @@ private enum SessionReplayVerifier {
 //
 // The agent encodes [AnyRRWebEvent] as a JSON array: [{type, timestamp, data}, ...].
 // RRWebEventType raw values: 2=fullSnapshot, 3=incrementalSnapshot, 4=meta.
+// Incremental source values: 0=mutation, 2=mouseInteraction (touchStart/End), 6=touchMove.
 //
 // SessionReplayManager sets:
 //   firstTimestamp = container.first.timestamp
 //   lastTimestamp  = container.last.timestamp
 // so the URL attribute timestamps must exactly match the body event range.
+// Touch events (source 2 or 6) are excluded from the firstTimestamp comparison
+// because they can appear before the first frame event.
+
+private func isTouchEvent(_ event: [String: Any]) -> Bool {
+    guard event["type"] as? Int == 3,
+          let source = (event["data"] as? [String: Any])?["source"] as? Int
+    else { return false }
+    return source == 2 || source == 6
+}
 
 private func rrwebConsistencyChecks(data: Data,
                                     attrs: [String: String],
@@ -550,9 +607,11 @@ private func rrwebConsistencyChecks(data: Data,
                       detail: "body is not a JSON array — decompression may have failed")]
     }
 
-    let timestamps = events.compactMap { ($0["timestamp"] as? NSNumber)?.doubleValue }
+    let timestamps        = events.compactMap { ($0["timestamp"] as? NSNumber)?.doubleValue }
+    let nonTouchTimestamps = events.filter { !isTouchEvent($0) }
+                                   .compactMap { ($0["timestamp"] as? NSNumber)?.doubleValue }
     let types      = events.compactMap { $0["type"] as? Int }
-    let bodyFirst  = timestamps.min()
+    let bodyFirst  = nonTouchTimestamps.min()
     let bodyLast   = timestamps.max()
     let typeSet    = Array(Set(types)).sorted().map(String.init).joined(separator: ",")
 


### PR DESCRIPTION
Introduces two related capabilities to the capture test harness:

Error injection
A new "Inject" button in the captures toolbar arms the server to return a chosen HTTP error code (429, 5xx) for a specific endpoint and a configurable number of times. While an injection is active the button shows the armed code as a pill badge. The inject sheet supports one-shot, repeat-N, and unlimited modes, with a Disarm option to cancel early.

Connect config editing
The connect response is now modeled as a typed ConnectConfig struct (Codable, replaces the hardcoded [String: Any] dict). A new button in the captures toolbar opens a dedicated config sheet where session replay settings (enabled, sampling rates, mode, mask toggles, custom masking rules) and log settings (enabled, level, sampling rate) can be edited with standard form controls. Changes apply immediately to the live server. Saving automatically arms a single 409 on /data so the agent reconnects and picks up the new settings — this is the only path that reliably triggers a reconnect, since a 409 on /connect is silently ignored by the harvester's state machine.

Behavioral verification
verifyAll() now tracks the effective ConnectConfig at each capture's timestamp and adds a failing check to any upload that shouldn't have happened given that config — e.g. a /mobile/blobs upload after session_replay.enabled=false, or a /mobile/logs upload after logs.enabled=false. These checks appear inline on the offending captures in the detail view.