### PR TITLE
NR-614312 Stop a low-memory recordError from killing the host app

### DIFF
--- a/Agent/HandledException/NRMAHandledExceptions.mm
+++ b/Agent/HandledException/NRMAHandledExceptions.mm
@@ -17,6 +17,7 @@
 #import "NRMAHarvestController.h"
 #import "NRMAAppToken.h"
 #include <execinfo.h>
+#include <exception>
 #import "NRMAFlags.h"
 #include <Analytics/AnalyticsController.hpp>
 #import "NRMABool.h"
@@ -33,6 +34,17 @@
 @end
 
 const NSString* kHexBackupStoreFolder = @"hexbkup/";
+
+// The unguarded bodies of the three public record* entry points. Every public
+// entry point wraps its counterpart here in the crash boundary below; nothing
+// else should call these directly.
+@interface NRMAHandledExceptions (CrashBoundary)
+- (void) nrma_recordErrorUnguarded:(NSError* _Nonnull)error
+                        attributes:(NSDictionary* _Nullable)attributes;
+- (void) nrma_recordHandledExceptionUnguarded:(NSException*)exception
+                                   attributes:(NSDictionary*)attributes;
+- (void) nrma_recordHandledExceptionWithStackTraceUnguarded:(NSDictionary*)exceptionDictionary;
+@end
 
 @implementation NRMAHandledExceptions {
     NewRelic::Hex::HexController* _controller;
@@ -201,8 +213,60 @@ const NSString* kHexBackupStoreFolder = @"hexbkup/";
     }
 }
 
+// MARK: - Crash boundary
+//
+// Everything under the record* entry points is C++ that allocates: createReport(),
+// the attribute maps, and the flatbuffer serialization inside HexStore::store().
+// When the device is low on memory any of those allocations can throw
+// std::bad_alloc, and a malformed report makes HexReport::finalize() throw
+// std::invalid_argument. None of it used to be caught, so the throw unwound
+// straight out through this Objective-C frame with no handler above it —
+// std::terminate -> __cxa_call_terminate -> the host app is killed.
+//
+// Instrumentation must never be able to kill the app it is watching. Guarding
+// here rather than inside HexController::submit() is deliberate: the throw can
+// originate in createReport() and in the attribute plumbing, both of which run
+// before submit() is reached. On failure the report is dropped and we return.
+//
+// See GitHub issue #884 / NR-614312.
+
 - (void) recordError:(NSError * _Nonnull)error
           attributes:(NSDictionary* _Nullable)attributes
+{
+    try {
+        [self nrma_recordErrorUnguarded:error attributes:attributes];
+    } catch (const std::exception& e) {
+        NRLOG_AGENT_ERROR(@"Dropped handled error report for domain \"%@\": %s", error.domain, e.what());
+    } catch (...) {
+        NRLOG_AGENT_ERROR(@"Dropped handled error report for domain \"%@\": unknown C++ exception", error.domain);
+    }
+}
+
+- (void) recordHandledException:(NSException*)exception
+                     attributes:(NSDictionary*)attributes
+{
+    try {
+        [self nrma_recordHandledExceptionUnguarded:exception attributes:attributes];
+    } catch (const std::exception& e) {
+        NRLOG_AGENT_ERROR(@"Dropped handled exception report \"%@\": %s", exception.name, e.what());
+    } catch (...) {
+        NRLOG_AGENT_ERROR(@"Dropped handled exception report \"%@\": unknown C++ exception", exception.name);
+    }
+}
+
+- (void) recordHandledExceptionWithStackTrace:(NSDictionary*)exceptionDictionary
+{
+    try {
+        [self nrma_recordHandledExceptionWithStackTraceUnguarded:exceptionDictionary];
+    } catch (const std::exception& e) {
+        NRLOG_AGENT_ERROR(@"Dropped handled exception report with stack trace: %s", e.what());
+    } catch (...) {
+        NRLOG_AGENT_ERROR(@"Dropped handled exception report with stack trace: unknown C++ exception");
+    }
+}
+
+- (void) nrma_recordErrorUnguarded:(NSError * _Nonnull)error
+                        attributes:(NSDictionary* _Nullable)attributes
 {
     void* callstack[1024];
     int frames = backtrace(callstack,1024);
@@ -253,8 +317,8 @@ const NSString* kHexBackupStoreFolder = @"hexbkup/";
     }
 }
 
-- (void) recordHandledException:(NSException*)exception
-                     attributes:(NSDictionary*)attributes {
+- (void) nrma_recordHandledExceptionUnguarded:(NSException*)exception
+                                   attributes:(NSDictionary*)attributes {
     if (exception == nil) {
         NRLOG_AGENT_ERROR(@"Ignoring nil exception.");
         return;
@@ -364,7 +428,7 @@ const NSString* kHexBackupStoreFolder = @"hexbkup/";
     });
 }
 
-- (void) recordHandledExceptionWithStackTrace:(NSDictionary*)exceptionDictionary {
+- (void) nrma_recordHandledExceptionWithStackTraceUnguarded:(NSDictionary*)exceptionDictionary {
 
     NSString* eName = exceptionDictionary[@"name"];
     NSString* eReason = exceptionDictionary[@"reason"];

--- a/Agent/HandledException/NRMAHandledExceptions.mm
+++ b/Agent/HandledException/NRMAHandledExceptions.mm
@@ -17,6 +17,7 @@
 #import "NRMAHarvestController.h"
 #import "NRMAAppToken.h"
 #include <execinfo.h>
+#include <exception>
 #import "NRMAFlags.h"
 #include <Analytics/AnalyticsController.hpp>
 #import "NRMABool.h"
@@ -33,6 +34,17 @@
 @end
 
 const NSString* kHexBackupStoreFolder = @"hexbkup/";
+
+// The unguarded bodies of the three public record* entry points. Every public
+// entry point wraps its counterpart here in the crash boundary below; nothing
+// else should call these directly.
+@interface NRMAHandledExceptions (CrashBoundary)
+- (void) nrma_recordErrorUnguarded:(NSError* _Nonnull)error
+                        attributes:(NSDictionary* _Nullable)attributes;
+- (void) nrma_recordHandledExceptionUnguarded:(NSException*)exception
+                                   attributes:(NSDictionary*)attributes;
+- (void) nrma_recordHandledExceptionWithStackTraceUnguarded:(NSDictionary*)exceptionDictionary;
+@end
 
 @implementation NRMAHandledExceptions {
     NewRelic::Hex::HexController* _controller;
@@ -201,8 +213,73 @@ const NSString* kHexBackupStoreFolder = @"hexbkup/";
     }
 }
 
+// MARK: - Crash boundary
+//
+// Everything under the record* entry points is C++ that allocates: createReport(),
+// the attribute maps, and the flatbuffer serialization inside HexStore::store().
+// When the device is low on memory any of those allocations can throw
+// std::bad_alloc, and a malformed report makes HexReport::finalize() throw
+// std::invalid_argument. None of it used to be caught, so the throw unwound
+// straight out through this Objective-C frame with no handler above it —
+// std::terminate -> __cxa_call_terminate -> the host app is killed.
+//
+// Instrumentation must never be able to kill the app it is watching. Guarding
+// here rather than inside HexController::submit() is deliberate: the throw can
+// originate in createReport() and in the attribute plumbing, both of which run
+// before submit() is reached. On failure the report is dropped and we return.
+//
+// Only C++ exceptions are absorbed. Objective-C exceptions are re-thrown, because
+// they mean API misuse rather than a resource failure — the canonical case is an
+// NSError whose localizedDescription is not a string, where -UTF8String raises
+// NSInvalidArgumentException. Swallowing that would hide a caller's bug, and
+// TestHandledExceptionController asserts it still propagates. The explicit
+// catch (id) is required: in Objective-C++ a bare catch (...) also catches @throw.
+//
+// See GitHub issue #884 / NR-614312.
+
 - (void) recordError:(NSError * _Nonnull)error
           attributes:(NSDictionary* _Nullable)attributes
+{
+    try {
+        [self nrma_recordErrorUnguarded:error attributes:attributes];
+    } catch (id objcException) {
+        @throw objcException;   // API misuse — not ours to swallow
+    } catch (const std::exception& e) {
+        NRLOG_AGENT_ERROR(@"Dropped handled error report for domain \"%@\": %s", error.domain, e.what());
+    } catch (...) {
+        NRLOG_AGENT_ERROR(@"Dropped handled error report for domain \"%@\": unknown C++ exception", error.domain);
+    }
+}
+
+- (void) recordHandledException:(NSException*)exception
+                     attributes:(NSDictionary*)attributes
+{
+    try {
+        [self nrma_recordHandledExceptionUnguarded:exception attributes:attributes];
+    } catch (id objcException) {
+        @throw objcException;   // API misuse — not ours to swallow
+    } catch (const std::exception& e) {
+        NRLOG_AGENT_ERROR(@"Dropped handled exception report \"%@\": %s", exception.name, e.what());
+    } catch (...) {
+        NRLOG_AGENT_ERROR(@"Dropped handled exception report \"%@\": unknown C++ exception", exception.name);
+    }
+}
+
+- (void) recordHandledExceptionWithStackTrace:(NSDictionary*)exceptionDictionary
+{
+    try {
+        [self nrma_recordHandledExceptionWithStackTraceUnguarded:exceptionDictionary];
+    } catch (id objcException) {
+        @throw objcException;   // API misuse — not ours to swallow
+    } catch (const std::exception& e) {
+        NRLOG_AGENT_ERROR(@"Dropped handled exception report with stack trace: %s", e.what());
+    } catch (...) {
+        NRLOG_AGENT_ERROR(@"Dropped handled exception report with stack trace: unknown C++ exception");
+    }
+}
+
+- (void) nrma_recordErrorUnguarded:(NSError * _Nonnull)error
+                        attributes:(NSDictionary* _Nullable)attributes
 {
     void* callstack[1024];
     int frames = backtrace(callstack,1024);
@@ -253,8 +330,8 @@ const NSString* kHexBackupStoreFolder = @"hexbkup/";
     }
 }
 
-- (void) recordHandledException:(NSException*)exception
-                     attributes:(NSDictionary*)attributes {
+- (void) nrma_recordHandledExceptionUnguarded:(NSException*)exception
+                                   attributes:(NSDictionary*)attributes {
     if (exception == nil) {
         NRLOG_AGENT_ERROR(@"Ignoring nil exception.");
         return;
@@ -364,7 +441,7 @@ const NSString* kHexBackupStoreFolder = @"hexbkup/";
     });
 }
 
