### PR TITLE
NR-610664 Trying to remove failure points from getting sessionAttributes into a JSError

### DIFF
--- a/Agent/Analytics/NRMAAnalytics+cppInterface.h
+++ b/Agent/Analytics/NRMAAnalytics+cppInterface.h
@@ -11,6 +11,7 @@
 
 @interface NRMAAnalytics (cppInterface)
 - (std::shared_ptr<NewRelic::AnalyticsController>&) analyticsController;
+- (NSDictionary*) sessionAttributeDictionaryFromCpp;
 
 - (BOOL) recordLegacyEventResult:(NewRelic::EventAddResult)result;
 

--- a/Agent/Analytics/NRMAAnalytics.h
+++ b/Agent/Analytics/NRMAAnalytics.h
@@ -33,6 +33,7 @@
 - (BOOL) addNetworkErrorEvent:(NRMANetworkRequestData *)requestData withResponse:(NRMANetworkResponseData *)responseData withNRMAPayload:(NRMAPayload*)payload;
 
 - (NSString*) analyticsJSONString;
+- (NSDictionary*) sessionAttributeDictionary;
 - (NSString*) sessionAttributeJSONString;
 
 - (void) sessionWillEnd;

--- a/Agent/Analytics/NRMAAnalytics.mm
+++ b/Agent/Analytics/NRMAAnalytics.mm
@@ -12,6 +12,10 @@
 #import "NRMAHarvestController.h"
 #import "NRMABool.h"
 #import <Utilities/LibLogger.hpp>
+#import <Utilities/String.hpp>
+#import <Utilities/Number.hpp>
+#import <Utilities/Boolean.hpp>
+#import <Analytics/AttributeBase.hpp>
 #import "NRConstants.h"
 #import "NewRelicInternalUtils.h"
 #import "NRMAFlags.h"
@@ -1069,6 +1073,74 @@ static PersistentStore<std::string,AnalyticEvent>* __eventStore;
             NRLOG_AGENT_VERBOSE(@"Failed to generate event json");
         }
         return nil;
+    }
+}
+
+- (NSDictionary*) sessionAttributeDictionaryFromCpp {
+    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+    try {
+        auto attributes = _analyticsController->getSessionAttributes();
+        for (const auto& pair : attributes) {
+            NSString *key = [NSString stringWithUTF8String:pair.first.c_str()];
+            auto value = pair.second->getValue();
+            if (!value) {
+                NRLOG_AGENT_VERBOSE(@"Skipping attribute \"%s\": null value", pair.first.c_str());
+                continue;
+            }
+            id objcValue = nil;
+            switch (value->getCategory()) {
+                case BaseValue::Category::STRING: {
+                    auto str = dynamic_cast<String*>(value.get());
+                    if (str) {
+                        objcValue = [NSString stringWithUTF8String:str->getValue().c_str()];
+                    }
+                    break;
+                }
+                case BaseValue::Category::NUMBER: {
+                    auto num = dynamic_cast<Number*>(value.get());
+                    if (num) {
+                        switch (num->getTag()) {
+                            case Number::Tag::DOUBLE:
+                                objcValue = [NSNumber numberWithDouble:num->doubleValue()];
+                                break;
+                            case Number::Tag::LONG:
+                                objcValue = [NSNumber numberWithLongLong:num->longLongValue()];
+                                break;
+                            case Number::Tag::U_LONG:
+                                objcValue = [NSNumber numberWithUnsignedLongLong:num->unsignedLongLongValue()];
+                                break;
+                            default:
+                                NRLOG_AGENT_VERBOSE(@"Skipping attribute \"%s\": unrecognised Number::Tag %d", pair.first.c_str(), (int)num->getTag());
+                                break;
+                        }
+                    }
+                    break;
+                }
+                case BaseValue::Category::BOOLEAN: {
+                    auto b = dynamic_cast<NewRelic::Boolean*>(value.get());
+                    if (b) {
+                        objcValue = [NSNumber numberWithBool:b->getValue()];
+                    }
+                    break;
+                }
+            }
+            if (key && objcValue) {
+                result[key] = objcValue;
+            }
+        }
+    } catch (std::exception& e) {
+        NRLOG_AGENT_VERBOSE(@"Failed to get session attributes from C++ layer: %s", e.what());
+    } catch (...) {
+        NRLOG_AGENT_VERBOSE(@"Failed to get session attributes from C++ layer.");
+    }
+    return [result copy];
+}
+
+- (NSDictionary*) sessionAttributeDictionary {
+    if ([NRMAFlags shouldEnableNewEventSystem]) {
+        return [_sessionAttributeManager sessionAttributeDictionary];
+    } else {
+        return [self sessionAttributeDictionaryFromCpp];
     }
 }
 

