### PR TITLE
NR-323614 added a check to not allow arrays or dictionaries to the new event system

### DIFF
--- a/Agent/Analytics/AttributeValidator/NRMAAttributeValidator.m
+++ b/Agent/Analytics/AttributeValidator/NRMAAttributeValidator.m
@@ -55,6 +55,11 @@
         return false;
     }
 
+    if ([value isKindOfClass:[NSArray class]] || [value isKindOfClass:[NSDictionary class]]) {
+        NRLOG_AGENT_ERROR(@"invalid attribute: value cannot be an NSArray or NSDictionary");
+        return false;
+    }
+
     if ([value isKindOfClass:[NSString class]]) {
         if ([(NSString*)value length] == 0) {
             NRLOG_AGENT_ERROR(@"invalid attribute: value length = 0");

--- a/Test Harness/NRTestApp/NRTestApp/ViewModels/UtilViewModel.swift
+++ b/Test Harness/NRTestApp/NRTestApp/ViewModels/UtilViewModel.swift
@@ -59,6 +59,10 @@ class UtilViewModel {
         options.append(UtilOption(title: "End Interaction Trace", handler: { [self] in stopInteractionTrace()}))
         options.append(UtilOption(title: "Notice Network Request", handler: { [self] in noticeNWRequest()}))
         options.append(UtilOption(title: "Notice Network Failure", handler: { [self] in noticeFailedNWRequest()}))
+        
+        // NR-323614 — NSArray/NSDictionary values must be rejected as attribute values.
+        options.append(UtilOption(title: "Try Collection Session Attributes", handler: { [self] in setCollectionSessionAttributes()}))
+        options.append(UtilOption(title: "Try Collection Event Attributes", handler: { [self] in setCollectionEventAttributes()}))
 
         options.append(UtilOption(title: "Test System Logs", handler: { [self] in testSystemLogs()}))
         options.append(UtilOption(title: "Notice Network Request w headers/params", handler: { [self] in 
@@ -345,6 +349,51 @@ class UtilViewModel {
 
     func shutDown() {
         NewRelic.shutdown()
+    }
+    
+    private var collectionAttributeValues: [(label: String, value: Any)] {
+        let nsArray: NSArray = NSArray(array: ["one", "two"])
+        let nsMutableArray = NSMutableArray(array: ["one", "two"])
+        let nsDictionary: NSDictionary = NSDictionary(dictionary: ["key": "value"])
+        let nsMutableDictionary = NSMutableDictionary(dictionary: ["key": "value"])
+
+        return [
+            ("NSArray", nsArray),
+            ("NSMutableArray", nsMutableArray),
+            ("NSDictionary", nsDictionary),
+            ("NSMutableDictionary", nsMutableDictionary),
+            ("SwiftArray_bridgedToNSArray", ["one", "two"]),
+            ("SwiftDictionary_bridgedToNSDictionary", ["key": "value"]),
+        ]
+    }
+
+    func setCollectionSessionAttributes() {
+        for sample in collectionAttributeValues {
+            let name = "collectionUserAttr_\(sample.label)"
+            _ = NewRelic.setAttribute(name, value: sample.value)
+        }
+
+        // Control case: a valid value must still be accepted after the rejected ones.
+        _ = NewRelic.setAttribute("collectionUserAttr_validString", value: "good attribute")
+    }
+
+    func setCollectionEventAttributes() {
+        for sample in collectionAttributeValues {
+            let eventAttributes: [String: Any] = [
+                "collectionSessionAttr": sample.value,
+                "validSessionAttr": "good attribute"
+            ]
+
+            _ = NewRelic.recordCustomEvent("CollectionAttributeTest",
+                                                            attributes: eventAttributes)
+            _ = NewRelic.recordBreadcrumb("CollectionAttributeTest",
+                                                                attributes: eventAttributes)
+            do {
+                try errorMethod()
+            } catch {
+                NewRelic.recordError(error, attributes: eventAttributes)
+            }
+        }
     }
 }
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
@@ -422,13 +422,15 @@
 
 - (void)testSetSessionAttributeWithArrayFails {
     NRMASAM *sam = [self samWithProductionValidator];
-    XCTAssertFalse([sam setSessionAttribute:@"arrayAttr" value:@[@"one", @"two"]],
+    NSArray *arrayValue = @[@"one", @"two"];
+    XCTAssertFalse([sam setSessionAttribute:@"arrayAttr" value:arrayValue],
                    @"Should reject NSArray as a session attribute value");
 }
 
 - (void)testSetSessionAttributeWithDictionaryFails {
     NRMASAM *sam = [self samWithProductionValidator];
-    XCTAssertFalse([sam setSessionAttribute:@"dictAttr" value:@{@"key": @"value"}],
+    NSDictionary *dictValue = @{@"key": @"value"};
+    XCTAssertFalse([sam setSessionAttribute:@"dictAttr" value:dictValue],
                    @"Should reject NSDictionary as a session attribute value");
 }
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
@@ -13,6 +13,7 @@
 #import "NRMAAnalytics.h"
 #import "Constants.h"
 #import "NRMABool.h"
+#import "NRMAAttributeValidator.h"
 
 @interface NRMASAMTest : XCTestCase
 {
@@ -413,6 +414,22 @@
     // valid attrib was added
     XCTAssertEqual(decode.count, 1);
 
+}
+
+- (NRMASAM *)samWithProductionValidator {
+    return [[NRMASAM alloc] initWithAttributeValidator:[[NRMAAttributeValidator alloc] init]];
+}
+
+- (void)testSetSessionAttributeWithArrayFails {
+    NRMASAM *sam = [self samWithProductionValidator];
+    XCTAssertFalse([sam setSessionAttribute:@"arrayAttr" value:@[@"one", @"two"]],
+                   @"Should reject NSArray as a session attribute value");
+}
+
+- (void)testSetSessionAttributeWithDictionaryFails {
+    NRMASAM *sam = [self samWithProductionValidator];
+    XCTAssertFalse([sam setSessionAttribute:@"dictAttr" value:@{@"key": @"value"}],
+                   @"Should reject NSDictionary as a session attribute value");
 }
 
 - (void)testIncrementIntegerValueWithDouble {

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/TestCustomEvents.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/TestCustomEvents.m
@@ -10,6 +10,7 @@
 
 #import "NRMACustomEvent.h"
 #import "BlockAttributeValidator.h"
+#import "NRMAAttributeValidator.h"
 
 @interface TestCustomEvents : XCTestCase
 
@@ -203,10 +204,10 @@
     NSTimeInterval timestamp = 10;
     unsigned long long elapsedTime = 50;
     NSString *eventType = @"New Event";
-    
+
     NSString *attributeName = @"String Attribute";
     NSString *stringAttributeValue = @"Go Pack Go";
-    
+
     BlockAttributeValidator *badNameValidator = [[BlockAttributeValidator alloc] initWithNameValidator:^BOOL(NSString *) {
         return YES;
     } valueValidator:^BOOL(id) {
@@ -214,15 +215,15 @@
     } andEventTypeValidator:^BOOL(NSString *) {
         return YES;
     }];
-    
-    
+
+
     // When
     NRMACustomEvent *sut = [[NRMACustomEvent alloc] initWithEventType:eventType
                                                             timestamp:timestamp
                                           sessionElapsedTimeInSeconds:elapsedTime
                                                withAttributeValidator:badNameValidator];
     [sut addAttribute:attributeName value:stringAttributeValue];
-    
+
     // Then
     NSDictionary *event = [sut JSONObject];
     XCTAssertEqual([event[@"timestamp"] doubleValue], timestamp);
@@ -230,6 +231,36 @@
     XCTAssertEqual(event[@"eventType"], @"New Event");
 //    XCTAssertTrue([event[attributeName] isEqualToString:stringAttributeValue]);
     XCTAssertNil(event[attributeName]);
+}
+
+- (void)testAddArrayAttributePreventsAdding {
+    // Given
+    NRMAAttributeValidator *realValidator = [[NRMAAttributeValidator alloc] init];
+    NRMACustomEvent *sut = [[NRMACustomEvent alloc] initWithEventType:@"TestEvent"
+                                                           timestamp:10
+                                         sessionElapsedTimeInSeconds:50
+                                              withAttributeValidator:realValidator];
+    // When
+    BOOL result = [sut addAttribute:@"arrayAttr" value:@[@"one", @"two"]];
+
+    // Then
+    XCTAssertFalse(result, @"Should reject NSArray as an event attribute value");
+    XCTAssertNil([sut JSONObject][@"arrayAttr"]);
+}
+
+- (void)testAddDictionaryAttributePreventsAdding {
+    // Given
+    NRMAAttributeValidator *realValidator = [[NRMAAttributeValidator alloc] init];
+    NRMACustomEvent *sut = [[NRMACustomEvent alloc] initWithEventType:@"TestEvent"
+                                                           timestamp:10
+                                         sessionElapsedTimeInSeconds:50
+                                              withAttributeValidator:realValidator];
+    // When
+    BOOL result = [sut addAttribute:@"dictAttr" value:@{@"key": @"value"}];
+
+    // Then
+    XCTAssertFalse(result, @"Should reject NSDictionary as an event attribute value");
+    XCTAssertNil([sut JSONObject][@"dictAttr"]);
 }
 
 @end


### PR DESCRIPTION
The legacy C++ event system enforced this restriction structurally: setSessionAttribute:value: and the event:withAttributes: bridge method used an explicit if/else if type-dispatch that only had branches for NSNumber, NSString, and NRMABool. Arrays and dictionaries fell to the final else, logged an error, and returned NO — the restriction came for free from the bridge's inability to translate those types to C++ primitives or const char*.

The new event system delegates validation to NRMAAttributeValidator, which previously caught arrays and dictionaries only incidentally — they fell through the NSString check and hit the generic else if (![value isKindOfClass:[NSNumber class]] && ...) catch-all. This worked correctly but gave a misleading error message ("value must be an NSString, NSNumber, or BOOL") with no explicit mention of what type was actually passed.

This PR adds an explicit early-exit check for NSArray and NSDictionary in NRMAAttributeValidator.valueValidator: with a targeted error message, and adds unit tests in NRMASAMTest (session attributes) and TestCustomEvents (event attributes) that use the production NRMAAttributeValidator to confirm both types are rejected.