### PR TITLE
Fall back to a default activity trace cap when /connect omits at_capture

### DIFF
--- a/Agent/ActivityTracing/NRMATraceController.m
+++ b/Agent/ActivityTracing/NRMATraceController.m
@@ -634,26 +634,18 @@ static NSString *__measurementLock = @"measurementTransmittersLock";
     return [self traceMachine] != nil;
 }
 
+// Forwarders. The trace-collection gate lives in NRMAHarvestController, which owns the harvest
+// buffer and the at_capture configuration it compares against; these duplicated the logic and had no
+// callers. Kept as thin forwarders rather than deleted outright because the declaration is in the
+// header and may be linked against out of tree.
 + (BOOL) shouldCollectTraces
 {
-    NRMAHarvestController* controller = [NRMAHarvestController harvestController];
-    NRMAHarvester* harvester = [controller harvester];
-    NRMAHarvestData* harvestData = [harvester harvestData];
-    NRMAHarvesterConfiguration *configuration = [NRMAHarvestController configuration];
-
-    if (harvestData == nil || configuration == nil)
-        return YES;
-
-    // todo: use fine grained AT capture rules later.
-    int currentCount = harvestData.activityTraces.count;
-    int maxCount = configuration.at_capture.maxTotalTraceCount;
-    NRLOG_AGENT_VERBOSE(@"Should collect traces: %d/%d", currentCount, maxCount);
-    return harvestData.activityTraces.count < configuration.at_capture.maxTotalTraceCount;
+    return [NRMAHarvestController shouldCollectTraces];
 }
 
 + (BOOL) shouldNotCollectTraces
 {
-    return ![self shouldCollectTraces];
+    return [NRMAHarvestController shouldNotCollectTraces];
 }
 
 @end

--- a/Agent/Harvester/DataStore/NRMAHarvesterConfiguration.m
+++ b/Agent/Harvester/DataStore/NRMAHarvesterConfiguration.m
@@ -92,8 +92,27 @@ static long long _accountId;
             self.activity_trace_max_size = NRMA_DEFAULT_ACTIVITY_TRACE_MAX_SIZE;
         }
 
-        self.at_capture = [[NRMATraceConfigurations alloc] initWithArray:[dict valueForKey:kNRMA_AT_CAPTURE]];
-        self.activity_trace_min_utilization = [[dict valueForKey:KNRMA_AT_MIN_UTILIZATION] doubleValue];
+        // Both of these used to be unguarded, unlike every other key in this initializer, and both
+        // failed in a way that was invisible at runtime:
+        //
+        //   at_capture absent  -> maxTotalTraceCount 0 -> the collection gate (count < max) is false
+        //                         for every trace, so *all* activity traces were dropped for the
+        //                         whole session.
+        //   min_utilization absent -> [nil doubleValue] == 0.0, a floor nothing can fall below, so
+        //                         the utilization filter was effectively disabled.
+        if ([dict objectForKey:kNRMA_AT_CAPTURE]) {
+            self.at_capture = [[NRMATraceConfigurations alloc] initWithArray:[dict valueForKey:kNRMA_AT_CAPTURE]];
+        }
+        else {
+            self.at_capture = [NRMATraceConfigurations defaultTraceConfigurations];
+        }
+
+        if ([dict objectForKey:KNRMA_AT_MIN_UTILIZATION]) {
+            self.activity_trace_min_utilization = [[dict valueForKey:KNRMA_AT_MIN_UTILIZATION] doubleValue];
+        }
+        else {
+            self.activity_trace_min_utilization = NRMA_DEFAULT_ACTIVITY_TRACE_MIN_UTILIZATION;
+        }
         if ([dict objectForKey:kNRMA_ENCODING_KEY]) {
             self.encoding_key = [dict valueForKey:kNRMA_ENCODING_KEY];
         }
@@ -399,7 +418,11 @@ static long long _accountId;
     dictionary[kNRMA_AT_MAX_SIZE] = @(self.activity_trace_max_size);
     dictionary[kNRMA_AT_MAX_SEND_ATTEMPTS] = @(self.activity_trace_max_send_attempts);
     dictionary[KNRMA_AT_MIN_UTILIZATION] = @(self.activity_trace_min_utilization);