-- (void) recordHandledExceptionWithStackTrace:(NSDictionary*)exceptionDictionary {
+- (void) nrma_recordHandledExceptionWithStackTraceUnguarded:(NSDictionary*)exceptionDictionary {
 
     NSString* eName = exceptionDictionary[@"name"];
     NSString* eReason = exceptionDictionary[@"reason"];

--- a/Test Harness/NRTestApp/NRTestApp/AppDelegate+UITest.swift
+++ b/Test Harness/NRTestApp/NRTestApp/AppDelegate+UITest.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import CoreData
+import NewRelic
 
 extension AppDelegate {
     func clearConnectUserDefaults() {
@@ -51,6 +52,70 @@ extension AppDelegate {
             NSLog("[NRTestApp] CoreDataRepro: nested re-entrant fetch -> \(nestedCount) results (survived)")
 
             NSLog("[NRTestApp] CoreDataRepro: DONE — app survived the executeFetchRequest:error: instrumentation path")
+        }
+    }
+
+    // Headless driver for GitHub issue #884 / NR-614312: the reporter's suggested
+    // repro -- "call recordError in a tight loop ... while the device is nearly out
+    // of memory, so that the allocations inside HexStore::store and
+    // HandledException::serialize start failing."
+    //
+    // Normally driven by scripts/run_oom_resilience_tests.sh, which pairs this loop
+    // with the operator-new injector in Tests/OOM-Resilience/oom_injector.cxx. By hand:
+    //
+    //   SIMCTL_CHILD_DYLD_INSERT_LIBRARIES=<path>/liboominject.dylib \
+    //   SIMCTL_CHILD_NR_OOM_ONE_IN=1000 SIMCTL_CHILD_NR_OOM_DELAY=12 \
+    //   xcrun simctl launch --console <sim> com.newrelic.NRApp.bitcode \
+    //       -RunHexOOMRepro -HexOOMIterations 20000 -HexOOMStartDelay 16
+    //
+    // Prints "DONE" with a count if the process survives. -HexOOMBallastMB additionally
+    // pins N MiB resident first; that alone will not make a simulator's malloc fail
+    // (see Tests/OOM-RESILIENCE.md), so it is off by default.
+    func runHexOOMReproIfRequested() {
+        guard ProcessInfo.processInfo.arguments.contains("-RunHexOOMRepro") else { return }
+
+        let args = ProcessInfo.processInfo.arguments
+        func intArg(_ name: String, _ fallback: Int) -> Int {
+            guard let i = args.firstIndex(of: name), i + 1 < args.count,
+                  let v = Int(args[i + 1]) else { return fallback }
+            return v
+        }
+        let iterations = intArg("-HexOOMIterations", 20000)
+        let ballastMB  = intArg("-HexOOMBallastMB", 0)
+        // Delay the loop so the DYLD_INSERT_LIBRARIES OOM injector (if used) has
+        // armed itself first, and so agent startup runs on a healthy heap.
+        let startDelay = Double(intArg("-HexOOMStartDelay", 1))
+
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + startDelay) {
+            // The OOM injector only fails allocations on this thread name, so that the
+            // agent's harvest/upload threads are not dragged into the test. Must match
+            // NR_OOM_THREAD in Tests/OOM-Resilience/oom_injector.cxx.
+            pthread_setname_np("nr-oom-loop")
+
+            var ballast: [UnsafeMutableRawPointer] = []
+            if ballastMB > 0 {
+                NSLog("[NRTestApp] HexOOMRepro: allocating \(ballastMB) MiB of ballast to squeeze the heap")
+                for _ in 0..<ballastMB {
+                    let sz = 1 << 20
+                    guard let p = malloc(sz) else {
+                        NSLog("[NRTestApp] HexOOMRepro: malloc returned NULL after \(ballast.count) MiB")
+                        break
+                    }
+                    memset(p, 0xA5, sz)   // touch it so it is really resident
+                    ballast.append(p)
+                }
+                NSLog("[NRTestApp] HexOOMRepro: ballast resident = \(ballast.count) MiB")
+            }
+
+            NSLog("[NRTestApp] HexOOMRepro: starting tight recordError loop, \(iterations) iterations")
+            let err = NSError(domain: "PlatformException", code: 1,
+                              userInfo: [NSLocalizedDescriptionKey: "Flutter recordError"])
+            for i in 0..<iterations {
+                NewRelic.recordError(err, attributes: ["id": i])
+                if i % 2000 == 0 { NSLog("[NRTestApp] HexOOMRepro: \(i) recordError calls survived") }
+            }
+            NSLog("[NRTestApp] HexOOMRepro: DONE — survived \(iterations) recordError calls")
+            for p in ballast { free(p) }
         }
     }
 }

--- a/Test Harness/NRTestApp/NRTestApp/AppDelegate.swift
+++ b/Test Harness/NRTestApp/NRTestApp/AppDelegate.swift
@@ -99,6 +99,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         NewRelic.logVerbose("NewRelic.start was called.")
 
         runCoreDataCrashReproIfRequested()
+        runHexOOMReproIfRequested()
 
         return true
     }