--- a/Agent/Analytics/NRMASAM.h
+++ b/Agent/Analytics/NRMASAM.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString*) getLastSessionsAttributes;
 
+- (NSDictionary*) sessionAttributeDictionary;
 - (NSString*) sessionAttributeJSONString;
 - (BOOL) setLastInteraction:(NSString*)name;
 @end

--- a/Agent/Analytics/NRMASAM.mm
+++ b/Agent/Analytics/NRMASAM.mm
@@ -223,6 +223,16 @@
 }
 
 // Includes Public and Private Attributes
+- (NSDictionary*) sessionAttributeDictionary {
+    @synchronized (attributeDict) {
+        @synchronized (privateAttributeDict) {
+            NSMutableDictionary *merged = [attributeDict mutableCopy];
+            [merged addEntriesFromDictionary:privateAttributeDict];
+            return [merged copy];
+        }
+    }
+}
+
 - (NSString*) sessionAttributeJSONString {
     // Take a snapshot under the locks, then serialize outside them.
     // NSJSONSerialization is instrumented by the method profiler, which tries to

--- a/Agent/JSError/JSErrorController.swift
+++ b/Agent/JSError/JSErrorController.swift
@@ -16,7 +16,7 @@ public class JSErrorController: NSObject {
 
     // MARK: - Properties
 
-    var sessionId: String?
+    private var sessionId: String?
     var sessionStartDate: Date?
 
     private let platform: String
@@ -150,16 +150,18 @@ public class JSErrorController: NSObject {
             allAttributes["appVersion"] = appVersion
             // Keep appVersion at top level for grouping in onHarvest
             errorData["appVersion"] = appVersion
+        } else {
+            NRLOG_AGENT_DEBUG("JS error recorded without agent configuration: appVersion returned nil")
         }
 
         // Add all session attributes from analytics controller
-        if let sessionAttributesJSON = analyticsController.sessionAttributeJSONString(),
-           !sessionAttributesJSON.isEmpty,
-           let sessionData = sessionAttributesJSON.data(using: .utf8),
-           let sessionAttributes = try? JSONSerialization.jsonObject(with: sessionData) as? [String: Any] {
+        if let sessionAttributes = analyticsController.sessionAttributeDictionary() as? [String: Any],
+           !sessionAttributes.isEmpty {
             for (key, value) in sessionAttributes {
                 allAttributes[key] = value
             }
+        } else {
+            NRLOG_AGENT_DEBUG("JS error recorded without session attributes: sessionAttributeDictionary() returned nil or empty")
         }
 
         // Add additional attributes if provided (may override session attributes)
@@ -306,9 +308,6 @@ public class JSErrorController: NSObject {
 
         // Format payload (session attributes are now per-error, not at payload level)
         let payload = formatPayload(errors, appVersion: appVersion)
-
-        // Get connection info
-        let connectInfo = NRMAAgentConfiguration.connectionInformation()
 
         // Track this upload
         pendingUploadsLock.lock()

--- a/Test Harness/NRTestApp/NRTestApp/AppDelegate.swift
+++ b/Test Harness/NRTestApp/NRTestApp/AppDelegate.swift
@@ -31,7 +31,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         NewRelic.addHTTPHeaderTracking(for: ["Test"])
         NewRelic.enableFeatures([NRMAFeatureFlags.NRFeatureFlag_SwiftAsyncURLSessionSupport,
                                  NRMAFeatureFlags.NRFeatureFlag_NewEventSystem,
-                                 NRMAFeatureFlags.NRFeatureFlag_OfflineStorage])
+                                 NRMAFeatureFlags.NRFeatureFlag_OfflineStorage,
+                                 NRMAFeatureFlags.NRFeatureFlag_JSErrorEvents])
         // Note: Disabled by default. Enable or disable (default) flag to enable background reporting.
         // NewRelic.enableFeatures([NRMAFeatureFlags.NRFeatureFlag_BackgroundReporting])
         


### PR DESCRIPTION
It really doesn't seem like the JSErrorController can be initialized without the analyticsController being initialized first. 
My best guess is a failure to encode and or decode the sessionAttributeJSONString. I attempted to fix this by adding a new direct dictionary path that avoids the JSON transition.