-    dictionary[kNRMA_AT_CAPTURE] = @[[NSNumber numberWithInt:self.at_capture.maxTotalTraceCount], self.at_capture.activityTraceConfigurations?:@[]];
+    // -asArray, not the raw activityTraceConfigurations: that array holds NRMATraceConfiguration
+    // objects, which are neither plist-serializable (this dictionary is written to NSUserDefaults)
+    // nor readable by -initWithArray:, which expects [namePattern, count] arrays and would send
+    // -objectAtIndex: to each object on restore.
+    dictionary[kNRMA_AT_CAPTURE] = [self.at_capture asArray];
     dictionary[kNMRA_APPLICATION_ID] = @(self.application_id);
     dictionary[kNRMA_ACCOUNT_ID] = @(self.account_id);
 

--- a/Agent/Harvester/DataStore/NRMATraceConfigurations.h
+++ b/Agent/Harvester/DataStore/NRMATraceConfigurations.h
@@ -8,11 +8,28 @@
 
 #import <Foundation/Foundation.h>
 
+/// Activity traces retained per in-flight harvest when the collector does not say otherwise.
+///
+/// Must never be 0: the collection gate is `count < maxTotalTraceCount`
+/// (`+[NRMAHarvestController shouldCollectTraces]`), so a cap of 0 is false for every trace and
+/// silently drops all activity traces for the whole session.
+#define NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT 1000
+
 @interface NRMATraceConfigurations : NSObject
 @property(nonatomic,assign) int maxTotalTraceCount;
 @property (atomic, strong) NSMutableArray *activityTraceConfigurations;
 
+/// Parses the collector's `at_capture` value: a 2-element array of
+/// `[maxTotalTraceCount, [[namePattern, totalTraceCount], ...]]`.
+///
+/// `maxTotalTraceCount` defaults to NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT when `array` is nil or is not
+/// in that shape, so a missing or reshaped `at_capture` degrades to the default cap rather than to 0.
 - (id) initWithArray:(NSArray*)array;
 + (id) defaultTraceConfigurations;
+
+/// Inverse of -initWithArray:, for persisting to NSUserDefaults. Emits plain arrays (not
+/// NRMATraceConfiguration objects) so the value is plist-serializable and round-trips back through
+/// -initWithArray:.
+- (NSArray*) asArray;
 
 @end

--- a/Agent/Harvester/DataStore/NRMATraceConfigurations.m
+++ b/Agent/Harvester/DataStore/NRMATraceConfigurations.m
@@ -8,6 +8,7 @@
 
 #import "NRMATraceConfigurations.h"
 #import "NRMATraceConfiguration.h"
+#import "NRLogger.h"
 
 @implementation NRMATraceConfigurations
 
