### PR TITLE
Harvester/NRMAHarvesterConfiguration LifeTime Fix

### DIFF
--- a/Agent.xcodeproj/project.pbxproj
+++ b/Agent.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		0209AC3124E7073800E45C90 /* NRMADeviceInformationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC2D24E7073800E45C90 /* NRMADeviceInformationTests.m */; };
 		0209AC3224E7073800E45C90 /* NRMAHarvestableAnalyticsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC2E24E7073800E45C90 /* NRMAHarvestableAnalyticsTest.m */; };
 		0209AC3424E7074100E45C90 /* NRMAConnectionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3324E7074100E45C90 /* NRMAConnectionTest.m */; };
+		CD11FE0002000000000000A2 /* NRMAHarvesterConfigurationLifetimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD11FE0001000000000000A1 /* NRMAHarvesterConfigurationLifetimeTests.m */; };
 		0209AC3D24E7075200E45C90 /* NRHarvestableVitalsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3624E7075100E45C90 /* NRHarvestableVitalsTest.m */; };
 		0209AC3E24E7075200E45C90 /* NRHarvesterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3724E7075100E45C90 /* NRHarvesterTest.m */; };
 		0209AC3F24E7075200E45C90 /* NRHarvesterStateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3824E7075200E45C90 /* NRHarvesterStateTest.m */; };
@@ -121,6 +122,7 @@
 		0256580E24EB19BF00FE3125 /* NRMAAppTokenTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC0824E7071400E45C90 /* NRMAAppTokenTest.m */; };
 		0256580F24EB19BF00FE3125 /* TestContextAdapter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0209ABD624E706AE00E45C90 /* TestContextAdapter.mm */; };
 		0256581024EB19BF00FE3125 /* NRMAConnectionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3324E7074100E45C90 /* NRMAConnectionTest.m */; };
+		CD11FE0003000000000000A3 /* NRMAHarvesterConfigurationLifetimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD11FE0001000000000000A1 /* NRMAHarvesterConfigurationLifetimeTests.m */; };
 		0256581124EB19BF00FE3125 /* NRMALastActivityTraceControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209ABE724E706F900E45C90 /* NRMALastActivityTraceControllerTest.m */; };
 		0256581224EB19BF00FE3125 /* APINetworkNoticeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC0624E7071400E45C90 /* APINetworkNoticeTest.m */; };
 		0256581324EB19BF00FE3125 /* NRMADeviceInformationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC2D24E7073800E45C90 /* NRMADeviceInformationTests.m */; };
@@ -1127,6 +1129,7 @@
 		3431DD7E2BED4A5200FF145F /* NRHarvesterConnectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3924E7075200E45C90 /* NRHarvesterConnectionTests.m */; };
 		3431DD7F2BED4A5200FF145F /* NRHarvesterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3724E7075100E45C90 /* NRHarvesterTest.m */; };
 		3431DD802BED4A5200FF145F /* NRMAConnectionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3324E7074100E45C90 /* NRMAConnectionTest.m */; };
+		CD11FE0004000000000000A4 /* NRMAHarvesterConfigurationLifetimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD11FE0001000000000000A1 /* NRMAHarvesterConfigurationLifetimeTests.m */; };
 		3431DD812BED4A5200FF145F /* NRHarvestableVitalsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3624E7075100E45C90 /* NRHarvestableVitalsTest.m */; };
 		3431DD822BED4A5200FF145F /* NRHarvesterStateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3824E7075200E45C90 /* NRHarvesterStateTest.m */; };
 		3431DD842BED4A9900FF145F /* NRMAFeatureFlagsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC4324E7078000E45C90 /* NRMAFeatureFlagsTests.m */; };
@@ -2131,6 +2134,7 @@
 		0209AC2D24E7073800E45C90 /* NRMADeviceInformationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRMADeviceInformationTests.m; sourceTree = "<group>"; };
 		0209AC2E24E7073800E45C90 /* NRMAHarvestableAnalyticsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRMAHarvestableAnalyticsTest.m; sourceTree = "<group>"; };
 		0209AC3324E7074100E45C90 /* NRMAConnectionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRMAConnectionTest.m; sourceTree = "<group>"; };
+		CD11FE0001000000000000A1 /* NRMAHarvesterConfigurationLifetimeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRMAHarvesterConfigurationLifetimeTests.m; sourceTree = "<group>"; };
 		0209AC3524E7075100E45C90 /* NRHarvesterStateTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NRHarvesterStateTest.h; sourceTree = "<group>"; };
 		0209AC3624E7075100E45C90 /* NRHarvestableVitalsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRHarvestableVitalsTest.m; sourceTree = "<group>"; };
 		0209AC3724E7075100E45C90 /* NRHarvesterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRHarvesterTest.m; sourceTree = "<group>"; };
@@ -3004,6 +3008,7 @@
 				0209AC3A24E7075200E45C90 /* NRHarvesterTest.h */,
 				0209AC3724E7075100E45C90 /* NRHarvesterTest.m */,
 				0209AC3324E7074100E45C90 /* NRMAConnectionTest.m */,
+				CD11FE0001000000000000A1 /* NRMAHarvesterConfigurationLifetimeTests.m */,
 				0209AC2A24E7072700E45C90 /* Harvestable-Data-Tests */,
 				F8D23CF92F840F92000FFD31 /* Agent-watchos-Tests-Bridging-Header.h */,
 			);
@@ -5633,6 +5638,7 @@
 				F85ABB602F1557EA0098A2CF /* SerializedNode.swift in Sources */,
 				0209ABDC24E706AE00E45C90 /* TestContextAdapter.mm in Sources */,
 				0209AC3424E7074100E45C90 /* NRMAConnectionTest.m in Sources */,
+				CD11FE0002000000000000A2 /* NRMAHarvesterConfigurationLifetimeTests.m in Sources */,
 				F85ABB632F155B4B0098A2CF /* RRWebEvent.swift in Sources */,
 				0209ABF124E706FA00E45C90 /* NRMALastActivityTraceControllerTest.m in Sources */,
 				0209AC0E24E7071500E45C90 /* APINetworkNoticeTest.m in Sources */,
@@ -6047,6 +6053,7 @@
 				0256580F24EB19BF00FE3125 /* TestContextAdapter.mm in Sources */,
 				F8FBFA5A2A77FA3000CDC8C5 /* TestRequestEvents.m in Sources */,
 				0256581024EB19BF00FE3125 /* NRMAConnectionTest.m in Sources */,
+				CD11FE0003000000000000A3 /* NRMAHarvesterConfigurationLifetimeTests.m in Sources */,
 				0256581124EB19BF00FE3125 /* NRMALastActivityTraceControllerTest.m in Sources */,
 				0256581224EB19BF00FE3125 /* APINetworkNoticeTest.m in Sources */,
 				0256581324EB19BF00FE3125 /* NRMADeviceInformationTests.m in Sources */,
@@ -6462,6 +6469,7 @@
 				3431DD7E2BED4A5200FF145F /* NRHarvesterConnectionTests.m in Sources */,
 				3431DD7F2BED4A5200FF145F /* NRHarvesterTest.m in Sources */,
 				3431DD802BED4A5200FF145F /* NRMAConnectionTest.m in Sources */,
+				CD11FE0004000000000000A4 /* NRMAHarvesterConfigurationLifetimeTests.m in Sources */,
 				3431DD812BED4A5200FF145F /* NRHarvestableVitalsTest.m in Sources */,
 				3431DD822BED4A5200FF145F /* NRHarvesterStateTest.m in Sources */,
 				3431DD562BED38F400FF145F /* NRMAHTTPUtilitiesTests.m in Sources */,

--- a/Agent/Harvester/DataStore/NRMAHarvesterConfiguration.h
+++ b/Agent/Harvester/DataStore/NRMAHarvesterConfiguration.h
@@ -91,7 +91,7 @@
 @property(nonatomic,assign) int       activity_trace_max_send_attempts;
 @property(nonatomic,strong) NRMATraceConfigurations*  at_capture;
 @property(nonatomic,assign) double    activity_trace_min_utilization;
-@property(nonatomic,assign) NSString* encoding_key;
+@property(nonatomic,copy) NSString* encoding_key;
 @property(nonatomic,assign) long long account_id;
 @property(nonatomic,assign) long long application_id;
 @property(nonatomic,strong) NSString* trusted_account_key;