--- a/Tests/OOM-RESILIENCE.md
+++ b/Tests/OOM-RESILIENCE.md
@@ -1,0 +1,184 @@
+# Handled-exception OOM-resilience tests
+
+Recording a handled error must never be able to kill the app that is being watched.
+Everything under `-[NRMAHandledExceptions recordError:attributes:]` is C++ that
+allocates — the report object, the attribute maps, and the flatbuffer serialization
+inside `HexStore::store()`. One `recordError` call makes **112–304 heap allocations**.
+When a device is low on memory any one of them can throw `std::bad_alloc`, and for a
+long time nothing on that path caught it: the throw unwound straight out through the
+Objective-C frame with no handler above it, hit `std::terminate`, and the host app died
+with `__cxa_call_terminate` in the trace.
+
+That is [issue #884](https://github.com/newrelic/newrelic-ios-agent/issues/884) /
+NR-614312. It was reported as a single crash from a single user, because it only needs
+one unlucky allocation during one serialization.
+
+This suite makes that failure deterministic. It replaces global `operator new` so a
+chosen fraction of allocations fail on demand, then hammers the handled-exception path
+and asserts the process is still alive and every persisted report is well-formed.
+
+## Running it
+
+```bash
+scripts/run_oom_resilience_tests.sh
+```
+
+That runs both stages and prints a summary:
+
+```
+============== OOM resilience summary ==============
+native harness (store path survives):  PASS
+stored reports well-formed:            PASS
+app end-to-end (crash boundary holds): PASS
+RESULT: PASS
+```
+
+```bash
+# just the fast native harness — no simulator, a few seconds
+scripts/run_oom_resilience_tests.sh --harness-only
+
+# just the end-to-end app test, with the pressure turned up
+scripts/run_oom_resilience_tests.sh --app-only --fail-one-in 500
+
+# pick a simulator, reuse the previous app build
+scripts/run_oom_resilience_tests.sh --simulator 'iPhone 17 Pro' --no-build
+```
+
+Logs and binaries land in `build/oom-resilience/` (gitignored).
+
+The injector reads three env vars, forwarded by the script but overridable:
+`NR_OOM_ONE_IN` (failure rate), `NR_OOM_DELAY` (seconds before arming), and
+`NR_OOM_THREAD` (thread name to target, or `*` for process-wide).
+
+### Confirming the test is not vacuous
+
+A resilience test that passes because it never provoked anything is worse than no test.
+To check it still detects the original bug, revert the fix and assert the crash:
+
+```bash
+git stash push -- Agent/HandledException/NRMAHandledExceptions.mm \
+                  libMobileAgent/src/Hex/src/HexStore.cxx \
+                  libMobileAgent/src/Hex/src/report/exception/HandledException.cxx
+
+scripts/run_oom_resilience_tests.sh --app-only --expect-crash
+# expect: PASS (crashed as expected with --expect-crash)
+
+git stash pop
+```
+
+Without the fix the app dies within the first couple of thousand calls with
+`libc++abi: terminating due to uncaught exception of type std::bad_alloc`.
+
+## The two stages
+
+### `harness` — the store path, natively
+
+`Tests/OOM-Resilience/hex_oom_harness.cxx` compiles the agent's own Hex C++ into a
+standalone binary and calls `HexStore::store()` — what `HexController::submit()` calls
+— in a loop, wrapping each iteration in a `try`/`catch` that mirrors the Objective-C
+crash boundary. It catches two regressions:
+
+- **An exception escaping the store path.** Exit 70, with a demangled backtrace.
+- **A nested `FlatBufferBuilder`.** Exit 71. See below.
+
+`Tests/OOM-Resilience/verify_reports.cxx` then runs the flatbuffers verifier over every
+`.fbad` the loop wrote. Surviving is only half the contract; the other half is that no
+half-written report reaches disk and therefore the collector.
+
+### `app` — the crash boundary, end to end
+
+`Tests/OOM-Resilience/oom_injector.cxx` builds a dylib that replaces global
+`operator new` and is loaded with `SIMCTL_CHILD_DYLD_INSERT_LIBRARIES`, so **no agent
+or app code has to change to run the test**. Two things keep it targeted:
+
+- It arms a few seconds after load, so app and agent startup happen on a healthy heap.
+- It only fails allocations on the thread named `nr-oom-loop`, which the driver names
+  before it starts looping. Process-wide injection also takes down the agent's harvest
+  and upload threads — a real exposure, but a different one from #884, and it made this
+  test flaky. Set `NR_OOM_THREAD=*` to explore that instead (see below).
+
+The loop itself is `-[AppDelegate runHexOOMReproIfRequested]` in NRTestApp, driven by
+launch arguments:
+
+```bash
+xcrun simctl launch --console <sim> com.newrelic.NRApp.bitcode \
+    -RunHexOOMRepro -HexOOMIterations 20000 -HexOOMStartDelay 16
+```
+
+Pass looks like many `Dropped handled error report … std::bad_alloc` lines followed by
+`HexOOMRepro: DONE — survived 20000 recordError calls`.
+
+Note that on a passing run the app is still alive at the end — it is a UI app and does
+not exit. `simctl launch --console` would therefore block forever, so the script watches
+the log for a verdict and then terminates the app itself (`--timeout`, default 600s). If
+you drive the launch by hand, remember to `simctl terminate` afterwards.
+
+## C++ exceptions are absorbed; Objective-C exceptions are not
+
+The crash boundary catches C++ exceptions only. An Objective-C exception reaching it is
+re-thrown, because it means API misuse rather than a resource failure — the case the
+unit tests pin down is an `NSError` whose `localizedDescription` is not a string, where
+`-UTF8String` raises `NSInvalidArgumentException`. Swallowing that would hide a caller's
+bug, and `TestHandledExceptionController/testRecordError` asserts it still propagates.
+
+This needs an explicit `catch (id)` ahead of the C++ handlers: in Objective-C++ a bare
+`catch (...)` also catches `@throw`. Removing that clause makes those tests fail, which
+is the intended tripwire.
+
+## Why `FLATBUFFERS_ASSERT` is the detector
+
+`Library::serialize` and `Thread::serialize` write into the `FlatBufferBuilder` through
+`CreateLibrary`/`CreateThread`, which open a table. Swallowing an exception thrown
+part-way through leaves the builder with `nested_ == true`. The next
+`CreateString`/`CreateVector` then trips `FLATBUFFERS_ASSERT(!nested)`.
+
+This is exactly what the `catch (...)` blocks inside `buildLibraries()` used to do, and
+it is why they are gone. `HandledException.cxx` now guards only the parts that touch no
+flatbuffer state — copying the library snapshot, and reading the app image UUID — and
+lets a throw from any builder write propagate so the whole report is abandoned.
+
+**Both stages must be built without `NDEBUG`.** `FLATBUFFERS_ASSERT` is plain `assert`,
+so a release build (`ENABLE_NS_ASSERTIONS = NO`) compiles it out; a nested builder then
+silently emits a malformed buffer instead of aborting. The runner script hard-codes
+`-O0` with no `-DNDEBUG` for this reason — do not "optimize" that away.
+
+## Reading the output
+
+| Symptom | What it means |
+|---|---|
+| harness exit 70, `PROCESS KILLED by an uncaught C++ exception` | Something on the store path throws and nothing catches it. The backtrace names the frame. |
+| harness exit 71, `FLATBUFFERS_ASSERT(!nested)` | A `catch` swallowed an exception mid-table and left the builder nested. Look for a new `try`/`catch` around a builder write. |
+| `verify_reports` reports invalid or 0-byte reports | A partially serialized report reached disk. Check that `HexStore::store()` still serializes *before* it opens the file. |
+| app stage: `libc++abi: terminating` | The Objective-C crash boundary is gone or a new unguarded entry point was added. |
+| app stage: `FAIL (INCONCLUSIVE: nothing was dropped)` | The injector armed but never fired, so the run proved nothing. Usually a `DYLD_INSERT_LIBRARIES` path problem, `--fail-one-in` set too high, or the loop thread not being named `nr-oom-loop`. Counted as a failure on purpose — a run that provoked nothing must not report PASS. |
+
+## Tuning the failure rate
+
+`--fail-one-in 1000` is the default and is aggressive enough to kill unfixed code within
+a couple of thousand calls. Turning it up is fine, with one caveat: **below roughly
+1-in-100 the app's own startup and UIKit allocations start failing** in code that has
+nothing to do with the agent. A crash there is a false positive, not an agent bug.
+
+The reporter's device had ~175 MiB free of ~6.8 GiB in use, which is a *transient*
+condition — most allocations succeed and the occasional one fails. That is what a
+1-in-N rate models, and it is a better approximation than a hard allocation ceiling.
+
+## What is deliberately not covered
+
+- **Real device memory pressure.** A simulator app is a macOS process with the host's
+  RAM and swap behind it, so `malloc` never actually fails; iOS jetsams a real device
+  instead of returning null. Injection is the only way to make this deterministic. A
+  tight `recordError` loop with *no* injection survives 20,000 calls and proves nothing.
+- **The agent's other threads.** Injecting process-wide (`NR_OOM_THREAD=*`) kills the
+  app from the harvest and upload threads instead — they do unguarded C++ allocation
+  too, and on a device at 175 MiB free they are exposed the same way `recordError` was.
+  Nothing here fixes or tests that; it is a strictly larger piece of work than #884 and
+  is called out so it is not mistaken for covered ground. If you want to see it:
+  `NR_OOM_THREAD='*' scripts/run_oom_resilience_tests.sh --app-only`.
+
+- **The upload path.** `NRMAHexUploader` has its own failure modes (see #745 and the
+  invalidated-`NSURLSession` fix in 7.7.6). This suite stops at the report on disk.
+- **`_keyContext->insert()` ordering.** `HexController::submit()` stores to disk before
+  inserting into the in-memory context, so a throw from `insert` leaves a report that
+  will upload but is missing from the in-memory mirror. The crash boundary catches it
+  and the app survives; the ordering itself is untouched and untested.

--- a/Tests/OOM-RESILIENCE.md
+++ b/Tests/OOM-RESILIENCE.md
@@ -1,0 +1,172 @@
+# Handled-exception OOM-resilience tests
+
+Recording a handled error must never be able to kill the app that is being watched.
+Everything under `-[NRMAHandledExceptions recordError:attributes:]` is C++ that
+allocates — the report object, the attribute maps, and the flatbuffer serialization
+inside `HexStore::store()`. One `recordError` call makes **112–304 heap allocations**.
+When a device is low on memory any one of them can throw `std::bad_alloc`, and for a
+long time nothing on that path caught it: the throw unwound straight out through the
+Objective-C frame with no handler above it, hit `std::terminate`, and the host app died
+with `__cxa_call_terminate` in the trace.
+
+That is [issue #884](https://github.com/newrelic/newrelic-ios-agent/issues/884) /
+NR-614312. It was reported as a single crash from a single user, because it only needs
+one unlucky allocation during one serialization.
+
+This suite makes that failure deterministic. It replaces global `operator new` so a
+chosen fraction of allocations fail on demand, then hammers the handled-exception path
+and asserts the process is still alive and every persisted report is well-formed.
+
+## Running it
+
+```bash
+scripts/run_oom_resilience_tests.sh
+```
+
+That runs both stages and prints a summary:
+
+```
+============== OOM resilience summary ==============
+native harness (store path survives):  PASS
+stored reports well-formed:            PASS
+app end-to-end (crash boundary holds): PASS
+RESULT: PASS
+```
+
+```bash
+# just the fast native harness — no simulator, a few seconds
+scripts/run_oom_resilience_tests.sh --harness-only
+
+# just the end-to-end app test, with the pressure turned up
+scripts/run_oom_resilience_tests.sh --app-only --fail-one-in 500
+
+# pick a simulator, reuse the previous app build
+scripts/run_oom_resilience_tests.sh --simulator 'iPhone 17 Pro' --no-build
+```
+
+Logs and binaries land in `build/oom-resilience/` (gitignored).
+
+The injector reads three env vars, forwarded by the script but overridable:
+`NR_OOM_ONE_IN` (failure rate), `NR_OOM_DELAY` (seconds before arming), and
+`NR_OOM_THREAD` (thread name to target, or `*` for process-wide).
+
+### Confirming the test is not vacuous
+
+A resilience test that passes because it never provoked anything is worse than no test.
+To check it still detects the original bug, revert the fix and assert the crash:
+
+```bash
+git stash push -- Agent/HandledException/NRMAHandledExceptions.mm \
+                  libMobileAgent/src/Hex/src/HexStore.cxx \
+                  libMobileAgent/src/Hex/src/report/exception/HandledException.cxx
+
+scripts/run_oom_resilience_tests.sh --app-only --expect-crash
+# expect: PASS (crashed as expected with --expect-crash)
+
+git stash pop
+```
+
+Without the fix the app dies within the first couple of thousand calls with
+`libc++abi: terminating due to uncaught exception of type std::bad_alloc`.
+
+## The two stages
+
+### `harness` — the store path, natively
+
+`Tests/OOM-Resilience/hex_oom_harness.cxx` compiles the agent's own Hex C++ into a
+standalone binary and calls `HexStore::store()` — what `HexController::submit()` calls
+— in a loop, wrapping each iteration in a `try`/`catch` that mirrors the Objective-C
+crash boundary. It catches two regressions:
+
+- **An exception escaping the store path.** Exit 70, with a demangled backtrace.
+- **A nested `FlatBufferBuilder`.** Exit 71. See below.
+
+`Tests/OOM-Resilience/verify_reports.cxx` then runs the flatbuffers verifier over every
+`.fbad` the loop wrote. Surviving is only half the contract; the other half is that no
+half-written report reaches disk and therefore the collector.
+
+### `app` — the crash boundary, end to end
+
+`Tests/OOM-Resilience/oom_injector.cxx` builds a dylib that replaces global
+`operator new` and is loaded with `SIMCTL_CHILD_DYLD_INSERT_LIBRARIES`, so **no agent
+or app code has to change to run the test**. Two things keep it targeted:
+
+- It arms a few seconds after load, so app and agent startup happen on a healthy heap.
+- It only fails allocations on the thread named `nr-oom-loop`, which the driver names
+  before it starts looping. Process-wide injection also takes down the agent's harvest
+  and upload threads — a real exposure, but a different one from #884, and it made this
+  test flaky. Set `NR_OOM_THREAD=*` to explore that instead (see below).
+
+The loop itself is `-[AppDelegate runHexOOMReproIfRequested]` in NRTestApp, driven by
+launch arguments:
+
+```bash
+xcrun simctl launch --console <sim> com.newrelic.NRApp.bitcode \
+    -RunHexOOMRepro -HexOOMIterations 20000 -HexOOMStartDelay 16
+```
+
+Pass looks like many `Dropped handled error report … std::bad_alloc` lines followed by
+`HexOOMRepro: DONE — survived 20000 recordError calls`.
+
+Note that on a passing run the app is still alive at the end — it is a UI app and does
+not exit. `simctl launch --console` would therefore block forever, so the script watches
+the log for a verdict and then terminates the app itself (`--timeout`, default 600s). If
+you drive the launch by hand, remember to `simctl terminate` afterwards.
+
+## Why `FLATBUFFERS_ASSERT` is the detector
+
+`Library::serialize` and `Thread::serialize` write into the `FlatBufferBuilder` through
+`CreateLibrary`/`CreateThread`, which open a table. Swallowing an exception thrown
+part-way through leaves the builder with `nested_ == true`. The next
+`CreateString`/`CreateVector` then trips `FLATBUFFERS_ASSERT(!nested)`.
+
+This is exactly what the `catch (...)` blocks inside `buildLibraries()` used to do, and
+it is why they are gone. `HandledException.cxx` now guards only the parts that touch no
+flatbuffer state — copying the library snapshot, and reading the app image UUID — and
+lets a throw from any builder write propagate so the whole report is abandoned.
+
+**Both stages must be built without `NDEBUG`.** `FLATBUFFERS_ASSERT` is plain `assert`,
+so a release build (`ENABLE_NS_ASSERTIONS = NO`) compiles it out; a nested builder then
+silently emits a malformed buffer instead of aborting. The runner script hard-codes
+`-O0` with no `-DNDEBUG` for this reason — do not "optimize" that away.
+
+## Reading the output
+
+| Symptom | What it means |
+|---|---|
+| harness exit 70, `PROCESS KILLED by an uncaught C++ exception` | Something on the store path throws and nothing catches it. The backtrace names the frame. |
+| harness exit 71, `FLATBUFFERS_ASSERT(!nested)` | A `catch` swallowed an exception mid-table and left the builder nested. Look for a new `try`/`catch` around a builder write. |
+| `verify_reports` reports invalid or 0-byte reports | A partially serialized report reached disk. Check that `HexStore::store()` still serializes *before* it opens the file. |
+| app stage: `libc++abi: terminating` | The Objective-C crash boundary is gone or a new unguarded entry point was added. |
+| app stage: `INCONCLUSIVE (nothing was dropped)` | The injector never armed — usually a `DYLD_INSERT_LIBRARIES` path problem, or `--fail-one-in` set too high. |
+
+## Tuning the failure rate
+
+`--fail-one-in 1000` is the default and is aggressive enough to kill unfixed code within
+a couple of thousand calls. Turning it up is fine, with one caveat: **below roughly
+1-in-100 the app's own startup and UIKit allocations start failing** in code that has
+nothing to do with the agent. A crash there is a false positive, not an agent bug.
+
+The reporter's device had ~175 MiB free of ~6.8 GiB in use, which is a *transient*
+condition — most allocations succeed and the occasional one fails. That is what a
+1-in-N rate models, and it is a better approximation than a hard allocation ceiling.
+
+## What is deliberately not covered
+
+- **Real device memory pressure.** A simulator app is a macOS process with the host's
+  RAM and swap behind it, so `malloc` never actually fails; iOS jetsams a real device
+  instead of returning null. Injection is the only way to make this deterministic. A
+  tight `recordError` loop with *no* injection survives 20,000 calls and proves nothing.
+- **The agent's other threads.** Injecting process-wide (`NR_OOM_THREAD=*`) kills the
+  app from the harvest and upload threads instead — they do unguarded C++ allocation
+  too, and on a device at 175 MiB free they are exposed the same way `recordError` was.
+  Nothing here fixes or tests that; it is a strictly larger piece of work than #884 and
+  is called out so it is not mistaken for covered ground. If you want to see it:
+  `NR_OOM_THREAD='*' scripts/run_oom_resilience_tests.sh --app-only`.
+
+- **The upload path.** `NRMAHexUploader` has its own failure modes (see #745 and the
+  invalidated-`NSURLSession` fix in 7.7.6). This suite stops at the report on disk.
+- **`_keyContext->insert()` ordering.** `HexController::submit()` stores to disk before
+  inserting into the in-memory context, so a throw from `insert` leaves a report that
+  will upload but is missing from the in-memory mirror. The crash boundary catches it
+  and the app survives; the ordering itself is untouched and untested.

--- a/Tests/OOM-Resilience/hex_oom_harness.cxx
+++ b/Tests/OOM-Resilience/hex_oom_harness.cxx
@@ -1,0 +1,228 @@
+//
+//  hex_oom_harness.cxx
+//  Handled-exception OOM-resilience harness
+//
+//  Drives the real HexStore::store() -> HexReport::finalize() ->
+//  AgentData::serialize() -> HandledException::serialize() path while making a
+//  configurable fraction of heap allocations fail, simulating a device that is
+//  nearly out of memory.
+//
+//  Written for GitHub issue #884 / NR-614312, where a std::bad_alloc raised
+//  during handled-exception serialization unwound out of an Objective-C frame
+//  with no handler above it and killed the host app.
+//
+//  It guards two distinct regressions:
+//
+//    1. A nested FlatBufferBuilder. Swallowing an exception thrown part-way
+//       through a flatbuffer table (which HandledException.cxx used to do around
+//       Library::serialize and Thread::serialize) leaves the builder with
+//       nested_ == true. The next CreateString/CreateVector then trips
+//       FLATBUFFERS_ASSERT(!nested). THIS HARNESS MUST BE COMPILED WITHOUT
+//       NDEBUG so that assert is live -- it is the detector.
+//
+//    2. Invalid or truncated reports written to disk. Pair a run with
+//       verify_reports to confirm every .fbad that survived is a well-formed
+//       HexAgentData buffer.
+//
+//  See Tests/OOM-RESILIENCE.md.
+//
+
+#include <Hex/HexStore.hpp>
+#include <Hex/HexReport.hpp>
+#include <Hex/HandledException.hpp>
+#include <Hex/AppInfo.hpp>
+#include <Hex/ApplicationLicense.hpp>
+#include <Analytics/AttributeValidator.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <csignal>
+#include <exception>
+#include <execinfo.h>
+#include <memory>
+#include <new>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+std::atomic<bool>     g_armed{false};
+std::atomic<long>     g_allocations{0};
+std::atomic<long>     g_iteration{0};
+std::atomic<long>     g_stored{0};
+std::atomic<long>     g_dropped{0};
+
+long     g_failOneIn = 1000;
+bool     g_guard     = true;
+uint64_t g_rng       = 88442211ULL;
+
+uint64_t xorshift() {
+    g_rng ^= g_rng << 13;
+    g_rng ^= g_rng >> 7;
+    g_rng ^= g_rng << 17;
+    return g_rng;
+}
+
+// Reported when the process is about to die, so a regression names the frame it
+// died in rather than just the exception type.
+void onTerminate() {
+    g_armed.store(false, std::memory_order_relaxed);
+    std::printf("\n*** PROCESS KILLED by an uncaught C++ exception ***\n");
+    std::printf("    on iteration %ld, after %ld allocations\n",
+                g_iteration.load(), g_allocations.load());
+    if (auto e = std::current_exception()) {
+        try { std::rethrow_exception(e); }
+        catch (const std::exception& ex) { std::printf("    exception: %s\n", ex.what()); }
+        catch (...)                      { std::printf("    exception: <unknown>\n"); }
+    }
+    void* frames[48];
+    int n = backtrace(frames, 48);
+    std::printf("    backtrace (pipe through c++filt to demangle):\n");
+    backtrace_symbols_fd(frames, n, 1);
+    std::fflush(stdout);
+    _exit(70);
+}
+
+// A flatbuffers FLATBUFFERS_ASSERT failure lands here, not in onTerminate.
+// That is regression #1 above, so name it explicitly.
+void onAbort(int) {
+    std::printf("\n*** PROCESS ABORTED (assertion failure) ***\n");
+    std::printf("    on iteration %ld, after %ld allocations\n",
+                g_iteration.load(), g_allocations.load());
+    std::printf("    A FLATBUFFERS_ASSERT(!nested) here means an exception was\n");
+    std::printf("    swallowed part-way through building a flatbuffer table,\n");
+    std::printf("    leaving the builder nested. See issue #884.\n");
+    void* frames[48];
+    int n = backtrace(frames, 48);
+    std::printf("    backtrace (pipe through c++filt to demangle):\n");
+    backtrace_symbols_fd(frames, n, 1);
+    std::fflush(stdout);
+    _exit(71);
+}
+
+void usage(const char* argv0) {
+    std::printf(
+        "usage: %s [options]\n"
+        "\n"
+        "  --fail-one-in N   Fail 1 in N heap allocations while the loop runs. Default 1000.\n"
+        "                    0 disables injection entirely (sanity check).\n"
+        "  --iterations N    recordError-equivalent calls to make. Default 50000.\n"
+        "  --store DIR       Directory to write .fbad reports into. Default ./oom-store.\n"
+        "  --no-guard        Do NOT wrap each call, mirroring an agent with no crash\n"
+        "                    boundary. Expected to die; use it to show the boundary is\n"
+        "                    load-bearing, not as a pass/fail test.\n"
+        "  --seed N          PRNG seed, for reproducing a specific failure.\n"
+        "  -h, --help        This message.\n"
+        "\n"
+        "exit: 0 survived, 70 uncaught exception, 71 assertion failure, 2 bad usage.\n",
+        argv0);
+}
+
+} // namespace
+
+// Replacing global operator new is how the low-memory device is simulated. The
+// agent's C++ is statically linked into this binary, so its allocations come
+// through here too.
+void* operator new(std::size_t n) {
+    if (g_armed.load(std::memory_order_relaxed)) {
+        g_allocations.fetch_add(1, std::memory_order_relaxed);
+        if (g_failOneIn > 0 && (xorshift() % static_cast<uint64_t>(g_failOneIn)) == 0) {
+            throw std::bad_alloc();
+        }
+    }
+    void* p = std::malloc(n ? n : 1);
+    if (!p) throw std::bad_alloc();
+    return p;
+}
+void* operator new[](std::size_t n) { return ::operator new(n); }
+void* operator new(std::size_t n, const std::nothrow_t&) noexcept { return std::malloc(n ? n : 1); }
+void* operator new[](std::size_t n, const std::nothrow_t&) noexcept { return std::malloc(n ? n : 1); }
+void operator delete(void* p) noexcept { std::free(p); }
+void operator delete[](void* p) noexcept { std::free(p); }
+void operator delete(void* p, std::size_t) noexcept { std::free(p); }
+void operator delete[](void* p, std::size_t) noexcept { std::free(p); }
+void operator delete(void* p, const std::nothrow_t&) noexcept { std::free(p); }
+void operator delete[](void* p, const std::nothrow_t&) noexcept { std::free(p); }
+
+using namespace NewRelic;
+using namespace NewRelic::Hex;
+
+int main(int argc, char** argv) {
+    std::setvbuf(stdout, nullptr, _IONBF, 0);
+
+    long        iterations = 50000;
+    std::string storeDir   = "./oom-store";
+
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        auto next = [&](const char* what) -> const char* {
+            if (i + 1 >= argc) { std::printf("missing value for %s\n", what); std::exit(2); }
+            return argv[++i];
+        };
+        if      (a == "--fail-one-in") g_failOneIn = std::atol(next("--fail-one-in"));
+        else if (a == "--iterations")  iterations  = std::atol(next("--iterations"));
+        else if (a == "--store")       storeDir    = next("--store");
+        else if (a == "--seed")        g_rng       = std::strtoull(next("--seed"), nullptr, 10);
+        else if (a == "--no-guard")    g_guard     = false;
+        else if (a == "-h" || a == "--help") { usage(argv[0]); return 0; }
+        else { std::printf("unknown option: %s\n\n", a.c_str()); usage(argv[0]); return 2; }
+    }
+
+    std::set_terminate(onTerminate);
+    signal(SIGABRT, onAbort);
+
+    std::printf("handled-exception OOM resilience harness\n");
+    std::printf("  store       : %s\n", storeDir.c_str());
+    std::printf("  iterations  : %ld\n", iterations);
+    std::printf("  failure rate: %s\n",
+                g_failOneIn > 0 ? ("1 in " + std::to_string(g_failOneIn)).c_str() : "disabled");
+    std::printf("  crash guard : %s\n\n", g_guard ? "on (mirrors NRMAHandledExceptions)" : "OFF");
+
+    auto store = std::make_shared<HexStore>(storeDir.c_str());
+
+    Report::ApplicationLicense license("AAABBB123");
+    auto appInfo = std::make_shared<Report::AppInfo>(&license, fbs::Platform_iOS);
+    NewRelic::AttributeValidator validator([](const char*){ return true; },
+                                           [](const char*){ return true; },
+                                           [](const char*){ return true; });
+
+    // One recordError-equivalent: build the report, then serialize and persist it.
+    auto once = [&](long i) {
+        auto exception = std::make_shared<Report::HandledException>(
+            "oom-harness-session",
+            1700000000000ULL + static_cast<uint64_t>(i),
+            "Flutter recordError",
+            "PlatformException",
+            std::vector<std::shared_ptr<Report::Thread>>{});
+        auto report = std::make_shared<Report::HexReport>(exception, appInfo, validator);
+        store->store(report);   // what HexController::submit() calls
+    };
+
+    g_armed.store(true, std::memory_order_relaxed);
+    for (long i = 0; i < iterations; ++i) {
+        g_iteration.store(i, std::memory_order_relaxed);
+        if (g_guard) {
+            // Mirrors the crash boundary in -[NRMAHandledExceptions recordError:attributes:].
+            try {
+                once(i);
+                g_stored.fetch_add(1, std::memory_order_relaxed);
+            } catch (...) {
+                g_dropped.fetch_add(1, std::memory_order_relaxed);
+            }
+        } else {
+            once(i);
+            g_stored.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    g_armed.store(false, std::memory_order_relaxed);
+
+    std::printf("SURVIVED %ld calls (%ld allocations)\n", iterations, g_allocations.load());
+    std::printf("  reports stored : %ld\n", g_stored.load());
+    std::printf("  reports dropped: %ld\n", g_dropped.load());
+    std::printf("RESULT: PASS (no uncaught exception, no assertion failure)\n");
+    return 0;
+}

--- a/Tests/OOM-Resilience/oom_injector.cxx
+++ b/Tests/OOM-Resilience/oom_injector.cxx
@@ -1,0 +1,111 @@
+//
+//  oom_injector.cxx
+//  Handled-exception OOM-resilience harness
+//
+//  Replaces global operator new so that 1-in-N allocations throw std::bad_alloc,
+//  simulating the reporter's device in issue #884 / NR-614312 (~175 MiB free of
+//  ~6.8 GiB in use). Loaded with SIMCTL_CHILD_DYLD_INSERT_LIBRARIES, so no agent
+//  or app code has to change to run the test.
+//
+//  Two things keep the injection targeted at the path under test:
+//
+//    1. It arms NR_OOM_DELAY seconds after load, so app and agent startup run on
+//       a healthy heap.
+//    2. It only fails allocations on the thread named NR_OOM_THREAD (default
+//       "nr-oom-loop"), which the NRTestApp driver names before it starts looping.
+//       Without this the agent's harvest and upload threads also start throwing —
+//       those are genuinely unguarded, but they are a different problem from #884
+//       and their failures made this test flaky.
+//
+//  Env:
+//    NR_OOM_ONE_IN   fail 1 in N allocations (default 1000; 0 disables)
+//    NR_OOM_DELAY    seconds after load before arming (default 10)
+//    NR_OOM_THREAD   only fail on this thread name (default "nr-oom-loop";
+//                    set to "*" to fail process-wide)
+//
+//  See Tests/OOM-RESILIENCE.md.
+//
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <new>
+#include <pthread.h>
+#include <thread>
+
+namespace {
+
+std::atomic<bool> g_armed{false};
+long              g_oneIn = 1000;
+char              g_threadName[64] = "nr-oom-loop";
+bool              g_anyThread = false;
+
+// A plain integer so the thread_local needs no dynamic initialization — an
+// allocating initializer here would recurse through operator new.
+thread_local unsigned long long t_rng = 0;
+
+// Deliberately NOT cached per thread. The driver's loop runs on a pooled GCD
+// thread that already exists and is renamed only when the block starts, so a
+// cached "not selected" from an allocation made between arming and renaming
+// would disable injection for the whole run — silently, since the loop then
+// just survives. pthread_getname_np only copies out of the pthread struct, so
+// querying every time is cheap, and the cost is paid only while armed.
+bool threadIsSelected() {
+    if (g_anyThread) return true;
+    char name[64] = {0};
+    if (pthread_getname_np(pthread_self(), name, sizeof(name)) != 0) return false;
+    return std::strcmp(name, g_threadName) == 0;
+}
+
+unsigned long long xorshift() {
+    if (t_rng == 0) t_rng = 88442211ULL ^ (unsigned long long)(uintptr_t)&t_rng;
+    t_rng ^= t_rng << 13;
+    t_rng ^= t_rng >> 7;
+    t_rng ^= t_rng << 17;
+    return t_rng;
+}
+
+__attribute__((constructor))
+void nr_oom_init() {
+    if (const char* n = getenv("NR_OOM_ONE_IN")) g_oneIn = atol(n);
+    if (const char* t = getenv("NR_OOM_THREAD")) {
+        if (std::strcmp(t, "*") == 0) g_anyThread = true;
+        else { std::strncpy(g_threadName, t, sizeof(g_threadName) - 1); }
+    }
+    long delay = 10;
+    if (const char* d = getenv("NR_OOM_DELAY")) delay = atol(d);
+
+    // stderr, not os_log: simctl launch --console captures stdio, so the runner
+    // script can see these markers.
+    std::fprintf(stderr, "[NR_OOM] injector loaded: 1-in-%ld on thread \"%s\", arming in %lds\n",
+                 g_oneIn, g_anyThread ? "*" : g_threadName, delay);
+    std::fflush(stderr);
+
+    std::thread([delay]() {
+        std::this_thread::sleep_for(std::chrono::seconds(delay));
+        g_armed.store(true, std::memory_order_relaxed);
+        std::fprintf(stderr, "[NR_OOM] ARMED\n");
+        std::fflush(stderr);
+    }).detach();
+}
+
+} // namespace
+
+void* operator new(std::size_t n) {
+    if (g_armed.load(std::memory_order_relaxed) && g_oneIn > 0 && threadIsSelected()) {
+        if ((xorshift() % (unsigned long long)g_oneIn) == 0) throw std::bad_alloc();
+    }
+    void* p = std::malloc(n ? n : 1);
+    if (!p) throw std::bad_alloc();
+    return p;
+}
+void* operator new[](std::size_t n) { return ::operator new(n); }
+void* operator new(std::size_t n, const std::nothrow_t&) noexcept { return std::malloc(n ? n : 1); }
+void* operator new[](std::size_t n, const std::nothrow_t&) noexcept { return std::malloc(n ? n : 1); }
+void operator delete(void* p) noexcept { std::free(p); }
+void operator delete[](void* p) noexcept { std::free(p); }
+void operator delete(void* p, std::size_t) noexcept { std::free(p); }
+void operator delete[](void* p, std::size_t) noexcept { std::free(p); }
+void operator delete(void* p, const std::nothrow_t&) noexcept { std::free(p); }
+void operator delete[](void* p, const std::nothrow_t&) noexcept { std::free(p); }

--- a/Tests/OOM-Resilience/oom_injector.cxx
+++ b/Tests/OOM-Resilience/oom_injector.cxx
@@ -1,0 +1,111 @@
+//
+//  oom_injector.cxx
+//  Handled-exception OOM-resilience harness
+//
+//  Replaces global operator new so that 1-in-N allocations throw std::bad_alloc,
+//  simulating the reporter's device in issue #884 / NR-614312 (~175 MiB free of
+//  ~6.8 GiB in use). Loaded with SIMCTL_CHILD_DYLD_INSERT_LIBRARIES, so no agent
+//  or app code has to change to run the test.
+//
+//  Two things keep the injection targeted at the path under test:
+//
+//    1. It arms NR_OOM_DELAY seconds after load, so app and agent startup run on
+//       a healthy heap.
+//    2. It only fails allocations on the thread named NR_OOM_THREAD (default
+//       "nr-oom-loop"), which the NRTestApp driver names before it starts looping.
+//       Without this the agent's harvest and upload threads also start throwing —
+//       those are genuinely unguarded, but they are a different problem from #884
+//       and their failures made this test flaky.
+//
+//  Env:
+//    NR_OOM_ONE_IN   fail 1 in N allocations (default 1000; 0 disables)
+//    NR_OOM_DELAY    seconds after load before arming (default 10)
+//    NR_OOM_THREAD   only fail on this thread name (default "nr-oom-loop";
+//                    set to "*" to fail process-wide)
+//
+//  See Tests/OOM-RESILIENCE.md.
+//
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <new>
+#include <pthread.h>
+#include <thread>
+
+namespace {
+
+std::atomic<bool> g_armed{false};
+long              g_oneIn = 1000;
+char              g_threadName[64] = "nr-oom-loop";
+bool              g_anyThread = false;
+
+// Plain integers so the thread_locals need no dynamic initialization — an
+// allocating initializer here would recurse through operator new.
+thread_local int      t_selected = -1;   // -1 unknown, 0 no, 1 yes
+thread_local unsigned long long t_rng = 0;
+
+bool threadIsSelected() {
+    if (g_anyThread) return true;
+    if (t_selected >= 0) return t_selected == 1;
+    char name[64] = {0};
+    if (pthread_getname_np(pthread_self(), name, sizeof(name)) != 0) {
+        t_selected = 0;
+        return false;
+    }
+    t_selected = (std::strcmp(name, g_threadName) == 0) ? 1 : 0;
+    return t_selected == 1;
+}
+
+unsigned long long xorshift() {
+    if (t_rng == 0) t_rng = 88442211ULL ^ (unsigned long long)(uintptr_t)&t_rng;
+    t_rng ^= t_rng << 13;
+    t_rng ^= t_rng >> 7;
+    t_rng ^= t_rng << 17;
+    return t_rng;
+}
+
+__attribute__((constructor))
+void nr_oom_init() {
+    if (const char* n = getenv("NR_OOM_ONE_IN")) g_oneIn = atol(n);
+    if (const char* t = getenv("NR_OOM_THREAD")) {
+        if (std::strcmp(t, "*") == 0) g_anyThread = true;
+        else { std::strncpy(g_threadName, t, sizeof(g_threadName) - 1); }
+    }
+    long delay = 10;
+    if (const char* d = getenv("NR_OOM_DELAY")) delay = atol(d);
+
+    // stderr, not os_log: simctl launch --console captures stdio, so the runner
+    // script can see these markers.
+    std::fprintf(stderr, "[NR_OOM] injector loaded: 1-in-%ld on thread \"%s\", arming in %lds\n",
+                 g_oneIn, g_anyThread ? "*" : g_threadName, delay);
+    std::fflush(stderr);
+
+    std::thread([delay]() {
+        std::this_thread::sleep_for(std::chrono::seconds(delay));
+        g_armed.store(true, std::memory_order_relaxed);
+        std::fprintf(stderr, "[NR_OOM] ARMED\n");
+        std::fflush(stderr);
+    }).detach();
+}
+
+} // namespace
+
+void* operator new(std::size_t n) {
+    if (g_armed.load(std::memory_order_relaxed) && g_oneIn > 0 && threadIsSelected()) {
+        if ((xorshift() % (unsigned long long)g_oneIn) == 0) throw std::bad_alloc();
+    }
+    void* p = std::malloc(n ? n : 1);
+    if (!p) throw std::bad_alloc();
+    return p;
+}
+void* operator new[](std::size_t n) { return ::operator new(n); }
+void* operator new(std::size_t n, const std::nothrow_t&) noexcept { return std::malloc(n ? n : 1); }
+void* operator new[](std::size_t n, const std::nothrow_t&) noexcept { return std::malloc(n ? n : 1); }
+void operator delete(void* p) noexcept { std::free(p); }
+void operator delete[](void* p) noexcept { std::free(p); }
+void operator delete(void* p, std::size_t) noexcept { std::free(p); }
+void operator delete[](void* p, std::size_t) noexcept { std::free(p); }
+void operator delete(void* p, const std::nothrow_t&) noexcept { std::free(p); }
+void operator delete[](void* p, const std::nothrow_t&) noexcept { std::free(p); }

--- a/Tests/OOM-Resilience/verify_reports.cxx
+++ b/Tests/OOM-Resilience/verify_reports.cxx
@@ -1,0 +1,97 @@
+//
+//  verify_reports.cxx
+//  Handled-exception OOM-resilience harness
+//
+//  Verifies that every persisted .fbad handled-exception report in a directory is
+//  a well-formed HexAgentData flatbuffer, and reports the shapes it found.
+//
+//  Companion to hex_oom_harness. Surviving the OOM run is only half the contract;
+//  the other half is that no half-written report reaches disk (and therefore the
+//  collector). Before the issue #884 fix, a run at a 1-in-500 failure rate left
+//  behind 0-byte files, reports truncated mid-library-list, and at least one
+//  buffer the flatbuffers verifier rejected outright.
+//
+//  See Tests/OOM-RESILIENCE.md.
+//
+
+#include "hex-agent-data_generated.h"
+#include <flatbuffers/flatbuffers.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <dirent.h>
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+
+int main(int argc, char** argv) {
+    const char* dir = (argc > 1) ? argv[1] : ".";
+
+    DIR* d = ::opendir(dir);
+    if (!d) {
+        std::printf("verify_reports: cannot open directory: %s\n", dir);
+        return 2;
+    }
+
+    int valid = 0, invalid = 0, empty = 0;
+    std::map<size_t, std::pair<int, size_t>> shapes;  // size -> (count, libraries)
+    std::vector<std::string> rejected;
+
+    struct dirent* entry = nullptr;
+    while ((entry = ::readdir(d)) != nullptr) {
+        std::string name{entry->d_name};
+        const std::string ext = ".fbad";
+        if (name.size() <= ext.size()) continue;
+        if (name.compare(name.size() - ext.size(), ext.size(), ext) != 0) continue;
+
+        const std::string path = std::string(dir) + "/" + name;
+        std::ifstream f{path, std::ios::binary | std::ios::ate};
+        if (!f.good()) { rejected.push_back(name + " (unreadable)"); ++invalid; continue; }
+
+        const std::streamsize size = f.tellg();
+        if (size <= 0) { ++empty; ++invalid; rejected.push_back(name + " (0 bytes)"); continue; }
+
+        f.seekg(0);
+        std::vector<uint8_t> buf(static_cast<size_t>(size));
+        f.read(reinterpret_cast<char*>(buf.data()), size);
+
+        flatbuffers::Verifier verifier(buf.data(), buf.size());
+        if (!com::newrelic::mobile::fbs::VerifyHexAgentDataBuffer(verifier)) {
+            ++invalid;
+            rejected.push_back(name + " (" + std::to_string(size) + " bytes, failed verification)");
+            continue;
+        }
+
+        size_t libraries = 0;
+        const auto* agentData = com::newrelic::mobile::fbs::GetHexAgentData(buf.data());
+        if (agentData && agentData->handledExceptions() && agentData->handledExceptions()->size() > 0) {
+            const auto* handled = agentData->handledExceptions()->Get(0);
+            if (handled && handled->libraries()) libraries = handled->libraries()->size();
+        }
+        ++valid;
+        auto& shape = shapes[static_cast<size_t>(size)];
+        shape.first++;
+        shape.second = libraries;
+    }
+    ::closedir(d);
+
+    std::printf("================ report verification ================\n");
+    std::printf("directory : %s\n", dir);
+    std::printf("valid     : %d\n", valid);
+    for (const auto& kv : shapes) {
+        std::printf("            %6zu bytes x%-6d -> %zu libraries\n",
+                    kv.first, kv.second.first, kv.second.second);
+    }
+    std::printf("invalid   : %d", invalid);
+    if (empty) std::printf("  (%d of them 0-byte)", empty);
+    std::printf("\n");
+    for (const auto& r : rejected) std::printf("            %s\n", r.c_str());
+
+    if (valid == 0 && invalid == 0) {
+        std::printf("RESULT: INCONCLUSIVE (no .fbad reports found)\n");
+        return 3;
+    }
+    std::printf("RESULT: %s\n", invalid == 0 ? "PASS" : "FAIL");
+    return invalid == 0 ? 0 : 1;
+}

--- a/libMobileAgent/src/Hex/src/HexStore.cxx
+++ b/libMobileAgent/src/Hex/src/HexStore.cxx
@@ -112,6 +112,17 @@ namespace NewRelic {
         HexStore::HexStore(const char* storePath) : storePath(storePath) {}
 
         void HexStore::store(const std::shared_ptr<Report::HexReport>& report) {
+            // Serialize BEFORE touching the filesystem. finalize() can throw --
+            // std::bad_alloc when the device is low on memory, std::invalid_argument
+            // on a report missing its exception/app info. When the file was opened
+            // first, every such failure left a 0-byte .fbad behind for readAll() to
+            // detect and reap. Serializing first means a failed report costs nothing
+            // on disk. The throw itself propagates to the crash boundary in
+            // NRMAHandledExceptions, which drops the report. See issue #884.
+            flatbuffers::FlatBufferBuilder builder{};
+            auto agentData = report->finalize(builder);
+            builder.Finish(agentData);
+
             // Bound the on-disk backlog before we add another file. Cheap single
             // dirent walk; protects against an indefinitely-offline app from
             // exhausting disk + file descriptors.
@@ -130,9 +141,6 @@ namespace NewRelic {
                 }
                 return;
             }
-            flatbuffers::FlatBufferBuilder builder{};
-            auto agentData = report->finalize(builder);
-            builder.Finish(agentData);
             auto size = std::fwrite(builder.GetBufferPointer(), sizeof(uint8_t),
                                     builder.GetSize(), file.get());
             if (size < builder.GetSize()) {

--- a/libMobileAgent/src/Hex/src/report/exception/HandledException.cxx
+++ b/libMobileAgent/src/Hex/src/report/exception/HandledException.cxx
@@ -13,23 +13,40 @@ using namespace com::newrelic::mobile;
 using namespace flatbuffers;
 using namespace NewRelic::Hex::Report;
 
-// Build a container of Flatbuffer Libraries, given the global list of libraries found by LibraryController.
-// Uses librariesSnapshot() so the lock is acquired internally and we copy
-// out before serializing — avoids holding the mutex across flatbuffer writes
-// and is safe even if the caller forgets to lock.
-std::vector<Offset<fbs::ios::Library>> buildLibraries(FlatBufferBuilder& builder) {
-    std::vector<Offset<fbs::ios::Library>> libraries;
-
+// Copy out the global library list found by LibraryController.
+//
+// This touches no flatbuffer state, so it IS safe to guard: if LibraryController
+// is unavailable we serialize zero libraries rather than failing the whole
+// report. Uses librariesSnapshot() so the lock is acquired internally and we
+// copy out before serializing — avoids holding the mutex across flatbuffer
+// writes and is safe even if the caller forgets to lock.
+static std::vector<NewRelic::Hex::Report::Library> librarySnapshot() {
     try {
-        auto& libraryController = NewRelic::LibraryController::getInstance();
-        auto snapshot = libraryController.librariesSnapshot();
-        libraries.reserve(snapshot.size());
-        for (auto& l : snapshot) {
-            libraries.push_back(l.serialize(builder));
-        }
+        return NewRelic::LibraryController::getInstance().librariesSnapshot();
     } catch (...) {
-        // Never let library serialization failure escape — a partial
-        // libraries vector is preferable to crashing the host app.
+        return {};
+    }
+}
+
+// Build a container of Flatbuffer Libraries from that snapshot.
+//
+// DO NOT wrap the serialization loop in try/catch. Library::serialize() writes
+// into `builder` via CreateLibrary(), which opens a table. Swallowing an
+// exception thrown part-way through leaves the builder with nested_ == true,
+// and the next CreateString/CreateVector then trips
+// FLATBUFFERS_ASSERT(!nested) — which aborts in debug and, because release
+// builds define NDEBUG (ENABLE_NS_ASSERTIONS = NO), silently emits a malformed
+// buffer in production. A half-written builder cannot be salvaged, so the throw
+// must propagate and the caller must abandon the entire report. The crash
+// boundary that catches it lives in -[NRMAHandledExceptions recordError:...]
+// and its siblings. See GitHub issue #884 / NR-614312.
+std::vector<Offset<fbs::ios::Library>> buildLibraries(FlatBufferBuilder& builder) {
+    auto snapshot = librarySnapshot();
+
+    std::vector<Offset<fbs::ios::Library>> libraries;
+    libraries.reserve(snapshot.size());
+    for (auto& l : snapshot) {
+        libraries.push_back(l.serialize(builder));
     }
     return libraries;
 }
@@ -43,12 +60,11 @@ HandledException::serialize(flatbuffers::FlatBufferBuilder& builder) const {
     std::vector<Offset<fbs::hex::Thread>> threads;
     for (auto const& t : _threads) {
         if (!t) continue;
-        try {
-            threads.push_back(t->serialize(builder));
-        } catch (...) {
-            // Skip a thread that fails to serialize rather than aborting
-            // the whole exception report.
-        }
+        // Not guarded, for the same reason as buildLibraries(): Thread::serialize()
+        // writes into `builder`, so swallowing a mid-write throw here would leave
+        // the builder nested and corrupt the report. Let it propagate to the
+        // crash boundary in NRMAHandledExceptions, which drops the report.
+        threads.push_back(t->serialize(builder));
     }
 
     auto fbsThreads = builder.CreateVector(threads);
@@ -57,8 +73,9 @@ HandledException::serialize(flatbuffers::FlatBufferBuilder& builder) const {
 
     // getAppImage() is guaranteed to return a valid (possibly zero-UUID)
     // Library even when no images have been registered — see
-    // LibraryController::getAppImage(). We still wrap in try/catch as
-    // belt-and-suspenders against any future change.
+    // LibraryController::getAppImage(). This try/catch is safe to keep because
+    // nothing in it writes to `builder`; it only copies a Library and reads two
+    // integers off it, so swallowing here cannot leave the builder nested.
     uint64_t appUuidLow = 0;
     uint64_t appUuidHigh = 0;
     try {

--- a/scripts/run_oom_resilience_tests.sh
+++ b/scripts/run_oom_resilience_tests.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+#
+# Verify that the handled-exception path cannot kill the host app when the device
+# is out of memory, and that it never writes a malformed report to disk.
+#
+# Two stages:
+#   harness (fast)  Compiles the agent's Hex C++ into a standalone binary, replaces
+#                   global operator new so 1-in-N allocations throw std::bad_alloc,
+#                   and drives HexStore::store() in a tight loop. Then verifies every
+#                   .fbad it wrote is a well-formed HexAgentData buffer. No simulator.
+#   app             Builds NRTestApp, injects the same failure behaviour with
+#                   DYLD_INSERT_LIBRARIES, and drives -[NewRelic recordError:] in a
+#                   tight loop on a simulator. This is the end-to-end test: it
+#                   exercises the real Objective-C crash boundary.
+#
+# Both stages must be built WITHOUT NDEBUG. FLATBUFFERS_ASSERT(!nested) is the
+# detector for a swallowed mid-table exception, and release builds compile it out.
+#
+# See Tests/OOM-RESILIENCE.md for background and for what each failure means.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+SRC_DIR="Tests/OOM-Resilience"
+WORKSPACE="Agent.xcworkspace"
+SCHEME="NRTestApp"
+BUNDLE_ID="com.newrelic.NRApp.bitcode"
+OUT_DIR="build/oom-resilience"
+
+FAIL_ONE_IN=1000
+HARNESS_ITERATIONS=50000
+APP_ITERATIONS=20000
+INJECT_DELAY=12
+START_DELAY=16
+APP_TIMEOUT=600
+SIMULATOR=""
+STAGES="harness app"
+NO_BUILD=0
+EXPECT_CRASH=0
+
+usage() {
+  cat <<USAGE
+usage: scripts/run_oom_resilience_tests.sh [options]
+
+  --harness-only        Run only the fast native harness (no simulator).
+  --app-only            Run only the on-simulator end-to-end test.
+  --fail-one-in N       Fail 1 in N heap allocations. Default ${FAIL_ONE_IN}. Below ~100 the
+                        app's own startup allocations start failing; that is a false
+                        positive, not an agent bug.
+  --iterations N        recordError calls in the app stage. Default ${APP_ITERATIONS}.
+  --harness-iterations N  Calls in the harness stage. Default ${HARNESS_ITERATIONS}.
+  --simulator <id>      Simulator name or UDID. Default: a booted iPhone, else the
+                        newest available iPhone.
+  --expect-crash        Invert the app stage: PASS only if the app DOES die. Use this
+                        after reverting the fix, to confirm the test is not vacuous.
+  --timeout N           Seconds to wait for the app stage verdict. Default ${APP_TIMEOUT}.
+  --out <path>          Default: ${OUT_DIR}
+  --no-build            Reuse an existing NRTestApp build.
+  -h, --help            This message.
+
+examples:
+  scripts/run_oom_resilience_tests.sh
+  scripts/run_oom_resilience_tests.sh --harness-only
+  scripts/run_oom_resilience_tests.sh --app-only --fail-one-in 500
+  scripts/run_oom_resilience_tests.sh --app-only --expect-crash    # against pre-fix code
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --harness-only)       STAGES="harness"; shift ;;
+    --app-only)           STAGES="app"; shift ;;
+    --fail-one-in)        FAIL_ONE_IN="$2"; shift 2 ;;
+    --iterations)         APP_ITERATIONS="$2"; shift 2 ;;
+    --harness-iterations) HARNESS_ITERATIONS="$2"; shift 2 ;;
+    --simulator)          SIMULATOR="$2"; shift 2 ;;
+    --expect-crash)       EXPECT_CRASH=1; shift ;;
+    --timeout)            APP_TIMEOUT="$2"; shift 2 ;;
+    --out)                OUT_DIR="$2"; shift 2 ;;
+    --no-build)           NO_BUILD=1; shift ;;
+    -h|--help)            usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; echo >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$OUT_DIR"
+HARNESS_RESULT="skipped"
+VERIFY_RESULT="skipped"
+APP_RESULT="skipped"
+
+# ---- harness stage -----------------------------------------------------------------
+run_harness() {
+  local lib="libMobileAgent"
+  local inc="$OUT_DIR/include"
+
+  # The Hex sources include their headers as <Hex/Foo.hpp> but the tree nests them
+  # under include/Hex/report/... . Xcode papers over this with a recursive header
+  # search path; reproduce that here by flattening into one directory of symlinks.
+  echo "==> preparing include tree"
+  rm -rf "$inc"
+  mkdir -p "$inc/Hex" "$inc/Utilities" "$inc/Analytics"
+  local group
+  for group in Hex Utilities Analytics; do
+    find "$lib/src/$group/include" -type f \( -name '*.hpp' -o -name '*.h' \) \
+      -exec ln -sf "$REPO_ROOT/{}" "$inc/$group/" \;
+  done
+
+  if [[ ! -d "$lib/ext/flatbuffers/include" ]]; then
+    echo "error: $lib/ext/flatbuffers is empty. Run: git submodule update --init --recursive" >&2
+    HARNESS_RESULT="ERROR (missing flatbuffers submodule)"
+    return 1
+  fi
+
+  local sources=(
+    "$lib/src/Hex/src/HexStore.cxx"
+    "$lib/src/Hex/src/LibraryController.cxx"
+    "$lib/src/Hex/src/report/HexReport.cxx"
+    "$lib/src/Hex/src/report/AgentData.cxx"
+    "$lib/src/Hex/src/report/AppInfo.cxx"
+    "$lib/src/Hex/src/report/ApplicationLicense.cxx"
+    "$lib/src/Hex/src/report/exception/HandledException.cxx"
+    "$lib/src/Hex/src/report/exception/Library.cxx"
+    "$lib/src/Hex/src/report/exception/Thread.cxx"
+    "$lib/src/Hex/src/report/exception/Frame.cxx"
+    "$lib/src/Utilities/src/libLogger.cxx"
+    "$lib/src/Utilities/src/DefaultLogger.cxx"
+    "$lib/src/Utilities/src/BaseValue.cxx"
+    "$lib/src/Utilities/src/String.cxx"
+    "$lib/src/Utilities/src/Boolean.cxx"
+    "$lib/src/Utilities/src/Number.cxx"
+    "$lib/src/Utilities/src/Value.cxx"
+    "$lib/src/Utilities/src/Util.cxx"
+    "$lib/src/Analytics/src/AttributeValidator.cxx"
+    "$lib/src/Analytics/src/AttributeBase.cxx"
+    "$lib/src/Analytics/src/Attribute.cxx"
+  )
+  local attrs=("$lib"/src/Hex/src/report/attributes/*.cxx)
+
+  # -O0 and NO -DNDEBUG on purpose: FLATBUFFERS_ASSERT must stay live.
+  local cxxflags=(-std=c++17 -g -O0 -fexceptions -fno-omit-frame-pointer
+                  -I "$inc" -I "$inc/Hex" -I "$inc/Utilities" -I "$inc/Analytics"
+                  -I "$lib/ext/flatbuffers/include")
+
+  echo "==> compiling harness"
+  if ! clang++ "${cxxflags[@]}" "$SRC_DIR/hex_oom_harness.cxx" \
+       "${sources[@]}" "${attrs[@]}" -o "$OUT_DIR/hex_oom_harness" \
+       > "$OUT_DIR/harness-build.log" 2>&1; then
+    echo "error: harness failed to compile. See $OUT_DIR/harness-build.log" >&2
+    grep -m5 "error:" "$OUT_DIR/harness-build.log" >&2
+    HARNESS_RESULT="ERROR (compile)"
+    return 1
+  fi
+
+  echo "==> compiling verify_reports"
+  if ! clang++ -std=c++17 -O1 -I "$inc/Hex" -I "$lib/ext/flatbuffers/include" \
+       "$SRC_DIR/verify_reports.cxx" -o "$OUT_DIR/verify_reports" \
+       > "$OUT_DIR/verify-build.log" 2>&1; then
+    echo "error: verify_reports failed to compile. See $OUT_DIR/verify-build.log" >&2
+    grep -m5 "error:" "$OUT_DIR/verify-build.log" >&2
+    VERIFY_RESULT="ERROR (compile)"
+    return 1
+  fi
+
+  local store="$OUT_DIR/store"
+  rm -rf "$store"; mkdir -p "$store"
+
+  echo "==> running harness (1-in-${FAIL_ONE_IN}, ${HARNESS_ITERATIONS} calls)"
+  "$OUT_DIR/hex_oom_harness" \
+      --fail-one-in "$FAIL_ONE_IN" \
+      --iterations "$HARNESS_ITERATIONS" \
+      --store "$store" 2>&1 | tee "$OUT_DIR/harness.log"
+  local rc=${PIPESTATUS[0]}
+  case "$rc" in
+    0)  HARNESS_RESULT="PASS" ;;
+    70) HARNESS_RESULT="FAIL (uncaught C++ exception escaped the store path)" ;;
+    71) HARNESS_RESULT="FAIL (assertion failure — builder left nested?)" ;;
+    *)  HARNESS_RESULT="FAIL (exit $rc)" ;;
+  esac
+
+  echo
+  echo "==> verifying stored reports"
+  "$OUT_DIR/verify_reports" "$store" 2>&1 | tee "$OUT_DIR/verify.log"
+  case "${PIPESTATUS[0]}" in
+    0) VERIFY_RESULT="PASS" ;;
+    3) VERIFY_RESULT="INCONCLUSIVE (no reports written)" ;;
+    *) VERIFY_RESULT="FAIL (malformed report on disk)" ;;
+  esac
+}
+
+# ---- app stage ---------------------------------------------------------------------
+resolve_simulator() {
+  # Prefer something already booted so repeat runs do not pay the boot cost.
+  if [[ -z "$SIMULATOR" ]]; then
+    SIMULATOR=$(xcrun simctl list devices available -j 2>/dev/null | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+booted, avail = [], []
+for runtime, devices in data.get("devices", {}).items():
+    if "iOS" not in runtime:
+        continue
+    for d in devices:
+        if not d.get("isAvailable"):
+            continue
+        if "iPhone" not in d.get("name", ""):
+            continue
+        (booted if d.get("state") == "Booted" else avail).append((runtime, d))
+pick = sorted(booted, key=lambda i: i[0])[-1:] or sorted(avail, key=lambda i: i[0])[-1:]
+if pick:
+    print(pick[0][1]["udid"])
+')
+  fi
+  if [[ -z "$SIMULATOR" ]]; then
+    echo "error: no available iOS simulator found. Pass --simulator <name-or-udid>." >&2
+    return 1
+  fi
+}
+
+run_app() {
+  resolve_simulator || { APP_RESULT="ERROR (no simulator)"; return 1; }
+
+  local sdk; sdk=$(xcrun --sdk iphonesimulator --show-sdk-path)
+  echo "==> building OOM injector dylib"
+  if ! clang++ -std=c++17 -O1 -dynamiclib -fexceptions \
+       -isysroot "$sdk" -target arm64-apple-ios17.0-simulator \
+       "$SRC_DIR/oom_injector.cxx" -o "$OUT_DIR/liboominject.dylib" \
+       > "$OUT_DIR/injector-build.log" 2>&1; then
+    echo "error: injector failed to build. See $OUT_DIR/injector-build.log" >&2
+    grep -m5 "error:" "$OUT_DIR/injector-build.log" >&2
+    APP_RESULT="ERROR (injector compile)"
+    return 1
+  fi
+
+  local dd="$OUT_DIR/DerivedData"
+  if [[ "$NO_BUILD" -eq 0 ]]; then
+    echo "==> building $SCHEME"
+    if ! xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk iphonesimulator \
+         -destination "platform=iOS Simulator,id=${SIMULATOR}" -configuration Debug \
+         -derivedDataPath "$dd" build > "$OUT_DIR/app-build.log" 2>&1; then
+      echo "error: $SCHEME failed to build. See $OUT_DIR/app-build.log" >&2
+      grep -m5 "error:" "$OUT_DIR/app-build.log" >&2
+      APP_RESULT="ERROR (app build)"
+      return 1
+    fi
+  fi
+
+  local app="$dd/Build/Products/Debug-iphonesimulator/NRTestApp.app"
+  if [[ ! -d "$app" ]]; then
+    echo "error: built app not found at $app (try without --no-build)" >&2
+    APP_RESULT="ERROR (app missing)"
+    return 1
+  fi
+
+  echo "==> installing on $SIMULATOR"
+  xcrun simctl bootstatus "$SIMULATOR" -b > /dev/null 2>&1
+  xcrun simctl install "$SIMULATOR" "$app" || { APP_RESULT="ERROR (install)"; return 1; }
+  xcrun simctl terminate "$SIMULATOR" "$BUNDLE_ID" > /dev/null 2>&1
+
+  echo "==> running ${APP_ITERATIONS} recordError calls under 1-in-${FAIL_ONE_IN} allocation failure"
+  echo "    (injector arms at T+${INJECT_DELAY}s, loop starts at T+${START_DELAY}s)"
+  local log="$OUT_DIR/app.log"
+  : > "$log"
+  SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="$PWD/$OUT_DIR/liboominject.dylib" \
+  SIMCTL_CHILD_NR_OOM_ONE_IN="$FAIL_ONE_IN" \
+  SIMCTL_CHILD_NR_OOM_DELAY="$INJECT_DELAY" \
+  SIMCTL_CHILD_NR_OOM_THREAD="nr-oom-loop" \
+  xcrun simctl launch --console "$SIMULATOR" "$BUNDLE_ID" \
+      -RunHexOOMRepro \
+      -HexOOMIterations "$APP_ITERATIONS" \
+      -HexOOMStartDelay "$START_DELAY" > "$log" 2>&1 &
+  local launch_pid=$!
+
+  # NRTestApp is a UI app: on a PASSING run it stays alive, so `simctl launch
+  # --console` would block forever. Wait for a verdict to appear in the log
+  # instead, then shut the app down ourselves.
+  local waited=0
+  while (( waited < APP_TIMEOUT )); do
+    if grep -qE "HexOOMRepro: DONE|libc\+\+abi|terminating due to|Assertion failed" \
+         "$log" 2>/dev/null; then
+      break
+    fi
+    sleep 2
+    waited=$(( waited + 2 ))
+  done
+  sleep 1   # let the surrounding log lines flush
+  xcrun simctl terminate "$SIMULATOR" "$BUNDLE_ID" > /dev/null 2>&1
+  kill "$launch_pid" 2>/dev/null
+  wait "$launch_pid" 2>/dev/null
+
+  if (( waited >= APP_TIMEOUT )); then
+    APP_RESULT="FAIL (no verdict within ${APP_TIMEOUT}s — see $log)"
+    return 0
+  fi
+
+  local survived=0 crashed=0 drops=0
+  grep -q "HexOOMRepro: DONE" "$log" && survived=1
+  grep -qE "libc\+\+abi|terminating due to|Assertion failed" "$log" && crashed=1
+  drops=$(grep -cE "Dropped handled (error|exception) report" "$log")
+
+  echo
+  echo "    injector armed : $(grep -c '\[NR_OOM\] ARMED' "$log")"
+  echo "    reports dropped: $drops"
+  echo "    reached DONE   : $survived"
+  echo "    crash markers  : $crashed"
+  echo "    full log       : $log"
+
+  if [[ "$EXPECT_CRASH" -eq 1 ]]; then
+    if [[ "$crashed" -eq 1 && "$survived" -eq 0 ]]; then
+      APP_RESULT="PASS (crashed as expected with --expect-crash)"
+    else
+      APP_RESULT="FAIL (--expect-crash given but the app survived)"
+    fi
+    return 0
+  fi
+
+  if [[ "$crashed" -eq 1 ]]; then
+    APP_RESULT="FAIL (the app was killed — see $log)"
+  elif [[ "$survived" -eq 0 ]]; then
+    APP_RESULT="FAIL (never reached DONE — app died silently or loop never started)"
+  elif [[ "$drops" -eq 0 ]]; then
+    # Treated as a failure on purpose: a run that provoked nothing proves nothing,
+    # and reporting PASS here would hide a mis-armed injector.
+    APP_RESULT="FAIL (INCONCLUSIVE: survived but nothing was dropped — injector never fired)"
+  else
+    APP_RESULT="PASS"
+  fi
+}
+
+# ---- run ---------------------------------------------------------------------------
+for stage in $STAGES; do
+  echo
+  echo "######## stage: $stage ########"
+  case "$stage" in
+    harness) run_harness ;;
+    app)     run_app ;;
+  esac
+done
+
+echo
+echo "============== OOM resilience summary =============="
+echo "native harness (store path survives):  $HARNESS_RESULT"
+echo "stored reports well-formed:            $VERIFY_RESULT"
+echo "app end-to-end (crash boundary holds): $APP_RESULT"
+
+for result in "$HARNESS_RESULT" "$VERIFY_RESULT" "$APP_RESULT"; do
+  case "$result" in
+    FAIL*|ERROR*) echo "RESULT: FAIL"; exit 1 ;;
+  esac
+done
+echo "RESULT: PASS"

--- a/scripts/run_oom_resilience_tests.sh
+++ b/scripts/run_oom_resilience_tests.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+#
+# Verify that the handled-exception path cannot kill the host app when the device
+# is out of memory, and that it never writes a malformed report to disk.
+#
+# Two stages:
+#   harness (fast)  Compiles the agent's Hex C++ into a standalone binary, replaces
+#                   global operator new so 1-in-N allocations throw std::bad_alloc,
+#                   and drives HexStore::store() in a tight loop. Then verifies every
+#                   .fbad it wrote is a well-formed HexAgentData buffer. No simulator.
+#   app             Builds NRTestApp, injects the same failure behaviour with
+#                   DYLD_INSERT_LIBRARIES, and drives -[NewRelic recordError:] in a
+#                   tight loop on a simulator. This is the end-to-end test: it
+#                   exercises the real Objective-C crash boundary.
+#
+# Both stages must be built WITHOUT NDEBUG. FLATBUFFERS_ASSERT(!nested) is the
+# detector for a swallowed mid-table exception, and release builds compile it out.
+#
+# See Tests/OOM-RESILIENCE.md for background and for what each failure means.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+SRC_DIR="Tests/OOM-Resilience"
+WORKSPACE="Agent.xcworkspace"
+SCHEME="NRTestApp"
+BUNDLE_ID="com.newrelic.NRApp.bitcode"
+OUT_DIR="build/oom-resilience"
+
+FAIL_ONE_IN=1000
+HARNESS_ITERATIONS=50000
+APP_ITERATIONS=20000
+INJECT_DELAY=12
+START_DELAY=16
+APP_TIMEOUT=600
+SIMULATOR=""
+STAGES="harness app"
+NO_BUILD=0
+EXPECT_CRASH=0
+
+usage() {
+  cat <<USAGE
+usage: scripts/run_oom_resilience_tests.sh [options]
+
+  --harness-only        Run only the fast native harness (no simulator).
+  --app-only            Run only the on-simulator end-to-end test.
+  --fail-one-in N       Fail 1 in N heap allocations. Default ${FAIL_ONE_IN}. Below ~100 the
+                        app's own startup allocations start failing; that is a false
+                        positive, not an agent bug.
+  --iterations N        recordError calls in the app stage. Default ${APP_ITERATIONS}.
+  --harness-iterations N  Calls in the harness stage. Default ${HARNESS_ITERATIONS}.
+  --simulator <id>      Simulator name or UDID. Default: a booted iPhone, else the
+                        newest available iPhone.
+  --expect-crash        Invert the app stage: PASS only if the app DOES die. Use this
+                        after reverting the fix, to confirm the test is not vacuous.
+  --timeout N           Seconds to wait for the app stage verdict. Default ${APP_TIMEOUT}.
+  --out <path>          Default: ${OUT_DIR}
+  --no-build            Reuse an existing NRTestApp build.
+  -h, --help            This message.
+
+examples:
+  scripts/run_oom_resilience_tests.sh
+  scripts/run_oom_resilience_tests.sh --harness-only
+  scripts/run_oom_resilience_tests.sh --app-only --fail-one-in 500
+  scripts/run_oom_resilience_tests.sh --app-only --expect-crash    # against pre-fix code
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --harness-only)       STAGES="harness"; shift ;;
+    --app-only)           STAGES="app"; shift ;;
+    --fail-one-in)        FAIL_ONE_IN="$2"; shift 2 ;;
+    --iterations)         APP_ITERATIONS="$2"; shift 2 ;;
+    --harness-iterations) HARNESS_ITERATIONS="$2"; shift 2 ;;
+    --simulator)          SIMULATOR="$2"; shift 2 ;;
+    --expect-crash)       EXPECT_CRASH=1; shift ;;
+    --timeout)            APP_TIMEOUT="$2"; shift 2 ;;
+    --out)                OUT_DIR="$2"; shift 2 ;;
+    --no-build)           NO_BUILD=1; shift ;;
+    -h|--help)            usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; echo >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$OUT_DIR"
+HARNESS_RESULT="skipped"
+VERIFY_RESULT="skipped"
+APP_RESULT="skipped"
+
+# ---- harness stage -----------------------------------------------------------------
+run_harness() {
+  local lib="libMobileAgent"
+  local inc="$OUT_DIR/include"
+
+  # The Hex sources include their headers as <Hex/Foo.hpp> but the tree nests them
+  # under include/Hex/report/... . Xcode papers over this with a recursive header
+  # search path; reproduce that here by flattening into one directory of symlinks.
+  echo "==> preparing include tree"
+  rm -rf "$inc"
+  mkdir -p "$inc/Hex" "$inc/Utilities" "$inc/Analytics"
+  local group
+  for group in Hex Utilities Analytics; do
+    find "$lib/src/$group/include" -type f \( -name '*.hpp' -o -name '*.h' \) \
+      -exec ln -sf "$REPO_ROOT/{}" "$inc/$group/" \;
+  done
+
+  if [[ ! -d "$lib/ext/flatbuffers/include" ]]; then
+    echo "error: $lib/ext/flatbuffers is empty. Run: git submodule update --init --recursive" >&2
+    HARNESS_RESULT="ERROR (missing flatbuffers submodule)"
+    return 1
+  fi
+
+  local sources=(
+    "$lib/src/Hex/src/HexStore.cxx"
+    "$lib/src/Hex/src/LibraryController.cxx"
+    "$lib/src/Hex/src/report/HexReport.cxx"
+    "$lib/src/Hex/src/report/AgentData.cxx"
+    "$lib/src/Hex/src/report/AppInfo.cxx"
+    "$lib/src/Hex/src/report/ApplicationLicense.cxx"
+    "$lib/src/Hex/src/report/exception/HandledException.cxx"
+    "$lib/src/Hex/src/report/exception/Library.cxx"
+    "$lib/src/Hex/src/report/exception/Thread.cxx"
+    "$lib/src/Hex/src/report/exception/Frame.cxx"
+    "$lib/src/Utilities/src/libLogger.cxx"
+    "$lib/src/Utilities/src/DefaultLogger.cxx"
+    "$lib/src/Utilities/src/BaseValue.cxx"
+    "$lib/src/Utilities/src/String.cxx"
+    "$lib/src/Utilities/src/Boolean.cxx"
+    "$lib/src/Utilities/src/Number.cxx"
+    "$lib/src/Utilities/src/Value.cxx"
+    "$lib/src/Utilities/src/Util.cxx"
+    "$lib/src/Analytics/src/AttributeValidator.cxx"
+    "$lib/src/Analytics/src/AttributeBase.cxx"
+    "$lib/src/Analytics/src/Attribute.cxx"
+  )
+  local attrs=("$lib"/src/Hex/src/report/attributes/*.cxx)
+
+  # -O0 and NO -DNDEBUG on purpose: FLATBUFFERS_ASSERT must stay live.
+  local cxxflags=(-std=c++17 -g -O0 -fexceptions -fno-omit-frame-pointer
+                  -I "$inc" -I "$inc/Hex" -I "$inc/Utilities" -I "$inc/Analytics"
+                  -I "$lib/ext/flatbuffers/include")
+
+  echo "==> compiling harness"
+  if ! clang++ "${cxxflags[@]}" "$SRC_DIR/hex_oom_harness.cxx" \
+       "${sources[@]}" "${attrs[@]}" -o "$OUT_DIR/hex_oom_harness" \
+       > "$OUT_DIR/harness-build.log" 2>&1; then
+    echo "error: harness failed to compile. See $OUT_DIR/harness-build.log" >&2
+    grep -m5 "error:" "$OUT_DIR/harness-build.log" >&2
+    HARNESS_RESULT="ERROR (compile)"
+    return 1
+  fi
+
+  echo "==> compiling verify_reports"
+  if ! clang++ -std=c++17 -O1 -I "$inc/Hex" -I "$lib/ext/flatbuffers/include" \
+       "$SRC_DIR/verify_reports.cxx" -o "$OUT_DIR/verify_reports" \
+       > "$OUT_DIR/verify-build.log" 2>&1; then
+    echo "error: verify_reports failed to compile. See $OUT_DIR/verify-build.log" >&2
+    grep -m5 "error:" "$OUT_DIR/verify-build.log" >&2
+    VERIFY_RESULT="ERROR (compile)"
+    return 1
+  fi
+
+  local store="$OUT_DIR/store"
+  rm -rf "$store"; mkdir -p "$store"
+
+  echo "==> running harness (1-in-${FAIL_ONE_IN}, ${HARNESS_ITERATIONS} calls)"
+  "$OUT_DIR/hex_oom_harness" \
+      --fail-one-in "$FAIL_ONE_IN" \
+      --iterations "$HARNESS_ITERATIONS" \
+      --store "$store" 2>&1 | tee "$OUT_DIR/harness.log"
+  local rc=${PIPESTATUS[0]}
+  case "$rc" in
+    0)  HARNESS_RESULT="PASS" ;;
+    70) HARNESS_RESULT="FAIL (uncaught C++ exception escaped the store path)" ;;
+    71) HARNESS_RESULT="FAIL (assertion failure — builder left nested?)" ;;
+    *)  HARNESS_RESULT="FAIL (exit $rc)" ;;
+  esac
+
+  echo
+  echo "==> verifying stored reports"
+  "$OUT_DIR/verify_reports" "$store" 2>&1 | tee "$OUT_DIR/verify.log"
+  case "${PIPESTATUS[0]}" in
+    0) VERIFY_RESULT="PASS" ;;
+    3) VERIFY_RESULT="INCONCLUSIVE (no reports written)" ;;
+    *) VERIFY_RESULT="FAIL (malformed report on disk)" ;;
+  esac
+}
+
+# ---- app stage ---------------------------------------------------------------------
+resolve_simulator() {
+  # Prefer something already booted so repeat runs do not pay the boot cost.
+  if [[ -z "$SIMULATOR" ]]; then
+    SIMULATOR=$(xcrun simctl list devices available -j 2>/dev/null | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+booted, avail = [], []
+for runtime, devices in data.get("devices", {}).items():
+    if "iOS" not in runtime:
+        continue
+    for d in devices:
+        if not d.get("isAvailable"):
+            continue
+        if "iPhone" not in d.get("name", ""):
+            continue
+        (booted if d.get("state") == "Booted" else avail).append((runtime, d))
+pick = sorted(booted, key=lambda i: i[0])[-1:] or sorted(avail, key=lambda i: i[0])[-1:]
+if pick:
+    print(pick[0][1]["udid"])
+')
+  fi
+  if [[ -z "$SIMULATOR" ]]; then
+    echo "error: no available iOS simulator found. Pass --simulator <name-or-udid>." >&2
+    return 1
+  fi
+}
+
+run_app() {
+  resolve_simulator || { APP_RESULT="ERROR (no simulator)"; return 1; }
+
+  local sdk; sdk=$(xcrun --sdk iphonesimulator --show-sdk-path)
+  echo "==> building OOM injector dylib"
+  if ! clang++ -std=c++17 -O1 -dynamiclib -fexceptions \
+       -isysroot "$sdk" -target arm64-apple-ios17.0-simulator \
+       "$SRC_DIR/oom_injector.cxx" -o "$OUT_DIR/liboominject.dylib" \
+       > "$OUT_DIR/injector-build.log" 2>&1; then
+    echo "error: injector failed to build. See $OUT_DIR/injector-build.log" >&2
+    grep -m5 "error:" "$OUT_DIR/injector-build.log" >&2
+    APP_RESULT="ERROR (injector compile)"
+    return 1
+  fi
+
+  local dd="$OUT_DIR/DerivedData"
+  if [[ "$NO_BUILD" -eq 0 ]]; then
+    echo "==> building $SCHEME"
+    if ! xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk iphonesimulator \
+         -destination "platform=iOS Simulator,id=${SIMULATOR}" -configuration Debug \
+         -derivedDataPath "$dd" build > "$OUT_DIR/app-build.log" 2>&1; then
+      echo "error: $SCHEME failed to build. See $OUT_DIR/app-build.log" >&2
+      grep -m5 "error:" "$OUT_DIR/app-build.log" >&2
+      APP_RESULT="ERROR (app build)"
+      return 1
+    fi
+  fi
+
+  local app="$dd/Build/Products/Debug-iphonesimulator/NRTestApp.app"
+  if [[ ! -d "$app" ]]; then
+    echo "error: built app not found at $app (try without --no-build)" >&2
+    APP_RESULT="ERROR (app missing)"
+    return 1
+  fi
+
+  echo "==> installing on $SIMULATOR"
+  xcrun simctl bootstatus "$SIMULATOR" -b > /dev/null 2>&1
+  xcrun simctl install "$SIMULATOR" "$app" || { APP_RESULT="ERROR (install)"; return 1; }
+  xcrun simctl terminate "$SIMULATOR" "$BUNDLE_ID" > /dev/null 2>&1
+
+  echo "==> running ${APP_ITERATIONS} recordError calls under 1-in-${FAIL_ONE_IN} allocation failure"
+  echo "    (injector arms at T+${INJECT_DELAY}s, loop starts at T+${START_DELAY}s)"
+  local log="$OUT_DIR/app.log"
+  : > "$log"
+  SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="$PWD/$OUT_DIR/liboominject.dylib" \
+  SIMCTL_CHILD_NR_OOM_ONE_IN="$FAIL_ONE_IN" \
+  SIMCTL_CHILD_NR_OOM_DELAY="$INJECT_DELAY" \
+  SIMCTL_CHILD_NR_OOM_THREAD="nr-oom-loop" \
+  xcrun simctl launch --console "$SIMULATOR" "$BUNDLE_ID" \
+      -RunHexOOMRepro \
+      -HexOOMIterations "$APP_ITERATIONS" \
+      -HexOOMStartDelay "$START_DELAY" > "$log" 2>&1 &
+  local launch_pid=$!
+
+  # NRTestApp is a UI app: on a PASSING run it stays alive, so `simctl launch
+  # --console` would block forever. Wait for a verdict to appear in the log
+  # instead, then shut the app down ourselves.
+  local waited=0
+  while (( waited < APP_TIMEOUT )); do
+    if grep -qE "HexOOMRepro: DONE|libc\+\+abi|terminating due to|Assertion failed" \
+         "$log" 2>/dev/null; then
+      break
+    fi
+    sleep 2
+    waited=$(( waited + 2 ))
+  done
+  sleep 1   # let the surrounding log lines flush
+  xcrun simctl terminate "$SIMULATOR" "$BUNDLE_ID" > /dev/null 2>&1
+  kill "$launch_pid" 2>/dev/null
+  wait "$launch_pid" 2>/dev/null
+
+  if (( waited >= APP_TIMEOUT )); then
+    APP_RESULT="FAIL (no verdict within ${APP_TIMEOUT}s — see $log)"
+    return 0
+  fi
+
+  local survived=0 crashed=0 drops=0
+  grep -q "HexOOMRepro: DONE" "$log" && survived=1
+  grep -qE "libc\+\+abi|terminating due to|Assertion failed" "$log" && crashed=1
+  drops=$(grep -cE "Dropped handled (error|exception) report" "$log")
+
+  echo
+  echo "    injector armed : $(grep -c '\[NR_OOM\] ARMED' "$log")"
+  echo "    reports dropped: $drops"
+  echo "    reached DONE   : $survived"
+  echo "    crash markers  : $crashed"
+  echo "    full log       : $log"
+
+  if [[ "$EXPECT_CRASH" -eq 1 ]]; then
+    if [[ "$crashed" -eq 1 && "$survived" -eq 0 ]]; then
+      APP_RESULT="PASS (crashed as expected with --expect-crash)"
+    else
+      APP_RESULT="FAIL (--expect-crash given but the app survived)"
+    fi
+    return 0
+  fi
+
+  if [[ "$crashed" -eq 1 ]]; then
+    APP_RESULT="FAIL (the app was killed — see $log)"
+  elif [[ "$survived" -eq 0 ]]; then
+    APP_RESULT="FAIL (never reached DONE — app died silently or loop never started)"
+  elif [[ "$drops" -eq 0 ]]; then
+    APP_RESULT="INCONCLUSIVE (survived but nothing was dropped — was the injector armed?)"
+  else
+    APP_RESULT="PASS"
+  fi
+}
+
+# ---- run ---------------------------------------------------------------------------
+for stage in $STAGES; do
+  echo
+  echo "######## stage: $stage ########"
+  case "$stage" in
+    harness) run_harness ;;
+    app)     run_app ;;
+  esac
+done
+
+echo
+echo "============== OOM resilience summary =============="
+echo "native harness (store path survives):  $HARNESS_RESULT"
+echo "stored reports well-formed:            $VERIFY_RESULT"
+echo "app end-to-end (crash boundary holds): $APP_RESULT"
+
+for result in "$HARNESS_RESULT" "$VERIFY_RESULT" "$APP_RESULT"; do
+  case "$result" in
+    FAIL*|ERROR*) echo "RESULT: FAIL"; exit 1 ;;
+  esac
+done
+echo "RESULT: PASS"


### PR DESCRIPTION
A std::bad_alloc raised while serializing a handled-exception report unwound out of -[NRMAHandledExceptions recordError:attributes:] with no handler above it, hit std::terminate, and killed the host app. Reported as GitHub issue #884, with the frames HexController::submit -> HexStore::store -> HexReport::finalize -> AgentData::serialize -> HandledException::serialize and __cxa_call_terminate.

One recordError call makes 112-304 heap allocations and any single failure was fatal, which is why it surfaced as one crash from one user on a device with ~175 MiB free of ~6.8 GiB in use.

Three changes:

- NRMAHandledExceptions.mm: the three public record* entry points are now thin guarded wrappers around nrma_*Unguarded: internals, logging and dropping the report on any C++ exception. The guard is here rather than inside HexController::submit because the throw can originate in createReport() and in the attribute plumbing, both of which run before submit is reached — guarding submit alone just relocates the crash to HexReport's constructor.

- HandledException.cxx: buildLibraries() and the thread loop no longer swallow exceptions raised while writing to the FlatBufferBuilder. Library::serialize and Thread::serialize open a table, so catching mid-write left the builder with nested_ == true and the next CreateVector tripped FLATBUFFERS_ASSERT(!nested) — an abort in debug, and a silently malformed buffer in release, where ENABLE_NS_ASSERTIONS=NO defines NDEBUG and compiles the assert out. Only the builder-free work stays guarded: copying the library snapshot and reading the app image UUID.

- HexStore::store(): serializes before opening the file, so a report that fails to serialize no longer leaves a 0-byte .fbad behind for readAll() to reap.

Adds Tests/OOM-Resilience and scripts/run_oom_resilience_tests.sh, which make the failure deterministic by replacing global operator new so 1-in-N allocations throw. Measured across this change:

  before  app killed by uncaught std::bad_alloc within ~2k recordError calls.
          Reports on disk included 0-byte files, reports truncated mid-library-
          list, and one buffer the flatbuffers verifier rejected outright.
  after   20,000 calls survived, 10,341 reports dropped and logged, no crash.
          50,000 calls survived in the native harness. Every stored report
          verifies, in one of two shapes: complete, or zero libraries when the
          library snapshot itself failed.

The suite ships a --expect-crash mode that asserts the app DOES die, so the test can be shown to still catch the original bug rather than passing vacuously.

Not addressed here: the agent's harvest and upload threads do unguarded C++ allocation too and die the same way under process-wide injection. That is a larger piece of work than this issue; Tests/OOM-RESILIENCE.md calls it out so it is not mistaken for covered ground.