@@ -15,30 +16,71 @@
 {
     self = [super init];
     if (self) {
-        if (array != nil && array.count == 2) {
-            self.maxTotalTraceCount = [[array objectAtIndex:0] intValue];
-            NSArray *configurations = [array objectAtIndex:1];
+        // Seed the default *before* parsing. Leaving this at 0 when at_capture is absent or
+        // reshaped makes the collection gate (count < maxTotalTraceCount) false for every trace,
+        // which drops all activity traces for the entire session and logs "Maximum number of
+        // Activity Traces collected. Skipping" for each one.
+        self.maxTotalTraceCount = NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT;
 
-            self.activityTraceConfigurations = [[NSMutableArray alloc] initWithCapacity:configurations.count];
+        if (array == nil) {
+            return self;
+        }
 
-            for (int configurationIndex = 0; configurationIndex < configurations.count; configurationIndex++) {
-                NSArray* configArray = [configurations objectAtIndex:configurationIndex];
-                NRMATraceConfiguration *configuration = [[NRMATraceConfiguration alloc] init];
+        if (array.count != 2) {
+            NRLOG_AGENT_WARNING(@"Unexpected at_capture shape (%lu elements, expected 2); using default max activity trace count of %d.",
+                                (unsigned long)array.count, NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT);
+            return self;
+        }
 
-                // Set the name and total count.
-                configuration.activityTraceNamePattern = [configArray objectAtIndex:0];
-                configuration.totalTraceCount = [[configArray objectAtIndex:1] intValue];
+        self.maxTotalTraceCount = [[array objectAtIndex:0] intValue];
+        if (self.maxTotalTraceCount <= 0) {
+            NRLOG_AGENT_WARNING(@"at_capture specified a max activity trace count of %d, which would drop every activity trace; using %d.",
+                                self.maxTotalTraceCount, NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT);
+            self.maxTotalTraceCount = NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT;
+        }
 
-                [self.activityTraceConfigurations addObject:configuration];
+        NSArray *configurations = [array objectAtIndex:1];
+        if (![configurations isKindOfClass:[NSArray class]]) {
+            return self;
+        }
+
+        self.activityTraceConfigurations = [[NSMutableArray alloc] initWithCapacity:configurations.count];
+
+        for (int configurationIndex = 0; configurationIndex < configurations.count; configurationIndex++) {
+            id configArray = [configurations objectAtIndex:configurationIndex];
+            // Each entry must be a [namePattern, totalTraceCount] pair. Anything else is skipped
+            // rather than sent to -objectAtIndex:, which would raise on a non-array element.
+            if (![configArray isKindOfClass:[NSArray class]] || [configArray count] < 2) {
+                NRLOG_AGENT_WARNING(@"Skipping malformed at_capture trace configuration at index %d.", configurationIndex);
+                continue;
             }
+
+            NRMATraceConfiguration *configuration = [[NRMATraceConfiguration alloc] init];
+
+            // Set the name and total count.
+            configuration.activityTraceNamePattern = [configArray objectAtIndex:0];
+            configuration.totalTraceCount = [[configArray objectAtIndex:1] intValue];
+
+            [self.activityTraceConfigurations addObject:configuration];
         }
     }
     return self;
 }
+
+- (NSArray*) asArray
+{
+    NSMutableArray* configurations = [[NSMutableArray alloc] init];
+    for (NRMATraceConfiguration* configuration in self.activityTraceConfigurations) {
+        [configurations addObject:@[configuration.activityTraceNamePattern ?: @"",
+                                    @(configuration.totalTraceCount)]];
+    }
+    return @[@(self.maxTotalTraceCount), configurations];
+}
+
 + (id) defaultTraceConfigurations
 {
     NRMATraceConfigurations* traceConfigurations = [[NRMATraceConfigurations alloc] init];
-    traceConfigurations.maxTotalTraceCount = 1;
+    traceConfigurations.maxTotalTraceCount = NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT;
     return traceConfigurations;
 }
 @end

--- a/Agent/Harvester/NRMAHarvestController.h
+++ b/Agent/Harvester/NRMAHarvestController.h
@@ -38,6 +38,10 @@
 
 - (void) deinitialize;
 
+/// Whether the harvest buffer has room for another activity trace: `retained < at_capture max`.
+/// The buffer is cleared on a successful harvest, so a failing or rate-limited harvest keeps it full.
++ (BOOL) shouldCollectTraces;
+
 + (BOOL) shouldNotCollectTraces;
 
 + (void) setMaxOfflineStorageSize:(NSUInteger) size;

--- a/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRHarvesterTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRHarvesterTest.m
@@ -252,6 +252,82 @@ static void NRMAWaitForHarvesterToLeaveState(NRMAHarvester *harvester, NSInteger
     XCTAssertEqualObjects(@"/*", configuration.activityTraceNamePattern, @"Trace name pattern is not correct");
 }
 
+// The expected default is spelled out as a literal rather than as
+// NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT so that these assertions describe a behavior instead of
+// restating the constant: a cap of 0 drops every activity trace for the whole session, and a test
+// that mirrors the constant would keep passing if the constant were changed back to 0.
+
+- (void) testActivityTraceConfigurationMissingAtCaptureUsesDefaultCap
+{
+    // A /connect response that omits at_capture entirely.
+    NRMATraceConfigurations *traceConfigurations = [[NRMATraceConfigurations alloc] initWithArray:nil];
+
+    XCTAssertNotEqual(0, traceConfigurations.maxTotalTraceCount, @"A missing at_capture must not produce a cap of 0, which drops every activity trace.");
+    XCTAssertEqual(1000, traceConfigurations.maxTotalTraceCount, @"A missing at_capture should fall back to the default max trace count");
+}
+
+- (void) testActivityTraceConfigurationUnexpectedShapeUsesDefaultCap
+{
+    // at_capture present but not the documented 2-element [max, [configs]] shape.
+    NRMATraceConfigurations *traceConfigurations = [[NRMATraceConfigurations alloc] initWithArray:@[@5]];
+
+    XCTAssertEqual(1000, traceConfigurations.maxTotalTraceCount, @"A reshaped at_capture should fall back to the default max trace count");
+}
+
+- (void) testActivityTraceConfigurationNonPositiveCapUsesDefaultCap
+{
+    // at_capture in the right shape, but with a cap that would drop every trace.
+    NRMATraceConfigurations *traceConfigurations = [[NRMATraceConfigurations alloc] initWithArray:@[@0, @[]]];
+
+    XCTAssertEqual(1000, traceConfigurations.maxTotalTraceCount, @"A cap of 0 should be replaced with the default max trace count");
+}
+
+- (void) testActivityTraceConfigurationSkipsMalformedTraceConfigurations
+{
+    // Each inner entry must be a [namePattern, totalTraceCount] pair. A non-array entry used to be
+    // sent -objectAtIndex:, which raises.
+    NSArray *at_capture = @[@7, @[@"not-an-array", @[@"/valid", @3]]];
+
+    NRMATraceConfigurations *traceConfigurations = [[NRMATraceConfigurations alloc] initWithArray:at_capture];
+
+    XCTAssertEqual(7, traceConfigurations.maxTotalTraceCount, @"An explicit positive cap should be honored");
+    XCTAssertEqual(1, (int)traceConfigurations.activityTraceConfigurations.count, @"The malformed entry should be skipped and the valid one kept");
+
+    NRMATraceConfiguration *configuration = [traceConfigurations.activityTraceConfigurations objectAtIndex:0];
+    XCTAssertEqualObjects(@"/valid", configuration.activityTraceNamePattern, @"The surviving configuration should be the well-formed one");
+    XCTAssertEqual(3, configuration.totalTraceCount, @"The surviving configuration should keep its trace count");
+}
+
+- (void) testHarvestConfigurationMissingAtCaptureUsesDefaults
+{
+    NRMAHarvesterConfiguration* config = [[NRMAHarvesterConfiguration alloc] initWithDictionary:[NSDictionary dictionary]];
+
+    // if kNRMA_AT_CAPTURE is missing
+    XCTAssertEqual(1000, config.at_capture.maxTotalTraceCount, @"A bad dictionary should parse the max activity trace count to its default.");
+    // if KNRMA_AT_MIN_UTILIZATION is missing
+    XCTAssertEqual(NRMA_DEFAULT_ACTIVITY_TRACE_MIN_UTILIZATION, config.activity_trace_min_utilization, @"A bad dictionary should parse activity trace min utilization to its default.");
+}
+
+- (void) testActivityTraceConfigurationRoundTripsThroughDictionary
+{
+    // -asDictionary is what gets persisted to NSUserDefaults, so its at_capture value has to be
+    // plist-serializable and has to be readable back by -initWithDictionary:.
+    NRMAHarvesterConfiguration* config = [self makeHarvestConfig];
+    config.at_capture = [[NRMATraceConfigurations alloc] initWithArray:@[@9, @[@[@"/pattern", @4]]]];
+
+    NSDictionary* dictionary = [config asDictionary];
+    XCTAssertTrue([NSPropertyListSerialization propertyList:dictionary isValidForFormat:NSPropertyListBinaryFormat_v1_0],
+                  @"at_capture must serialize to plist types so the configuration can be persisted");
+
+    NRMAHarvesterConfiguration* restored = [[NRMAHarvesterConfiguration alloc] initWithDictionary:dictionary];
+    XCTAssertEqual(9, restored.at_capture.maxTotalTraceCount, @"The max trace count should survive a round trip");
+    XCTAssertEqual(1, (int)restored.at_capture.activityTraceConfigurations.count, @"The trace configurations should survive a round trip");
+
+    NRMATraceConfiguration *configuration = [restored.at_capture.activityTraceConfigurations objectAtIndex:0];
+    XCTAssertEqualObjects(@"/pattern", configuration.activityTraceNamePattern, @"The name pattern should survive a round trip");
+    XCTAssertEqual(4, configuration.totalTraceCount, @"The trace count should survive a round trip");
+}
+
 - (void) testBadStoredDataRecover
 {
     NRMAHarvester* newHarvester = [[NRMAHarvester alloc] init];


### PR DESCRIPTION
## Problem

`at_capture` was the only key in `-[NRMAHarvesterConfiguration initWithDictionary:]` parsed without a presence check, and the failure mode was invisible at runtime.

A `/connect` response that omits it produced `maxTotalTraceCount == 0`. The collection gate is `count < maxTotalTraceCount`, so a cap of 0 is false for *every* trace — all activity traces are dropped for the whole session, and the only signal is `"Maximum number of Activity Traces collected. Skipping"` logged once per trace, which reads identically to a normally-full buffer.

`activity_trace_min_utilization` had the same shape of bug: `[nil doubleValue]` is `0.0`, a floor nothing can fall below, so a missing value disabled the utilization filter rather than applying the default.

## Changes

**Parsing/defaulting** — `NRMATraceConfigurations` seeds `NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT` *before* parsing and keeps it when `at_capture` is `nil`, is not the documented 2-element `[max, [configs]]` shape, or specifies a non-positive cap. Inner entries that aren't `[namePattern, count]` pairs are skipped rather than sent `-objectAtIndex:`, which raised on a non-array element. `NRMAHarvesterConfiguration` guards both keys the way every other key in that initializer already was.

**Persistence** — `-asDictionary` was writing live `NRMATraceConfiguration` objects into the dictionary stored in `NSUserDefaults`. Those aren't plist-serializable, and `-initWithArray:` would send `-objectAtIndex:` to each one on restore. Adds `-asArray` as the inverse of `-initWithArray:` so the value round-trips.

**Dedup** — `NRMATraceController` held a second, caller-less copy of the collection gate. It now forwards to `NRMAHarvestController`, which owns both the harvest buffer and the configuration the gate compares against. Kept as a forwarder rather than deleted because the declaration is public in the header.

## Reviewer note: the default is 1000, up from 1

This is a behavior change beyond the bugfix and is the one thing here worth a second opinion. An agent that never hears an `at_capture` from the collector now retains the same number of traces the agent is otherwise configured for, instead of one. Behavior when the collector *does* send a valid `at_capture` is unchanged.

## Tests

Six cases added to `NRMAHarvesterTest`, covering: missing `at_capture`, wrong-shape `at_capture`, non-positive cap, malformed inner entries, missing `activity_trace_min_utilization`, and a `-asDictionary` → `-initWithDictionary:` round trip that asserts plist-serializability.

Each was written against unmodified `develop` first and observed to fail for the right reason — cap `0`, utilization `0.0`, a non-plist-serializable value, and two cases raising outright. All pass now.

Verified locally: `NRMAHarvesterTest`, `NRTraceMachineTests`, and `APIInteractionTraceTest` all green (42 tests, 0 failures), and 512 passing / 0 failing across the wider suite. The full run did not finish locally — it hangs in `NRMAURLSessionTaskOverrideTests`, which has a live-network dependency and is untouched by this diff. Leaving that to CI.