@@ -99,12 +99,12 @@
 @property(nonatomic,assign) BOOL      log_reporting_enabled;
 @property(nonatomic,assign) double    sampling_rate;
 @property(nonatomic,assign) BOOL      has_log_reporting_config;
-@property(nonatomic,assign) NSDictionary* request_header_map;
+@property(nonatomic,copy) NSDictionary* request_header_map;
 
 
 // CAN BE
 // NONE < ERROR < WARN < INFO < DEBUG < AUDIT < VERBOSE
-@property(nonatomic,assign) NSString* log_reporting_level;
+@property(nonatomic,copy) NSString* log_reporting_level;
 
 // Session Replay Configuration
 
@@ -113,7 +113,7 @@
 @property(nonatomic,assign) double    session_replay_sampling_rate;
 @property(nonatomic,assign) double    session_replay_error_sampling_rate;
 // MASKING MODE
-@property(nonatomic,assign) NSString*    session_replay_mode;
+@property(nonatomic,copy) SessionReplayMaskingMode session_replay_mode;
 
 @property(nonatomic,assign) BOOL      session_replay_maskApplicationText;
 @property(nonatomic,assign) BOOL      session_replay_maskUserInputText;
@@ -154,10 +154,10 @@
 
 
 @interface SessionReplayCustomMaskingRule : NSObject
-@property(nonatomic,assign) NSString*    identifier;
-@property(nonatomic,assign) NSArray*     name;
-@property(nonatomic,assign) NSString*    operatorName;
-@property(nonatomic,assign) NSString*    type;
+@property(nonatomic,copy) NSString*    identifier;
+@property(nonatomic,copy) NSArray*     name;
+@property(nonatomic,copy) NSString*    operatorName;
+@property(nonatomic,copy) NSString*    type;
 - (id) initWithDictionary:(NSDictionary*)dict;
 
 

--- a/Agent/Harvester/DataStore/NRMAHarvesterConfiguration.m
+++ b/Agent/Harvester/DataStore/NRMAHarvesterConfiguration.m
@@ -100,17 +100,32 @@ static long long _accountId;
         //                         whole session.
         //   min_utilization absent -> [nil doubleValue] == 0.0, a floor nothing can fall below, so
         //                         the utilization filter was effectively disabled.
-        if ([dict objectForKey:kNRMA_AT_CAPTURE]) {
-            self.at_capture = [[NRMATraceConfigurations alloc] initWithArray:[dict valueForKey:kNRMA_AT_CAPTURE]];
+        //
+        // Presence alone is not enough for either: the value is whatever the collector sent, so a
+        // JSON null (NSNull) or a reshaped value would be parsed as if it had the expected type.
+        // -initWithArray: re-checks its own argument, but the check here keeps a wrong-typed
+        // at_capture on the same "fall back to the documented default" path as an absent one.
+        id atCapture = [dict objectForKey:kNRMA_AT_CAPTURE];
+        if ([atCapture isKindOfClass:[NSArray class]]) {
+            self.at_capture = [[NRMATraceConfigurations alloc] initWithArray:atCapture];
         }
         else {
+            if (atCapture != nil) {
+                NRLOG_AGENT_WARNING(@"Ignoring at_capture of unexpected type %@; using the default activity trace configuration.",
+                                    NSStringFromClass([atCapture class]));
+            }
             self.at_capture = [NRMATraceConfigurations defaultTraceConfigurations];
         }
 
-        if ([dict objectForKey:KNRMA_AT_MIN_UTILIZATION]) {
-            self.activity_trace_min_utilization = [[dict valueForKey:KNRMA_AT_MIN_UTILIZATION] doubleValue];
+        id minUtilization = [dict objectForKey:KNRMA_AT_MIN_UTILIZATION];
+        if (NRMAIsNumberLikeConfigurationValue(minUtilization)) {
+            self.activity_trace_min_utilization = [minUtilization doubleValue];
         }
         else {
+            if (minUtilization != nil) {
+                NRLOG_AGENT_WARNING(@"Ignoring at_min_utilization of unexpected type %@; using the default of %f.",
+                                    NSStringFromClass([minUtilization class]), NRMA_DEFAULT_ACTIVITY_TRACE_MIN_UTILIZATION);
+            }
             self.activity_trace_min_utilization = NRMA_DEFAULT_ACTIVITY_TRACE_MIN_UTILIZATION;
         }
         if ([dict objectForKey:kNRMA_ENCODING_KEY]) {

--- a/Agent/Harvester/DataStore/NRMAHarvesterConfiguration.m
+++ b/Agent/Harvester/DataStore/NRMAHarvesterConfiguration.m
@@ -581,7 +581,8 @@ static long long _accountId;
     if (self == object) return YES;
     if (object == nil || ![object isKindOfClass:self.class]) return NO;
     NRMAHarvesterConfiguration* that = (NRMAHarvesterConfiguration*)object;
-    if (self.application_token != that.application_token) return NO;
+    if (self.application_token != that.application_token &&
+        ![self.application_token isEqualToString:that.application_token]) return NO;
     if (self.collect_network_errors != that.collect_network_errors) return NO;
     if (self.data_report_period != that.data_report_period) return NO;
     if (self.error_limit != that.error_limit) return NO;
@@ -604,7 +605,8 @@ static long long _accountId;
     if (![self.log_reporting_level isEqualToString:that.log_reporting_level]) return NO;
     if (self.log_reporting_enabled != that.log_reporting_enabled) return NO;
     if (self.has_log_reporting_config != that.has_log_reporting_config) return NO;
-    if (self.request_header_map != that.request_header_map) return NO;
+    if (self.request_header_map != that.request_header_map &&
+        ![self.request_header_map isEqualToDictionary:that.request_header_map]) return NO;
 
 
     // session replay equality

--- a/Agent/Harvester/DataStore/NRMATraceConfigurations.h
+++ b/Agent/Harvester/DataStore/NRMATraceConfigurations.h
@@ -15,6 +15,17 @@
 /// silently drops all activity traces for the whole session.
 #define NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT 1000
 
+/// Whether a value parsed out of a collector response (or out of the NSUserDefaults round trip) can
+/// safely be sent -intValue/-doubleValue.
+///
+/// Numeric collector fields arrive as JSON numbers and are persisted as NSNumber, but JSON `null`
+/// decodes to NSNull and a reshaped field can be an array or a dictionary. None of those respond to
+/// the numeric accessors, so converting one without checking is an unrecognized-selector crash
+/// rather than a fallback to the default.
+static inline BOOL NRMAIsNumberLikeConfigurationValue(id value) {
+    return [value isKindOfClass:[NSNumber class]] || [value isKindOfClass:[NSString class]];
+}
+
 @interface NRMATraceConfigurations : NSObject
 @property(nonatomic,assign) int maxTotalTraceCount;
 @property (atomic, strong) NSMutableArray *activityTraceConfigurations;

--- a/Agent/Harvester/DataStore/NRMATraceConfigurations.m
+++ b/Agent/Harvester/DataStore/NRMATraceConfigurations.m
@@ -22,7 +22,15 @@
         // Activity Traces collected. Skipping" for each one.
         self.maxTotalTraceCount = NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT;
 
-        if (array == nil) {
+        // Everything below has to tolerate an arbitrary decoded JSON graph. at_capture is typed
+        // NSArray* here, but the collector can send null (NSNull) or any other shape, and every
+        // conversion in this method (-count, -objectAtIndex:, -intValue) is an unrecognized selector
+        // on the wrong type.
+        if (![array isKindOfClass:[NSArray class]]) {
+            if (array != nil) {
+                NRLOG_AGENT_WARNING(@"Unexpected at_capture type (%@, expected an array); using default max activity trace count of %d.",
+                                    NSStringFromClass([array class]), NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT);
+            }
             return self;
         }
 
@@ -32,7 +40,14 @@
             return self;
         }
 
-        self.maxTotalTraceCount = [[array objectAtIndex:0] intValue];
+        id maxTotalTraceCount = [array objectAtIndex:0];
+        if (!NRMAIsNumberLikeConfigurationValue(maxTotalTraceCount)) {
+            NRLOG_AGENT_WARNING(@"Unexpected at_capture max activity trace count type (%@, expected a number); using default of %d.",
+                                NSStringFromClass([maxTotalTraceCount class]), NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT);
+            return self;
+        }
+
+        self.maxTotalTraceCount = [maxTotalTraceCount intValue];
         if (self.maxTotalTraceCount <= 0) {
             NRLOG_AGENT_WARNING(@"at_capture specified a max activity trace count of %d, which would drop every activity trace; using %d.",
                                 self.maxTotalTraceCount, NRMA_DEFAULT_MAX_TOTAL_TRACE_COUNT);
@@ -55,11 +70,22 @@
                 continue;
             }
 
+            // The pair's own element types are just as unchecked as the outer array's: the pattern
+            // has to be a string because -activityTraceNamePattern is one and is later matched
+            // against trace names, and the count has to be convertible to an int.
+            id namePattern = [configArray objectAtIndex:0];
+            id totalTraceCount = [configArray objectAtIndex:1];
+            if (![namePattern isKindOfClass:[NSString class]] || !NRMAIsNumberLikeConfigurationValue(totalTraceCount)) {
+                NRLOG_AGENT_WARNING(@"Skipping at_capture trace configuration at index %d with unexpected element types (%@, %@).",
+                                    configurationIndex, NSStringFromClass([namePattern class]), NSStringFromClass([totalTraceCount class]));
+                continue;
+            }
+
             NRMATraceConfiguration *configuration = [[NRMATraceConfiguration alloc] init];
 
             // Set the name and total count.
-            configuration.activityTraceNamePattern = [configArray objectAtIndex:0];
-            configuration.totalTraceCount = [[configArray objectAtIndex:1] intValue];
+            configuration.activityTraceNamePattern = namePattern;
+            configuration.totalTraceCount = [totalTraceCount intValue];
 
             [self.activityTraceConfigurations addObject:configuration];
         }

--- a/Agent/Harvester/HarvestableTypes/Instances/NRMADeviceInformation.h
+++ b/Agent/Harvester/HarvestableTypes/Instances/NRMADeviceInformation.h
@@ -31,7 +31,7 @@
 @property(strong) NSString* regionCode;
 @property(strong) NSString* manufacturer;
 @property(assign) NRMAApplicationPlatform platform;
-@property(assign) NSString* platformVersion;
+@property(copy) NSString* platformVersion;
 @property(strong) NSMutableDictionary* misc;
 
 - (id) JSONObject;

--- a/Agent/Harvester/NRMAHarvester.mm
+++ b/Agent/Harvester/NRMAHarvester.mm
@@ -206,10 +206,8 @@ static const NSTimeInterval kNRMARateLimitMaxBackoffSeconds  = 600.0;
 #ifndef  DISABLE_NRMA_EXCEPTION_WRAPPER
     @try {
 #endif
-        // Snapshot values into strong locals up front. Several object-typed properties on
-        // NRMAHarvesterConfiguration are declared 'assign' (e.g. request_header_map), so the
-        // backing object can be deallocated while the property still holds the pointer. Pulling
-        // values once and copying object types up front contains that risk to one wrapped block.
+        // Snapshot values into strong locals up front so a concurrent reconfigure cannot
+        // change them partway through this method.
         long long accountId = harvestConfiguration.account_id;
         long long applicationId = harvestConfiguration.application_id;
         NSString* trustedAccountKey = harvestConfiguration.trusted_account_key;
@@ -217,16 +215,8 @@ static const NSTimeInterval kNRMARateLimitMaxBackoffSeconds  = 600.0;
         long long serverTimestamp = harvestConfiguration.server_timestamp;
         NSString* crossProcessID = harvestConfiguration.cross_process_id;
 
-        NSDictionary* requestHeaders = nil;
-        @try {
-            id rawHeaders = harvestConfiguration.request_header_map;
-            if ([rawHeaders isKindOfClass:[NSDictionary class]]) {
-                requestHeaders = [(NSDictionary*)rawHeaders copy];
-            }
-        } @catch (NSException* exception) {
-            NRLOG_AGENT_ERROR(@"configureHarvester: invalid request_header_map; ignoring.");
-            requestHeaders = nil;
-        }
+        // request_header_map is a `copy` property, so this hands back storage we own.
+        NSDictionary* requestHeaders = harvestConfiguration.request_header_map;
 
         // Keep the NSStrings alive for the lifetime of the setContext call so the C string
         // pointers we hand to ApplicationContext remain valid.
@@ -662,8 +652,9 @@ static const NSTimeInterval kNRMARateLimitMaxBackoffSeconds  = 600.0;
 {
     NRLOG_AGENT_VERBOSE(@"config: transitionToConnected");
 
-    // Validate the inbound configuration before touching it. Sending messages to a
-    // freed/corrupt object here is the suspected root cause of crashes seen at this site.
+    // Nil/type guard: configureFromCollector: returns nil when the collector response
+    // is unparseable, and the stored-config path can return a non-config object. Neither
+    // should be promoted to CONNECTED.
     if (![_configuration isKindOfClass:[NRMAHarvesterConfiguration class]]) {
         NRLOG_AGENT_ERROR(@"transitionToConnected: invalid configuration; aborting transition.");
         return;

--- a/Tests/MEMORY-SAFETY.md
+++ b/Tests/MEMORY-SAFETY.md
@@ -1,0 +1,210 @@
+# Memory-safety tests
+
+A use-after-free in Objective-C usually does not crash where the bug is. The freed memory
+is still mapped and often still holds plausible bytes, so the bad read succeeds for weeks
+and then one day `objc_msgSend` lands on a recycled `isa` pointer and the process dies
+somewhere unrelated. In a crash report that looks like a mystery segfault in `libobjc`.
+
+This suite makes those bugs deterministic. It runs the existing unit tests with the
+malloc and Objective-C runtime diagnostics enabled, so a stale pointer traps at the moment
+it is used, with the type of the freed object named in the message.
+
+## Running it
+
+```bash
+scripts/run_memory_safety_tests.sh
+```
+
+That builds and runs the curated suite (below) with zombies and scribble on, then prints a
+summary and exits non-zero if anything tripped.
+
+```bash
+# one class or one test
+scripts/run_memory_safety_tests.sh --only NRMAHarvesterConfigurationLifetimeTests
+scripts/run_memory_safety_tests.sh --only NRMAHarvesterTest/testHarvestConfiguration
+
+# the whole Agent_Tests target, not just the curated suite
+scripts/run_memory_safety_tests.sh --all
+
+# AddressSanitizer instead of zombies (slower, but reports who freed the memory)
+scripts/run_memory_safety_tests.sh --asan
+
+# reuse the previous build, pick a simulator, list the suite
+scripts/run_memory_safety_tests.sh --no-build
+scripts/run_memory_safety_tests.sh --simulator 'iPhone 16 Pro'
+scripts/run_memory_safety_tests.sh --list
+```
+
+Logs land in `build/memory-safety/` (gitignored).
+
+### From Xcode
+
+Enable the diagnostics on the **Agent-iOS** scheme by hand:
+*Product → Scheme → Edit Scheme → Test → Diagnostics*, then check **Zombie Objects**
+and **Malloc Scribble**. Run tests with `⌘U`. Turn them back off afterwards — zombies
+never free anything, so leaving them on makes every subsequent test run leak and slow down.
+
+Do not try to commit those checkboxes as a shared scheme. They are not serialized in a form
+that `xcodebuild build-for-testing` bakes into the `.xctestrun`, so a scheme that looks
+correct in the Xcode UI can still run with the diagnostics inert — which is worse than not
+having them, because the suite then reports success without checking anything. That is
+exactly why the script injects the environment variables into the `.xctestrun` instead, and
+why it independently greps the log rather than trusting the pass/fail summary.
+
+### From CI
+
+The script is self-contained and returns a meaningful exit code, so a job is just:
+
+```yaml
+- name: Memory-safety tests
+  run: scripts/run_memory_safety_tests.sh
+```
+
+This is not currently wired into `.github/workflows/main.yml`. It is worth adding — the
+bug this suite was written for shipped through five releases precisely because nothing in
+CI would have caught it.
+
+## How it is wired
+
+```
+scripts/run_memory_safety_tests.sh   the runner: builds, injects diagnostics, runs, judges
+scripts/lib_patch_xctestrun.py       injects env vars into every test target in the .xctestrun
+Tests/.../NRMAHarvesterConfigurationLifetimeTests.m   the lifetime regression tests
+```
+
+`xcodebuild build-for-testing` emits an `.xctestrun`, which is the complete launch spec for
+the test bundle — including the environment the test process runs in. The runner patches
+`EnvironmentVariables` in that file and then calls `test-without-building -xctestrun`, so the
+diagnostics are guaranteed to be present. `lib_patch_xctestrun.py` handles both the legacy
+layout (target names as top-level keys) and the newer `TestConfigurations` layout.
+
+### Checking that the harness still works
+
+A memory-safety suite that has quietly stopped enabling its diagnostics passes everything
+forever. If you change the plumbing, verify it end to end by reintroducing the original bug
+and confirming the suite fails:
+
+```bash
+# make one property unsafe again
+sed -i '' 's/@property(nonatomic,copy) NSDictionary\* request_header_map;/@property(nonatomic,assign) NSDictionary* request_header_map;/' \
+  Agent/Harvester/DataStore/NRMAHarvesterConfiguration.h
+
+scripts/run_memory_safety_tests.sh --only NRMAHarvesterConfigurationLifetimeTests
+# expected: "zombie messages (use-after-free): 1" or more, and RESULT: FAIL
+
+git checkout -- Agent/Harvester/DataStore/NRMAHarvesterConfiguration.h
+```
+
+If that comes back `RESULT: PASS`, the harness is broken, not the code.
+
+## What the diagnostics do
+
+| Setting | Env var | What it catches |
+|---|---|---|
+| Zombie Objects | `NSZombieEnabled` | A deallocated object is replaced by a zombie that logs `message sent to deallocated instance` and traps, instead of being freed and reused. This is the one that catches the classic dangling-`assign`-property bug. |
+| Malloc Scribble | `MallocScribble` | Freed memory is overwritten with `0x55`, so a surviving pointer reads obvious garbage rather than stale-but-plausible data. Catches non-object buffers that zombies do not cover. |
+| Malloc Guard Edges | `MallocGuardEdges` | Guard pages around large allocations, so overruns fault immediately. |
+| Malloc Pre-Scribble | `MallocPreScribble` | Fills *new* allocations with `0xAA`, catching reads of uninitialized memory. |
+| Freed-object autorelease check | `NSAutoreleaseFreedObjectCheckEnabled` | Catches autoreleasing an object that was already freed. |
+| AddressSanitizer | (`--asan`) | Full redzone/quarantine instrumentation. Reports the allocation stack *and* the free stack. Needs its own instrumented build. |
+
+Zombies and ASan overlap but are not redundant: zombies are cheap and pinpoint the bad
+*send*; ASan is expensive and pinpoints the bad *free*. Reach for zombies first, then ASan
+once you know a UAF exists and need to find who released the object.
+
+`MallocStackLogging` is off by default because it is slow. Pass `--stacks` when you need
+`malloc_history` to resolve a specific zombie address to its allocation stack.
+
+## Reading the output
+
+A clean run:
+
+```
+================ memory safety summary ================
+zombie messages (use-after-free): 0
+AddressSanitizer reports:         0
+unexpected process exits:         0
+xcodebuild exit code:             0
+RESULT: PASS
+```
+
+A detected use-after-free:
+
+```
+--- use-after-free detected ---
+  *** -[__NSDictionaryI retain]: message sent to deallocated instance 0x10656f2c0
+RESULT: FAIL
+```
+
+**A zombie trap kills the test process.** XCTest cannot report a normal failure for a
+process that no longer exists, so `xcodebuild` may say `Executed 0 tests, with 0 failures`
+for the very run that found the bug. Never read the summary line on its own — that is why
+the script greps the log independently and treats any zombie message as a failure. If you
+run `xcodebuild` by hand, do the same.
+
+The class in the message is the type of the **freed** object, not the object that was
+messaged incorrectly. `-[__NSDictionaryI retain]` means something held an unowned pointer
+to an immutable dictionary that had already been released.
+
+## The suite
+
+`scripts/run_memory_safety_tests.sh --list` is the source of truth; the list lives in the
+script. Today it is the harvester configuration and harvest-cycle classes, because that is
+where the agent keeps parsed collector state alive across autorelease-pool and
+harvest-cycle boundaries:
+
+- `NRMAHarvesterConfigurationLifetimeTests` — written for this; see below
+- `NRMAHarvesterTest`, `NRMAHarvestControllerTest`, `NRMAHarvesterStateTest`
+- `NRMAConnectionTest`
+- `SessionReplayTest`
+
+`NRMAHarvesterConnectionTests` is deliberately **not** in the suite: its `testSendData`
+issues a real, unmocked request to `mobile-collector.newrelic.com` and asserts a `403`, so
+it reports `statusCode 0` and fails whenever the network is unavailable. This suite is a
+deterministic gate on memory safety and must not go red over a live HTTP call. Run it
+explicitly with `--only NRMAHarvesterConnectionTests` when you want it.
+
+## Writing a test that can actually fail
+
+Under zombies a lifetime test only proves something if the object under test would
+genuinely have been deallocated. Two ways to write a test that always passes by accident:
+
+**1. String and dictionary literals are never freed.** `@"custom"` is a compile-time
+`NSConstantString` in the binary; a dangling pointer to one stays readable forever. Build
+values dynamically — parse them out of JSON, or construct them with `stringWithFormat:` —
+so they are heap allocated and reference counted.
+
+**2. The pool has to actually drain.** Parse inside an explicit `@autoreleasepool` and read
+only after the closing brace. Without that, the autoreleased graph is still alive for the
+rest of the test method and the bug stays hidden.
+
+`NRMAHarvesterConfigurationLifetimeTests` follows this shape:
+
+```objc
+NRMAHarvesterConfiguration *configuration = nil;
+@autoreleasepool {
+    NSDictionary *parsed = [NSJSONSerialization JSONObjectWithData:json options:0 error:nil];
+    configuration = [[NRMAHarvesterConfiguration alloc] initWithDictionary:parsed];
+}
+// `parsed` and everything it owned is gone. Reads below must still be valid.
+XCTAssertEqualObjects(configuration.request_header_map[@"X-Trace-Id"], @"abc123");
+```
+
+Add new classes to `SUITE` in the script and to the list above.
+
+## Background: the bug this was written for
+
+`NRMAHarvesterConfiguration` declared eight object-typed properties as `assign`. Under ARC
+that means `unsafe_unretained` — the setter stores a raw pointer with no retain.
+`initWithDictionary:` pointed them into the autoreleased dictionary it was parsing (the
+`NRMAJSON` graph from the collector, or the `NSUserDefaults` graph for stored config),
+while the configuration object itself lives in a strong ivar that far outlives that pool.
+Every later read was a use-after-free, and it surfaced as `SIGSEGV` in `objc_msgSend` from
+`-[NRMAHarvester transitionToConnected:]`.
+
+The lesson worth keeping: the first attempt to fix it added an `isKindOfClass:` check
+wrapped in `@try/@catch`. That cannot work. The type check is itself an `objc_msgSend` on
+the dangling pointer, and `@catch` does not catch `SIGSEGV` — a segfault is a signal, not
+an `NSException`. Defensive checks cannot rescue a pointer that is already invalid; only
+ownership can. Under this suite that distinction is immediate: the guarded version traps,
+the `copy` version passes.

--- a/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRHarvesterTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRHarvesterTest.m
@@ -298,6 +298,104 @@ static void NRMAWaitForHarvesterToLeaveState(NRMAHarvester *harvester, NSInteger
     XCTAssertEqual(3, configuration.totalTraceCount, @"The surviving configuration should keep its trace count");
 }
 
+- (void) testActivityTraceConfigurationNullAtCaptureUsesDefaultCap
+{
+    // A /connect response that sends "at_capture": null. NSJSONSerialization decodes that to NSNull,
+    // which is not nil and does not respond to -count/-objectAtIndex:.
+    NSString *configWithNullAtCapture = @"{\"at_capture\":null}";
+    NSDictionary *decoded = [NRMAJSON JSONObjectWithData:[configWithNullAtCapture dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
+    XCTAssertEqualObjects([NSNull null], decoded[@"at_capture"], @"JSON null should decode to NSNull, which is what this test is about");
+
+    NRMATraceConfigurations *traceConfigurations = [[NRMATraceConfigurations alloc] initWithArray:decoded[@"at_capture"]];
+
+    XCTAssertEqual(1000, traceConfigurations.maxTotalTraceCount, @"A null at_capture should fall back to the default max trace count instead of raising");
+}
+
+- (void) testActivityTraceConfigurationNonArrayAtCaptureUsesDefaultCap
+{
+    // at_capture is typed NSArray* but the collector can send any JSON value.
+    XCTAssertEqual(1000, [[NRMATraceConfigurations alloc] initWithArray:(NSArray *)@"nope"].maxTotalTraceCount,
+                   @"A string at_capture should fall back to the default max trace count");
+    XCTAssertEqual(1000, [[NRMATraceConfigurations alloc] initWithArray:(NSArray *)@{@"max": @5}].maxTotalTraceCount,
+                   @"A dictionary at_capture should fall back to the default max trace count");
+    XCTAssertEqual(1000, [[NRMATraceConfigurations alloc] initWithArray:(NSArray *)@5].maxTotalTraceCount,
+                   @"A bare number at_capture should fall back to the default max trace count");
+}
+
+- (void) testActivityTraceConfigurationNonNumericCapUsesDefaultCap
+{
+    // Right shape, but the cap itself is not a number, so -intValue would raise on it.
+    NRMATraceConfigurations *traceConfigurations = [[NRMATraceConfigurations alloc] initWithArray:@[[NSNull null], @[]]];
+
+    XCTAssertEqual(1000, traceConfigurations.maxTotalTraceCount, @"A non-numeric cap should fall back to the default max trace count");
+}
+
+- (void) testActivityTraceConfigurationSkipsTraceConfigurationsWithWrongElementTypes
+{
+    // The pattern has to be a string (-activityTraceNamePattern is one, and it is matched against
+    // trace names) and the count has to be numeric. Neither was checked before.
+    NSArray *at_capture = @[@7, @[@[[NSNull null], @3],
+                                  @[@"/null-count", [NSNull null]],
+                                  @[@42, @1],
+                                  @[@"/valid", @3]]];
+
+    NRMATraceConfigurations *traceConfigurations = [[NRMATraceConfigurations alloc] initWithArray:at_capture];
+
+    XCTAssertEqual(7, traceConfigurations.maxTotalTraceCount, @"An explicit positive cap should be honored");
+    XCTAssertEqual(1, (int)traceConfigurations.activityTraceConfigurations.count, @"Only the well-formed pair should be kept");
+
+    NRMATraceConfiguration *configuration = [traceConfigurations.activityTraceConfigurations objectAtIndex:0];
+    XCTAssertEqualObjects(@"/valid", configuration.activityTraceNamePattern, @"The surviving configuration should be the well-formed one");
+    XCTAssertEqual(3, configuration.totalTraceCount, @"The surviving configuration should keep its trace count");
+}
+
+- (void) testHarvestConfigurationNullAtCaptureAndMinUtilizationUseDefaults
+{
+    // The whole /connect body, decoded the way the agent decodes it, with both fields sent as null.
+    NSString *connectResponse = @"{\"at_capture\":null,\"activity_trace_min_utilization\":null}";
+    NSDictionary *decoded = [NRMAJSON JSONObjectWithData:[connectResponse dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
+
+    NRMAHarvesterConfiguration *config = [[NRMAHarvesterConfiguration alloc] initWithDictionary:decoded];
+
+    XCTAssertEqual(1000, config.at_capture.maxTotalTraceCount, @"A null at_capture should parse to the default max activity trace count");
+    XCTAssertEqual(NRMA_DEFAULT_ACTIVITY_TRACE_MIN_UTILIZATION, config.activity_trace_min_utilization, @"A null min utilization should parse to its default");
+}
+
+- (void) testHarvestConfigurationNonNumericMinUtilizationUsesDefault
+{
+    // Present-but-wrong-typed values used to reach -doubleValue directly.
+    for (id minUtilization in @[[NSNull null], @[@0.5], @{@"value": @0.5}]) {
+        NRMAHarvesterConfiguration *config = [[NRMAHarvesterConfiguration alloc] initWithDictionary:@{KNRMA_AT_MIN_UTILIZATION: minUtilization}];
+
+        XCTAssertEqual(NRMA_DEFAULT_ACTIVITY_TRACE_MIN_UTILIZATION, config.activity_trace_min_utilization,
+                       @"A min utilization of type %@ should fall back to its default", NSStringFromClass([minUtilization class]));
+    }
+}
+
+- (void) testHarvestConfigurationNumericStringValuesAreStillParsed
+{
+    // The guards reject non-numeric types, they do not tighten the parsing that already worked: the
+    // collector's numeric fields have always been read with -intValue/-doubleValue, which strings
+    // answer too.
+    NRMAHarvesterConfiguration *config = [[NRMAHarvesterConfiguration alloc] initWithDictionary:@{
+        kNRMA_AT_CAPTURE: @[@"12", @[@[@"/pattern", @"4"]]],
+        KNRMA_AT_MIN_UTILIZATION: @"0.75"
+    }];
+
+    XCTAssertEqual(12, config.at_capture.maxTotalTraceCount, @"A numeric string cap should still be parsed");
+    XCTAssertEqual(0.75, config.activity_trace_min_utilization, @"A numeric string min utilization should still be parsed");
+    XCTAssertEqual(1, (int)config.at_capture.activityTraceConfigurations.count, @"The well-formed pair should be kept");
+    XCTAssertEqual(4, [[config.at_capture.activityTraceConfigurations objectAtIndex:0] totalTraceCount], @"A numeric string trace count should still be parsed");
+}
+
+- (void) testHarvestConfigurationNonArrayAtCaptureUsesDefaultConfiguration
+{
+    NRMAHarvesterConfiguration *config = [[NRMAHarvesterConfiguration alloc] initWithDictionary:@{kNRMA_AT_CAPTURE: @"not-an-array"}];
+
+    XCTAssertEqual(1000, config.at_capture.maxTotalTraceCount, @"A wrong-typed at_capture should parse to the default max activity trace count");
+    XCTAssertEqual(0, (int)config.at_capture.activityTraceConfigurations.count, @"A wrong-typed at_capture should not produce any trace configurations");
+}
+
 - (void) testHarvestConfigurationMissingAtCaptureUsesDefaults
 {
     NRMAHarvesterConfiguration* config = [[NRMAHarvesterConfiguration alloc] initWithDictionary:[NSDictionary dictionary]];

--- a/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRMAHarvesterConfigurationLifetimeTests.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Harvester-Tests/NRMAHarvesterConfigurationLifetimeTests.m
@@ -1,0 +1,181 @@
+//
+//  NRMAHarvesterConfigurationLifetimeTests.m
+//  NewRelicAgent
+//
+//  Copyright © 2026 New Relic. All rights reserved.
+//
+//  Regression coverage for the crash reported at -[NRMAHarvester transitionToConnected:].
+//
+//  NRMAHarvesterConfiguration used to declare its object-typed properties as `assign`,
+//  which under ARC means unsafe_unretained: the setter stored a raw pointer into the
+//  autoreleased dictionary it was parsed from. The configuration object itself is held
+//  in a strong ivar that long outlives that pool, so once the pool drained every read of
+//  encoding_key / request_header_map / log_reporting_level / session_replay_mode was a
+//  use-after-free, surfacing as SIGSEGV inside objc_msgSend.
+//
+//  Each test below parses inside an explicit @autoreleasepool and reads only after the
+//  pool has drained. Run with NSZombieEnabled=YES (or MallocScribble=1) to make a
+//  regression abort loudly instead of silently reading recycled memory.
+//
+
+#import <XCTest/XCTest.h>
+#import "NRMAHarvesterConfiguration.h"
+#import "NRAgentTestBase.h"
+
+@interface NRMAHarvesterConfigurationLifetimeTests : NRMAAgentTestBase
+@end
+
+@implementation NRMAHarvesterConfigurationLifetimeTests
+
+// Builds the config from a freshly parsed JSON graph, mirroring
+// -[NRMAHarvester configureFromCollector:]. Every string here is heap allocated by
+// NSJSONSerialization rather than being a compile-time constant, so it is genuinely
+// deallocated when the pool drains -- a literal would mask the bug.
+- (NRMAHarvesterConfiguration *) configurationFromJSON:(NSString *)json
+{
+    NRMAHarvesterConfiguration *configuration = nil;
+
+    @autoreleasepool {
+        NSError *error = nil;
+        NSDictionary *parsed = [NSJSONSerialization JSONObjectWithData:[json dataUsingEncoding:NSUTF8StringEncoding]
+                                                              options:0
+                                                                error:&error];
+        XCTAssertNil(error, @"test payload must be valid JSON");
+        XCTAssertNotNil(parsed);
+
+        configuration = [[NRMAHarvesterConfiguration alloc] initWithDictionary:parsed];
+    }
+
+    return configuration;
+}
+
+- (NSString *) fullCollectorPayload
+{
+    return @"{"
+            "\"application_token\":\"AA1234567890abcdef\","
+            "\"data_token\":[1234,5678],"
+            "\"account_id\":190,"
+            "\"cross_process_id\":\"12345#67890\","
+            "\"encoding_key\":\"d67afc830dab717fd163bfcb0b8b88423e9a1a3b\","
+            "\"entity_guid\":\"MTAxfEFQTXxBUFB8MQ\","
+            "\"trusted_account_key\":\"190\","
+            "\"request_headers_map\":{\"X-Trace-Id\":\"abc123\",\"X-Tenant\":\"au\"},"
+            "\"configuration\":{"
+                "\"logs\":{\"enabled\":true,\"level\":\"DEBUG\",\"sampling_rate\":100},"
+                "\"session_replay\":{\"enabled\":true,\"mode\":\"custom\",\"sampling_rate\":50,\"error_sampling_rate\":25}"
+            "}"
+            "}";
+}
+
+#pragma mark - Lifetime
+
+// The core regression test: the exact read that crashed, performed after the pool drain.
+- (void) testCollectorConfigurationOutlivesItsParseDictionary
+{
+    NRMAHarvesterConfiguration *configuration = [self configurationFromJSON:[self fullCollectorPayload]];
+    XCTAssertNotNil(configuration);
+
+    // -[NRMAHarvester configureHarvester:] reads request_header_map here.
+    XCTAssertEqualObjects(configuration.request_header_map[@"X-Trace-Id"], @"abc123");
+    XCTAssertEqualObjects(configuration.request_header_map[@"X-Tenant"], @"au");
+    XCTAssertEqual(configuration.request_header_map.count, 2u);
+
+    // -[NRMAHarvester connected] reads log_reporting_level on every harvest cycle.
+    XCTAssertEqualObjects(configuration.log_reporting_level, @"DEBUG");
+
+    // ViewDetails.swift reads session_replay_mode on every captured view.
+    XCTAssertEqualObjects(configuration.session_replay_mode, @"custom");
+
+    XCTAssertEqualObjects(configuration.encoding_key, @"d67afc830dab717fd163bfcb0b8b88423e9a1a3b");
+}
+
+// The stored-configuration path: NSUserDefaults hands back an autoreleased graph, and the
+// config built from it is retained across harvest cycles by -[NRMAHarvester init].
+- (void) testStoredConfigurationOutlivesItsUserDefaultsDictionary
+{
+    NSString *key = @"com.newrelic.tests.harvesterConfigurationLifetime";
+    NRMAHarvesterConfiguration *configuration = nil;
+
+    @autoreleasepool {
+        NRMAHarvesterConfiguration *source = [self configurationFromJSON:[self fullCollectorPayload]];
+        [[NSUserDefaults standardUserDefaults] setObject:[source asDictionary] forKey:key];
+    }
+
+    @autoreleasepool {
+        id stored = [[NSUserDefaults standardUserDefaults] objectForKey:key];
+        XCTAssertTrue([stored isKindOfClass:[NSDictionary class]]);
+        configuration = [[NRMAHarvesterConfiguration alloc] initWithDictionary:(NSDictionary *)stored];
+    }
+
+    XCTAssertEqualObjects(configuration.request_header_map[@"X-Trace-Id"], @"abc123");
+    XCTAssertEqualObjects(configuration.log_reporting_level, @"DEBUG");
+    XCTAssertEqualObjects(configuration.session_replay_mode, @"custom");
+    XCTAssertEqualObjects(configuration.encoding_key, @"d67afc830dab717fd163bfcb0b8b88423e9a1a3b");
+
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
+}
+
+// SessionReplayCustomMaskingRule had the same four unretained properties, and its rules
+// are held for the whole session in session_replay_customRules.
+- (void) testCustomMaskingRulesOutliveTheirParseDictionary
+{
+    NRMAHarvesterConfiguration *configuration = [self configurationFromJSON:
+        @"{"
+         "\"data_token\":[1234,5678],"
+         "\"account_id\":190,"
+         "\"configuration\":{\"session_replay\":{\"enabled\":true,\"mode\":\"custom\","
+             "\"custom_masking_rules\":["
+                 "{\"identifier\":\"tag\",\"name\":[\"password_field\"],\"operator\":\"equals\",\"type\":\"mask\"}"
+             "]}}"
+         "}"];
+    XCTAssertNotNil(configuration);
+
+    XCTAssertEqual(configuration.session_replay_customRules.count, 1u);
+    SessionReplayCustomMaskingRule *rule = configuration.session_replay_customRules.firstObject;
+    XCTAssertNotNil(rule);
+
+    XCTAssertEqualObjects(rule.identifier, @"tag");
+    XCTAssertEqualObjects(rule.type, @"mask");
+    XCTAssertEqualObjects(rule.operatorName, @"equals");
+    XCTAssertEqualObjects(rule.name, (@[@"password_field"]));
+}
+
+// A `copy` property must snapshot, not alias: mutating the caller's container afterwards
+// must not change what the configuration reports.
+- (void) testRequestHeaderMapIsSnapshotNotAliased
+{
+    NRMAHarvesterConfiguration *configuration = [[NRMAHarvesterConfiguration alloc] init];
+
+    NSMutableDictionary *headers = [NSMutableDictionary dictionaryWithObject:@"abc123" forKey:@"X-Trace-Id"];
+    configuration.request_header_map = headers;
+    [headers setObject:@"leaked" forKey:@"X-Added-Later"];
+
+    XCTAssertEqual(configuration.request_header_map.count, 1u);
+    XCTAssertNil(configuration.request_header_map[@"X-Added-Later"]);
+}
+
+#pragma mark - Comparison correctness
+
+// request_header_map equality was a raw pointer comparison, so two configurations
+// carrying identical headers compared unequal and forced needless reconnects.
+- (void) testConfigurationsWithEqualHeaderMapsAreEqual
+{
+    NRMAHarvesterConfiguration *a = [self configurationFromJSON:[self fullCollectorPayload]];
+    NRMAHarvesterConfiguration *b = [self configurationFromJSON:[self fullCollectorPayload]];
+
+    XCTAssertNotEqual(a.request_header_map, b.request_header_map, @"must be distinct objects for this test to mean anything");
+    XCTAssertEqualObjects(a, b);
+    XCTAssertEqual(a.hash, b.hash);
+}
+
+// NOTE: a separate, unfixed defect lives next to this one. In -initWithDictionary: the
+// default-masking override is gated on `self.session_replay_mode == SessionReplayMaskingModeDefault`,
+// a raw pointer comparison. SessionReplayMaskingModeDefault is a `static const` in a header,
+// so each Mach-O image gets its own @"default" instance, and a collector-supplied "default"
+// is a freshly parsed string either way -- the comparison is therefore never true in practice
+// and the documented default masking booleans never apply. It is deliberately NOT fixed here:
+// the override forces session_replay_maskAllUserTouches to NO, so correcting the comparison
+// would *reduce* masking and unmask user touches that are masked today. That needs product
+// review on its own, not a ride-along with a crash fix.
+
+@end

--- a/scripts/lib_patch_xctestrun.py
+++ b/scripts/lib_patch_xctestrun.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Inject environment variables into every test target in an .xctestrun file.
+
+Xcode's scheme "Diagnostics" checkboxes are not serialized in a form that
+`xcodebuild build-for-testing` bakes into the .xctestrun, so setting zombies via a
+scheme is unreliable. Patching the .xctestrun is explicit and verifiable: the file is
+the complete launch spec that `test-without-building` consumes.
+
+Handles both the legacy layout (test target names as top-level keys) and the newer
+TestConfigurations layout.
+"""
+import plistlib
+import sys
+
+
+def targets(doc):
+    """Yield every test-target dict in either xctestrun layout."""
+    if "TestConfigurations" in doc:
+        for config in doc.get("TestConfigurations") or []:
+            for target in config.get("TestTargets") or []:
+                yield target
+        return
+    for key, value in doc.items():
+        if key.startswith("__"):
+            continue
+        if isinstance(value, dict):
+            yield value
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("usage: lib_patch_xctestrun.py <file.xctestrun> KEY=VALUE [KEY=VALUE ...]",
+              file=sys.stderr)
+        return 2
+
+    path = sys.argv[1]
+    env = {}
+    for pair in sys.argv[2:]:
+        key, _, value = pair.partition("=")
+        env[key] = value
+
+    with open(path, "rb") as handle:
+        doc = plistlib.load(handle)
+
+    patched = 0
+    for target in targets(doc):
+        existing = target.get("EnvironmentVariables")
+        if not isinstance(existing, dict):
+            existing = {}
+        existing.update(env)
+        target["EnvironmentVariables"] = existing
+        patched += 1
+
+    if patched == 0:
+        print("error: no test targets found in %s" % path, file=sys.stderr)
+        return 1
+
+    with open(path, "wb") as handle:
+        plistlib.dump(doc, handle)
+
+    print("patched %d test target(s) with: %s" % (patched, " ".join(sorted(env))))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_memory_safety_tests.sh
+++ b/scripts/run_memory_safety_tests.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+#
+# Run the agent's unit tests with memory-safety diagnostics enabled, so that
+# use-after-free bugs fail loudly instead of silently reading recycled memory.
+#
+# Two modes:
+#   zombies (default)  NSZombieEnabled + MallocScribble + friends. Cheap. A stale pointer
+#                      traps with "message sent to deallocated instance", naming the type
+#                      of the object that was already freed.
+#   asan               AddressSanitizer. Slower and needs its own instrumented build, but
+#                      reports the allocating *and* freeing stacks - what you want once you
+#                      know a UAF exists and need to find who released the object.
+#
+# The diagnostics are injected as environment variables into the .xctestrun produced by
+# build-for-testing. That file is the complete launch spec consumed by
+# test-without-building, which makes this explicit and verifiable -- unlike a scheme's
+# Diagnostics checkboxes, which are not reliably baked into the .xctestrun.
+#
+# See Tests/MEMORY-SAFETY.md.
+
+set -uo pipefail
+
+WORKSPACE="Agent.xcworkspace"
+SCHEME="Agent-iOS"
+TEST_TARGET="Agent_Tests"
+DERIVED_DATA="build/memory-safety"
+
+# The memory-safety suite: the classes that exercise object lifetime across
+# autorelease-pool and harvest-cycle boundaries, which is where the agent has historically
+# shipped use-after-free bugs. Keep in sync with Tests/MEMORY-SAFETY.md.
+#
+# Deliberately excluded: NRMAHarvesterConnectionTests. Its -testSendData issues a real,
+# unmocked request to mobile-collector.newrelic.com and asserts a 403, so it fails with
+# statusCode 0 whenever the network is unavailable. This suite is meant to be a
+# deterministic gate on memory safety; it must not go red because of a live HTTP call.
+# Run it with --only when you specifically want it.
+SUITE=(
+  "NRMAHarvesterConfigurationLifetimeTests"
+  "NRMAHarvesterTest"
+  "NRMAHarvestControllerTest"
+  "NRMAHarvesterStateTest"
+  "NRMAConnectionTest"
+  "SessionReplayTest"
+)
+
+# Zombie-mode diagnostics.
+#   NSZombieEnabled                     deallocated objects become trapping zombies
+#   NSDeallocateZombies                 keep the zombies around rather than freeing them
+#   MallocScribble                      fill freed memory with 0x55
+#   MallocPreScribble                   fill freshly allocated memory with 0xAA
+#   MallocGuardEdges                    guard pages around large allocations
+#   NSAutoreleaseFreedObjectCheckEnabled  catch autoreleasing an already-freed object
+DIAGNOSTICS=(
+  "NSZombieEnabled=YES"
+  "NSDeallocateZombies=NO"
+  "MallocScribble=1"
+  "MallocPreScribble=1"
+  "MallocGuardEdges=1"
+  "NSAutoreleaseFreedObjectCheckEnabled=1"
+)
+
+MODE="zombies"
+SIMULATOR=""
+RUN_ALL=0
+NO_BUILD=0
+STACKS=0
+ONLY=()
+
+usage() {
+  cat <<USAGE
+usage: scripts/run_memory_safety_tests.sh [options]
+
+  --asan                Run under AddressSanitizer instead of zombies/scribble.
+  --all                 Run the whole ${TEST_TARGET} target, not just the curated suite.
+  --only <Class[/test]> Run one class or one test. Repeatable. Overrides the suite.
+  --stacks              Also set MallocStackLogging, so malloc_history can resolve a
+                        zombie address to its allocation stack. Slow; for debugging.
+  --simulator <id>      Simulator name or UDID. Default: a booted iPhone, else the newest
+                        available iPhone.
+  --derived-data <path> Default: ${DERIVED_DATA}
+  --no-build            Reuse an existing build (skip build-for-testing).
+  --list                Print the suite and exit.
+  -h, --help            This message.
+
+examples:
+  scripts/run_memory_safety_tests.sh
+  scripts/run_memory_safety_tests.sh --only NRMAHarvesterConfigurationLifetimeTests
+  scripts/run_memory_safety_tests.sh --asan --all
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --asan)          MODE="asan"; shift ;;
+    --all)           RUN_ALL=1; shift ;;
+    --only)          ONLY+=("$2"); shift 2 ;;
+    --stacks)        STACKS=1; shift ;;
+    --simulator)     SIMULATOR="$2"; shift 2 ;;
+    --derived-data)  DERIVED_DATA="$2"; shift 2 ;;
+    --no-build)      NO_BUILD=1; shift ;;
+    --list)          printf '%s\n' "${SUITE[@]}"; exit 0 ;;
+    -h|--help)       usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+cd "$(dirname "$0")/.." || exit 1
+[[ -d "$WORKSPACE" ]] || { echo "error: $WORKSPACE not found" >&2; exit 1; }
+
+if [[ $STACKS -eq 1 ]]; then
+  DIAGNOSTICS+=("MallocStackLogging=1" "MallocStackLoggingNoCompact=1")
+fi
+
+# ---- simulator: prefer one already booted so repeat runs skip the boot cost -----------
+if [[ -z "$SIMULATOR" ]]; then
+  SIMULATOR=$(xcrun simctl list devices available -j 2>/dev/null | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+booted, avail = [], []
+for runtime, devices in data.get("devices", {}).items():
+    if "iOS" not in runtime:
+        continue
+    for d in devices:
+        if d.get("isAvailable") and "iPhone" in d.get("name", ""):
+            (booted if d.get("state") == "Booted" else avail).append((runtime, d))
+pick = sorted(booted, key=lambda i: i[0])[-1:] or sorted(avail, key=lambda i: i[0])[-1:]
+if pick:
+    print(pick[0][1]["udid"])
+')
+fi
+[[ -n "$SIMULATOR" ]] || { echo "error: no iOS simulator found; pass --simulator" >&2; exit 1; }
+
+if [[ "$SIMULATOR" =~ ^[0-9A-Fa-f-]{36}$ ]]; then
+  DESTINATION="platform=iOS Simulator,id=${SIMULATOR}"
+else
+  DESTINATION="platform=iOS Simulator,name=${SIMULATOR}"
+fi
+
+# ---- scope ---------------------------------------------------------------------------
+TEST_ARGS=()
+if [[ ${#ONLY[@]} -gt 0 ]]; then
+  for t in "${ONLY[@]}"; do
+    [[ "$t" == *"/"* && "$t" != "${TEST_TARGET}/"* ]] && t="${TEST_TARGET}/${t}"
+    [[ "$t" != *"/"* ]] && t="${TEST_TARGET}/${t}"
+    TEST_ARGS+=("-only-testing:$t")
+  done
+elif [[ $RUN_ALL -eq 0 ]]; then
+  for t in "${SUITE[@]}"; do TEST_ARGS+=("-only-testing:${TEST_TARGET}/${t}"); done
+fi
+
+SANITIZER_ARGS=()
+[[ "$MODE" == "asan" ]] && SANITIZER_ARGS+=("-enableAddressSanitizer" "YES")
+
+mkdir -p "$DERIVED_DATA"
+LOG="${DERIVED_DATA}/memory-safety-$(date +%Y%m%d-%H%M%S).log"
+
+echo "mode:        $MODE"
+echo "destination: $DESTINATION"
+if [[ ${#TEST_ARGS[@]} -eq 0 ]]; then
+  echo "scope:       entire ${TEST_TARGET} target"
+else
+  echo "scope:       ${#TEST_ARGS[@]} selection(s)"
+fi
+echo "log:         $LOG"
+echo
+
+# ---- build ---------------------------------------------------------------------------
+if [[ $NO_BUILD -eq 0 ]]; then
+  echo "==> building for testing"
+  xcodebuild build-for-testing \
+    -workspace "$WORKSPACE" -scheme "$SCHEME" \
+    -destination "$DESTINATION" -derivedDataPath "$DERIVED_DATA" \
+    ${SANITIZER_ARGS[@]+"${SANITIZER_ARGS[@]}"} 2>&1 | tee -a "$LOG" \
+    | grep -E "error:|\*\* .* (SUCCEEDED|FAILED)"
+  BUILD_RC=${PIPESTATUS[0]}
+  if [[ $BUILD_RC -ne 0 ]]; then
+    echo "FAILED: build-for-testing exited $BUILD_RC (see $LOG)" >&2
+    exit $BUILD_RC
+  fi
+fi
+
+XCTESTRUN=$(ls -t "${DERIVED_DATA}/Build/Products/"*.xctestrun 2>/dev/null | head -1)
+if [[ -z "$XCTESTRUN" ]]; then
+  echo "FAILED: no .xctestrun in ${DERIVED_DATA}/Build/Products (build first)" >&2
+  exit 1
+fi
+
+# ---- inject diagnostics --------------------------------------------------------------
+# ASan is a build-time instrumentation, so it needs no env injection.
+if [[ "$MODE" == "zombies" ]]; then
+  echo "==> enabling diagnostics in $(basename "$XCTESTRUN")"
+  python3 scripts/lib_patch_xctestrun.py "$XCTESTRUN" \
+    ${DIAGNOSTICS[@]+"${DIAGNOSTICS[@]}"} | tee -a "$LOG"
+  PATCH_RC=${PIPESTATUS[0]}
+  if [[ $PATCH_RC -ne 0 ]]; then
+    echo "FAILED: could not patch $XCTESTRUN" >&2
+    exit 1
+  fi
+fi
+
+# ---- run -----------------------------------------------------------------------------
+echo
+echo "==> running tests"
+xcodebuild test-without-building -xctestrun "$XCTESTRUN" \
+  -destination "$DESTINATION" \
+  ${SANITIZER_ARGS[@]+"${SANITIZER_ARGS[@]}"} \
+  ${TEST_ARGS[@]+"${TEST_ARGS[@]}"} 2>&1 | tee -a "$LOG" \
+  | grep -E "Test Case .*(passed|failed)|error:|message sent to deallocated instance|AddressSanitizer|Executed [0-9]+ test|\*\* TEST"
+TEST_RC=${PIPESTATUS[0]}
+
+# ---- verdict -------------------------------------------------------------------------
+# A zombie trap kills the test process, so xcodebuild can report "Executed 0 tests, with 0
+# failures" for the very run that found the bug. Never trust the summary line alone.
+count() { local n; n=$(grep -c "$1" "$LOG" 2>/dev/null | tr -d ' '); echo "${n:-0}"; }
+ZOMBIES=$(count "message sent to deallocated instance")
+ASAN=$(count "ERROR: AddressSanitizer")
+CRASHES=$(count "Restarting after unexpected exit")
+
+echo
+echo "================ memory safety summary ================"
+printf 'mode:                             %s\n' "$MODE"
+printf 'zombie messages (use-after-free): %s\n' "$ZOMBIES"
+printf 'AddressSanitizer reports:         %s\n' "$ASAN"
+printf 'unexpected process exits:         %s\n' "$CRASHES"
+printf 'xcodebuild exit code:             %s\n' "$TEST_RC"
+
+if [[ "$ZOMBIES" -gt 0 ]]; then
+  echo
+  echo "--- use-after-free detected ---"
+  grep "message sent to deallocated instance" "$LOG" | sed 's/^/  /' | sort -u
+  echo
+  echo "The class named above is the type of the object that was already freed. Look for a"
+  echo "property declared 'assign'/'unsafe_unretained' of that type, or a raw pointer kept"
+  echo "past the lifetime of whatever owned it."
+fi
+
+if [[ "$ASAN" -gt 0 ]]; then
+  echo
+  echo "--- AddressSanitizer ---"
+  grep -A 25 "ERROR: AddressSanitizer" "$LOG" | sed 's/^/  /' | head -60
+fi
+
+if [[ "$CRASHES" -gt 0 && "$ZOMBIES" -eq 0 && "$ASAN" -eq 0 ]]; then
+  echo
+  echo "NOTE: the test process died with no zombie or ASan report. That is still a real"
+  echo "failure - it usually means memory was corrupted rather than merely stale. Re-run"
+  echo "with --asan for allocation and free stacks."
+fi
+
+echo "full log: $LOG"
+echo "======================================================="
+
+if [[ $TEST_RC -ne 0 || "$ZOMBIES" -gt 0 || "$ASAN" -gt 0 || "$CRASHES" -gt 0 ]]; then
+  echo "RESULT: FAIL"
+  exit 1
+fi
+echo "RESULT: PASS"


### PR DESCRIPTION
Root cause

NRMAHarvesterConfiguration declared eight object-typed properties as assign. Under ARC (both files compile with ARC — neither carries -fno-objc-arc) that means unsafe_unretained. initWithDictionary: pointed them straight into the autoreleased dictionary it was parsing — either the NRMAJSON graph from configureFromCollector: or the [NSUserDefaults objectForKey:] graph from fetchHarvestConfiguration. The configuration object itself is held in a strong ivar that long outlives that pool, so every later read was a use-after-free, surfacing as SIGSEGV in objc_msgSend.

The prior fix (#742) couldn't work: its [rawHeaders isKindOfClass:] guard is an objc_msgSend on the dangling pointer, and @catch cannot catch a SIGSEGV. That's why the crash survived 7.7.2 → 7.7.6, drifting from :549 to :678.

Changes

- NRMAHarvesterConfiguration.h — the eight properties assign → copy (encoding_key, request_header_map, log_reporting_level, session_replay_mode, and SessionReplayCustomMaskingRule's identifier/name/operatorName/type). session_replay_mode is now also typed as its real SessionReplayMaskingMode, which the Swift consumers in ViewDetails.swift require once ownership changes.
- NRMAHarvester.mm — removed the dead request_header_map workaround in configureHarvester:; corrected the misleading comment on the transitionToConnected: guard (I kept the guard — it provides real nil-safety when configureFromCollector: returns nil).
- NRMAHarvesterConfiguration.m — isEqual: compared application_token and request_header_map by raw pointer. application_token is the first check, so it short-circuited everything after it and left config-change detection permanently reporting "changed".
- NRMADeviceInformation.h — platformVersion was the identical assign NSString* defect.
- New NRMAHarvesterConfigurationLifetimeTests.m, registered in all three test targets.

Verification (zombies + MallocScribble via the .xctestrun, not the shared scheme)

Before, each test crashed the xctest process — note the PID changing as the runner relaunched:

testCollectorConfigurationOutlivesItsParseDictionary
  *** -[__NSDictionaryI retain]: message sent to deallocated instance 0x10656f2c0
testCustomMaskingRulesOutliveTheirParseDictionary
  *** -[__NSSingleObjectArrayI retain]: message sent to deallocated instance 0x101afcd70
testStoredConfigurationOutlivesItsUserDefaultsDictionary
  *** -[CFString retain]: message sent to deallocated instance 0x10bd58840
** TEST EXECUTE FAILED **

After: 74 tests, 0 failures — my 5 plus the existing Harvester, HarvestController, HarvesterState, HarvesterConnection, Connection, and SessionReplay suites.