### PR TITLE
NR-461357 added a supportability metric to detect browser agent in webview

### DIFF
--- a/Agent.xcodeproj/project.pbxproj
+++ b/Agent.xcodeproj/project.pbxproj
@@ -1615,6 +1615,7 @@
 		F806E4282D9C7E3F0003B9D6 /* SessionReplayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F806E4272D9C7E3F0003B9D6 /* SessionReplayManager.swift */; };
 		F80C1D6A2DA07691007C0F52 /* ViewDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80C1D692DA07691007C0F52 /* ViewDetails.swift */; };
 		F810620E2E16D02D00B8CC81 /* UIVisualEffectViewThingy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81061FA2E16D01D00B8CC81 /* UIVisualEffectViewThingy.swift */; };
+		F81C3D223049FD410063C9C0 /* NRMAWebViewSupportability.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BD0738B2EB038AB00E3556B /* NRMAWebViewSupportability.m */; };
 		F81E70682EC7A75C00698BF8 /* UIColorHexStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81E70672EC7A75C00698BF8 /* UIColorHexStringTests.swift */; };
 		F81E707C2EC7AB4800698BF8 /* UIColor+HexString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D0401D2D86036D007BE92D /* UIColor+HexString.swift */; };
 		F824A43129AEAD63000886A6 /* NRViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F824A43029AEAD63000886A6 /* NRViewModifier.swift */; };
@@ -2698,6 +2699,7 @@
 		34EA78DF2A3924CC0071CC95 /* TestCustomEvents.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestCustomEvents.m; sourceTree = "<group>"; };
 		59AA4543706D6BB36459A6C5 /* NewRelicAgent.podspec.template */ = {isa = PBXFileReference; lastKnownFileType = file.podspec; name = NewRelicAgent.podspec.template; path = cocoapods/NewRelicAgent.podspec.template; sourceTree = "<group>"; };
 		59AA4F6AF53601FEA41A1303 /* dev_build_xcframework.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = dev_build_xcframework.sh; sourceTree = "<group>"; };
+		C15109B42FC49AA5B0AE1D31 /* SessionReplayHarvestEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayHarvestEndToEndTests.swift; sourceTree = "<group>"; };
 		C94F518C28577E0000E81E01 /* InstrumentationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InstrumentationTests.m; sourceTree = "<group>"; };
 		C94F51A02857832B00E81E01 /* NRMAActivityNameGeneratorTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRMAActivityNameGeneratorTest.m; sourceTree = "<group>"; };
 		C9C28B9E284A6AF70097B433 /* NRMAKeyAttributesTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRMAKeyAttributesTest.m; sourceTree = "<group>"; };
@@ -2740,7 +2742,6 @@
 		F879257B2D441ACC00576F5D /* NRMAAttributeValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NRMAAttributeValidator.h; sourceTree = "<group>"; };
 		F88801D12FC5FB780051DC67 /* SessionReplayReporterOfflineStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayReporterOfflineStorageTests.swift; sourceTree = "<group>"; };
 		F88801E62FC734C90051DC67 /* SessionReplayReporterNetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayReporterNetworkTests.swift; sourceTree = "<group>"; };
-		C15109B42FC49AA5B0AE1D31 /* SessionReplayHarvestEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayHarvestEndToEndTests.swift; sourceTree = "<group>"; };
 		F88C2CE32A2FA7AC00373EFE /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		F89167382BC9D1540085BCFC /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.2.sdk/usr/lib/libc++.tbd"; sourceTree = DEVELOPER_DIR; };
 		F891A6BD2CB6F5C1007675F4 /* NRAutoLogCollector.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRAutoLogCollector.m; sourceTree = "<group>"; };
@@ -5644,6 +5645,7 @@
 				F85ABB652F155B780098A2CF /* UIFont+CSSConversion.swift in Sources */,
 				F8BF15512F3A38B700EF5628 /* XrayDecoder+Children.swift in Sources */,
 				F8A455482AFBE31E0057B1E0 /* NRMAURLSessionHeaderTrackingTestsOldEventSystem.m in Sources */,
+				F81C3D223049FD410063C9C0 /* NRMAWebViewSupportability.m in Sources */,
 				343883562834405700B31C2E /* NRMAURLTransformerTests.m in Sources */,
 				0209AC0C24E7071500E45C90 /* APIMethodTraceTest.m in Sources */,
 				0209ABD824E706AE00E45C90 /* TestRetryTracker.m in Sources */,
@@ -5660,7 +5662,6 @@
 				2B4226FB29DB9A170068BB8A /* NRMAHTTPUtilitiesTests.m in Sources */,
 				0209AC3D24E7075200E45C90 /* NRHarvestableVitalsTest.m in Sources */,
 				F88801E72FC734C90051DC67 /* SessionReplayReporterNetworkTests.swift in Sources */,
-				0EA0DA15A28C7FE0E98CD11E /* SessionReplayHarvestEndToEndTests.swift in Sources */,
 				F8BF15382F3A37C200EF5628 /* SwiftUIShapeThingy.swift in Sources */,
 				0209AC4A24E7078C00E45C90 /* NRMACrashDataUploaderTest.m in Sources */,
 				C94F51A12857832B00E81E01 /* NRMAActivityNameGeneratorTest.m in Sources */,

--- a/Agent.xcodeproj/project.pbxproj
+++ b/Agent.xcodeproj/project.pbxproj
@@ -52,7 +52,6 @@
 		0209AC3124E7073800E45C90 /* NRMADeviceInformationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC2D24E7073800E45C90 /* NRMADeviceInformationTests.m */; };
 		0209AC3224E7073800E45C90 /* NRMAHarvestableAnalyticsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC2E24E7073800E45C90 /* NRMAHarvestableAnalyticsTest.m */; };
 		0209AC3424E7074100E45C90 /* NRMAConnectionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3324E7074100E45C90 /* NRMAConnectionTest.m */; };
-		CD11FE0002000000000000A2 /* NRMAHarvesterConfigurationLifetimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD11FE0001000000000000A1 /* NRMAHarvesterConfigurationLifetimeTests.m */; };
 		0209AC3D24E7075200E45C90 /* NRHarvestableVitalsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3624E7075100E45C90 /* NRHarvestableVitalsTest.m */; };
 		0209AC3E24E7075200E45C90 /* NRHarvesterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3724E7075100E45C90 /* NRHarvesterTest.m */; };
 		0209AC3F24E7075200E45C90 /* NRHarvesterStateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3824E7075200E45C90 /* NRHarvesterStateTest.m */; };
@@ -122,7 +121,6 @@
 		0256580E24EB19BF00FE3125 /* NRMAAppTokenTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC0824E7071400E45C90 /* NRMAAppTokenTest.m */; };
 		0256580F24EB19BF00FE3125 /* TestContextAdapter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0209ABD624E706AE00E45C90 /* TestContextAdapter.mm */; };
 		0256581024EB19BF00FE3125 /* NRMAConnectionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3324E7074100E45C90 /* NRMAConnectionTest.m */; };
-		CD11FE0003000000000000A3 /* NRMAHarvesterConfigurationLifetimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD11FE0001000000000000A1 /* NRMAHarvesterConfigurationLifetimeTests.m */; };
 		0256581124EB19BF00FE3125 /* NRMALastActivityTraceControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209ABE724E706F900E45C90 /* NRMALastActivityTraceControllerTest.m */; };
 		0256581224EB19BF00FE3125 /* APINetworkNoticeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC0624E7071400E45C90 /* APINetworkNoticeTest.m */; };
 		0256581324EB19BF00FE3125 /* NRMADeviceInformationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC2D24E7073800E45C90 /* NRMADeviceInformationTests.m */; };
@@ -1129,7 +1127,6 @@
 		3431DD7E2BED4A5200FF145F /* NRHarvesterConnectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3924E7075200E45C90 /* NRHarvesterConnectionTests.m */; };
 		3431DD7F2BED4A5200FF145F /* NRHarvesterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3724E7075100E45C90 /* NRHarvesterTest.m */; };
 		3431DD802BED4A5200FF145F /* NRMAConnectionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3324E7074100E45C90 /* NRMAConnectionTest.m */; };
-		CD11FE0004000000000000A4 /* NRMAHarvesterConfigurationLifetimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD11FE0001000000000000A1 /* NRMAHarvesterConfigurationLifetimeTests.m */; };
 		3431DD812BED4A5200FF145F /* NRHarvestableVitalsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3624E7075100E45C90 /* NRHarvestableVitalsTest.m */; };
 		3431DD822BED4A5200FF145F /* NRHarvesterStateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC3824E7075200E45C90 /* NRHarvesterStateTest.m */; };
 		3431DD842BED4A9900FF145F /* NRMAFeatureFlagsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0209AC4324E7078000E45C90 /* NRMAFeatureFlagsTests.m */; };
@@ -1584,6 +1581,9 @@
 		C94F518D28577E0000E81E01 /* InstrumentationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C94F518C28577E0000E81E01 /* InstrumentationTests.m */; };
 		C94F51A12857832B00E81E01 /* NRMAActivityNameGeneratorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C94F51A02857832B00E81E01 /* NRMAActivityNameGeneratorTest.m */; };
 		C9C28B9F284A6AF70097B433 /* NRMAKeyAttributesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C9C28B9E284A6AF70097B433 /* NRMAKeyAttributesTest.m */; };
+		CD11FE0002000000000000A2 /* NRMAHarvesterConfigurationLifetimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD11FE0001000000000000A1 /* NRMAHarvesterConfigurationLifetimeTests.m */; };
+		CD11FE0003000000000000A3 /* NRMAHarvesterConfigurationLifetimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD11FE0001000000000000A1 /* NRMAHarvesterConfigurationLifetimeTests.m */; };
+		CD11FE0004000000000000A4 /* NRMAHarvesterConfigurationLifetimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD11FE0001000000000000A1 /* NRMAHarvesterConfigurationLifetimeTests.m */; };
 		D4580CA72F563363003BAD8C /* JSErrorControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D4580CA52F563363003BAD8C /* JSErrorControllerTests.m */; };
 		D46F91C02F69CD5600FD2EBE /* UISwitchThingy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46F91BF2F69CD5600FD2EBE /* UISwitchThingy.swift */; };
 		D46F91C12F69CD5600FD2EBE /* UISwitchThingy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46F91BF2F69CD5600FD2EBE /* UISwitchThingy.swift */; };
@@ -1692,6 +1692,7 @@
 		F8BF15572F3A3A8F00EF5628 /* XRayDecoderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B34935D2E8DD6EF006DE9D0 /* XRayDecoderError.swift */; };
 		F8BF15582F3A3AC700EF5628 /* XrayDecoder+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3493632E8E1438006DE9D0 /* XrayDecoder+Navigation.swift */; };
 		F8BF15592F3A3AE800EF5628 /* UIViewThingy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3493DF4B2D542D9900BF5BED /* UIViewThingy.swift */; };
+		F8CF3ABF3051955E003E48CA /* SessionReplayHarvestEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15109B42FC49AA5B0AE1D31 /* SessionReplayHarvestEndToEndTests.swift */; };
 		F8D23CF22F7C0DC9000FFD31 /* NRMASessionDurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D23CF12F7C0DC9000FFD31 /* NRMASessionDurationManager.swift */; };
 		F8D23CF32F7C0DC9000FFD31 /* NRMASessionDurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D23CF12F7C0DC9000FFD31 /* NRMASessionDurationManager.swift */; };
 		F8D23CF42F7C0DC9000FFD31 /* NRMASessionDurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D23CF12F7C0DC9000FFD31 /* NRMASessionDurationManager.swift */; };
@@ -2135,7 +2136,6 @@
 		0209AC2D24E7073800E45C90 /* NRMADeviceInformationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRMADeviceInformationTests.m; sourceTree = "<group>"; };
 		0209AC2E24E7073800E45C90 /* NRMAHarvestableAnalyticsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRMAHarvestableAnalyticsTest.m; sourceTree = "<group>"; };
 		0209AC3324E7074100E45C90 /* NRMAConnectionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRMAConnectionTest.m; sourceTree = "<group>"; };
-		CD11FE0001000000000000A1 /* NRMAHarvesterConfigurationLifetimeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRMAHarvesterConfigurationLifetimeTests.m; sourceTree = "<group>"; };
 		0209AC3524E7075100E45C90 /* NRHarvesterStateTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NRHarvesterStateTest.h; sourceTree = "<group>"; };
 		0209AC3624E7075100E45C90 /* NRHarvestableVitalsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRHarvestableVitalsTest.m; sourceTree = "<group>"; };
 		0209AC3724E7075100E45C90 /* NRHarvesterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRHarvesterTest.m; sourceTree = "<group>"; };
@@ -2707,6 +2707,7 @@
 		C94F518C28577E0000E81E01 /* InstrumentationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InstrumentationTests.m; sourceTree = "<group>"; };
 		C94F51A02857832B00E81E01 /* NRMAActivityNameGeneratorTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRMAActivityNameGeneratorTest.m; sourceTree = "<group>"; };
 		C9C28B9E284A6AF70097B433 /* NRMAKeyAttributesTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NRMAKeyAttributesTest.m; sourceTree = "<group>"; };
+		CD11FE0001000000000000A1 /* NRMAHarvesterConfigurationLifetimeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRMAHarvesterConfigurationLifetimeTests.m; sourceTree = "<group>"; };
 		D4580CA52F563363003BAD8C /* JSErrorControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = JSErrorControllerTests.m; sourceTree = "<group>"; };
 		D46F91BF2F69CD5600FD2EBE /* UISwitchThingy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISwitchThingy.swift; sourceTree = "<group>"; };
 		D48D55172F4E46B2003BE3AB /* JSErrorController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSErrorController.swift; sourceTree = "<group>"; };
@@ -5685,6 +5686,7 @@
 				0209AC4024E7075200E45C90 /* NRHarvesterConnectionTests.m in Sources */,
 				2BBC1A552DEDF61A00F5C584 /* SessionReplayTest.m in Sources */,
 				D4580CA72F563363003BAD8C /* JSErrorControllerTests.m in Sources */,
+				F8CF3ABF3051955E003E48CA /* SessionReplayHarvestEndToEndTests.swift in Sources */,
 				F85ABB642F155B6E0098A2CF /* IDGenerator.swift in Sources */,
 				F8BF14A52F3668D500EF5628 /* TextHelper.swift in Sources */,
 				0209AC9B24E7393300E45C90 /* NRCPUVitalsTest.m in Sources */,

--- a/Agent/Instrumentation/WKWebView/NRMAWKWebViewInstrumentation.m
+++ b/Agent/Instrumentation/WKWebView/NRMAWKWebViewInstrumentation.m
@@ -105,6 +105,10 @@ void (*NRMA__WKWebView_dealloc)(id self, SEL _cmd);
         SEL setNavigationDelegateSelector = @selector(setNavigationDelegate:);
         method_setImplementation(class_getInstanceMethod(clazz, setNavigationDelegateSelector), (IMP)NRMA__WKWebView_setNavigationDelegate);
 
+        SEL deallocSelector = @selector(dealloc);
+        if (NRMA__WKWebView_dealloc) {
+            method_setImplementation(class_getInstanceMethod(clazz, deallocSelector), (IMP)NRMA__WKWebView_dealloc);
+        }
     }
 #endif
 }

--- a/Agent/Instrumentation/WKWebView/NRMAWebViewSupportability.h
+++ b/Agent/Instrumentation/WKWebView/NRMAWebViewSupportability.h
@@ -8,9 +8,12 @@
 
 #import <Foundation/Foundation.h>
 
+@class WKWebView;
+
 @interface NRMAWebViewSupportability : NSObject
 
 + (void)recordPageFinished;
++ (void)startBrowserAgentDetection:(WKWebView *)webView;
 
 @end
 

--- a/Agent/Instrumentation/WKWebView/NRMAWebViewSupportability.m
+++ b/Agent/Instrumentation/WKWebView/NRMAWebViewSupportability.m
@@ -53,9 +53,14 @@ static BOOL sNRMABrowserAgentDetected = NO;
 
 + (void)recordBrowserAgentDetected {
     sNRMABrowserAgentDetected = YES;
-    static dispatch_once_t token;
-    [self recordWebViewSupportMetric:kNRMAWebViewBrowserAgentDetectedMetric withToken:&token];
+    [NRMAMeasurements recordAndScopeMetricNamed:kNRMAWebViewBrowserAgentDetectedMetric value:@1];
 }
+
+#ifdef DEBUG
++ (void)resetBrowserAgentDetectionForTesting {
+    sNRMABrowserAgentDetected = NO;
+}
+#endif
 
 + (void)recordWebViewSupportMetric:(NSString *)name withToken:(dispatch_once_t *)token {
     dispatch_once(token, ^{

--- a/Agent/Instrumentation/WKWebView/NRMAWebViewSupportability.m
+++ b/Agent/Instrumentation/WKWebView/NRMAWebViewSupportability.m
@@ -9,12 +9,52 @@
 #import "NRMAWebViewSupportability.h"
 #import "NRMAMeasurements.h"
 #import "NRConstants.h"
+#import <WebKit/WebKit.h>
+
+static const NSInteger kNRMABrowserAgentMaxAttempts = 8;
+static const NSTimeInterval kNRMABrowserAgentPollInterval = 0.250;
+static BOOL sNRMABrowserAgentDetected = NO;
 
 @implementation NRMAWebViewSupportability
 
 + (void)recordPageFinished {
     static dispatch_once_t token;
     [self recordWebViewSupportMetric:kNRSupportabilityPrefix@"/WebView/LoadUrl" withToken:&token];
+}
+
++ (void)startBrowserAgentDetection:(WKWebView *)webView {
+    if (sNRMABrowserAgentDetected) {
+        return;
+    }
+    [self pollForBrowserAgent:webView attempts:0];
+}
+
++ (void)pollForBrowserAgent:(WKWebView *)webView attempts:(NSInteger)attempts {
+    if (webView == nil || attempts >= kNRMABrowserAgentMaxAttempts) {
+        return;
+    }
+
+    __weak WKWebView *weakWebView = webView;
+    [webView evaluateJavaScript:@"typeof window.newrelic !== 'undefined'"
+              completionHandler:^(id result, NSError *error) {
+        if (error != nil || weakWebView == nil) {
+            return;
+        }
+        if ([result boolValue]) {
+            [self recordBrowserAgentDetected];
+        } else {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kNRMABrowserAgentPollInterval * NSEC_PER_SEC)),
+                           dispatch_get_main_queue(), ^{
+                [self pollForBrowserAgent:weakWebView attempts:attempts + 1];
+            });
+        }
+    }];
+}
+
++ (void)recordBrowserAgentDetected {
+    sNRMABrowserAgentDetected = YES;
+    static dispatch_once_t token;
+    [self recordWebViewSupportMetric:kNRMAWebViewBrowserAgentDetectedMetric withToken:&token];
 }
 
 + (void)recordWebViewSupportMetric:(NSString *)name withToken:(dispatch_once_t *)token {

--- a/Agent/Instrumentation/WKWebView/NRMAWebViewSupportability.m
+++ b/Agent/Instrumentation/WKWebView/NRMAWebViewSupportability.m
@@ -13,7 +13,6 @@
 
 static const NSInteger kNRMABrowserAgentMaxAttempts = 8;
 static const NSTimeInterval kNRMABrowserAgentPollInterval = 0.250;
-static BOOL sNRMABrowserAgentDetected = NO;
 
 @implementation NRMAWebViewSupportability
 
@@ -23,9 +22,6 @@ static BOOL sNRMABrowserAgentDetected = NO;
 }
 
 + (void)startBrowserAgentDetection:(WKWebView *)webView {
-    if (sNRMABrowserAgentDetected) {
-        return;
-    }
     [self pollForBrowserAgent:webView attempts:0];
 }
 
@@ -41,7 +37,7 @@ static BOOL sNRMABrowserAgentDetected = NO;
             return;
         }
         if ([result boolValue]) {
-            [self recordBrowserAgentDetected];
+            [NRMAMeasurements recordAndScopeMetricNamed:kNRMAWebViewBrowserAgentDetectedMetric value:@1];
         } else {
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kNRMABrowserAgentPollInterval * NSEC_PER_SEC)),
                            dispatch_get_main_queue(), ^{
@@ -50,17 +46,6 @@ static BOOL sNRMABrowserAgentDetected = NO;
         }
     }];
 }
-
-+ (void)recordBrowserAgentDetected {
-    sNRMABrowserAgentDetected = YES;
-    [NRMAMeasurements recordAndScopeMetricNamed:kNRMAWebViewBrowserAgentDetectedMetric value:@1];
-}
-
-#ifdef DEBUG
-+ (void)resetBrowserAgentDetectionForTesting {
-    sNRMABrowserAgentDetected = NO;
-}
-#endif
 
 + (void)recordWebViewSupportMetric:(NSString *)name withToken:(dispatch_once_t *)token {
     dispatch_once(token, ^{

--- a/Agent/Instrumentation/WKWebView/NRMAWebViewSupportability.m
+++ b/Agent/Instrumentation/WKWebView/NRMAWebViewSupportability.m
@@ -13,6 +13,8 @@
 
 static const NSInteger kNRMABrowserAgentMaxAttempts = 8;
 static const NSTimeInterval kNRMABrowserAgentPollInterval = 0.250;
+// Incremented by resetPollCycleForTesting to invalidate in-flight retries from previous cycles.
+static NSUInteger sNRMABrowserAgentPollCycle = 0;
 
 @implementation NRMAWebViewSupportability
 
@@ -22,10 +24,10 @@ static const NSTimeInterval kNRMABrowserAgentPollInterval = 0.250;
 }
 
 + (void)startBrowserAgentDetection:(WKWebView *)webView {
-    [self pollForBrowserAgent:webView attempts:0];
+    [self pollForBrowserAgent:webView attempts:0 cycle:sNRMABrowserAgentPollCycle];
 }
 
-+ (void)pollForBrowserAgent:(WKWebView *)webView attempts:(NSInteger)attempts {
++ (void)pollForBrowserAgent:(WKWebView *)webView attempts:(NSInteger)attempts cycle:(NSUInteger)cycle {
     if (webView == nil || attempts >= kNRMABrowserAgentMaxAttempts) {
         return;
     }
@@ -33,7 +35,7 @@ static const NSTimeInterval kNRMABrowserAgentPollInterval = 0.250;
     __weak WKWebView *weakWebView = webView;
     [webView evaluateJavaScript:@"typeof window.newrelic !== 'undefined'"
               completionHandler:^(id result, NSError *error) {
-        if (error != nil || weakWebView == nil) {
+        if (error != nil || weakWebView == nil || cycle != sNRMABrowserAgentPollCycle) {
             return;
         }
         if ([result boolValue]) {
@@ -41,11 +43,17 @@ static const NSTimeInterval kNRMABrowserAgentPollInterval = 0.250;
         } else {
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kNRMABrowserAgentPollInterval * NSEC_PER_SEC)),
                            dispatch_get_main_queue(), ^{
-                [self pollForBrowserAgent:weakWebView attempts:attempts + 1];
+                [self pollForBrowserAgent:weakWebView attempts:attempts + 1 cycle:cycle];
             });
         }
     }];
 }
+
+#ifdef DEBUG
++ (void)resetPollCycleForTesting {
+    sNRMABrowserAgentPollCycle++;
+}
+#endif
 
 + (void)recordWebViewSupportMetric:(NSString *)name withToken:(dispatch_once_t *)token {
     dispatch_once(token, ^{

--- a/Agent/Instrumentation/WKWebView/NRMAWebViewSupportability.m
+++ b/Agent/Instrumentation/WKWebView/NRMAWebViewSupportability.m
@@ -13,8 +13,6 @@
 
 static const NSInteger kNRMABrowserAgentMaxAttempts = 8;
 static const NSTimeInterval kNRMABrowserAgentPollInterval = 0.250;
-// Incremented by resetPollCycleForTesting to invalidate in-flight retries from previous cycles.
-static NSUInteger sNRMABrowserAgentPollCycle = 0;
 
 @implementation NRMAWebViewSupportability
 
@@ -24,10 +22,10 @@ static NSUInteger sNRMABrowserAgentPollCycle = 0;
 }
 
 + (void)startBrowserAgentDetection:(WKWebView *)webView {
-    [self pollForBrowserAgent:webView attempts:0 cycle:sNRMABrowserAgentPollCycle];
+    [self pollForBrowserAgent:webView attempts:0];
 }
 
-+ (void)pollForBrowserAgent:(WKWebView *)webView attempts:(NSInteger)attempts cycle:(NSUInteger)cycle {
++ (void)pollForBrowserAgent:(WKWebView *)webView attempts:(NSInteger)attempts {
     if (webView == nil || attempts >= kNRMABrowserAgentMaxAttempts) {
         return;
     }
@@ -35,7 +33,7 @@ static NSUInteger sNRMABrowserAgentPollCycle = 0;
     __weak WKWebView *weakWebView = webView;
     [webView evaluateJavaScript:@"typeof window.newrelic !== 'undefined'"
               completionHandler:^(id result, NSError *error) {
-        if (error != nil || weakWebView == nil || cycle != sNRMABrowserAgentPollCycle) {
+        if (error != nil || weakWebView == nil) {
             return;
         }
         if ([result boolValue]) {
@@ -43,17 +41,11 @@ static NSUInteger sNRMABrowserAgentPollCycle = 0;
         } else {
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kNRMABrowserAgentPollInterval * NSEC_PER_SEC)),
                            dispatch_get_main_queue(), ^{
-                [self pollForBrowserAgent:weakWebView attempts:attempts + 1 cycle:cycle];
+                [self pollForBrowserAgent:weakWebView attempts:attempts + 1];
             });
         }
     }];
 }
-
-#ifdef DEBUG
-+ (void)resetPollCycleForTesting {
-    sNRMABrowserAgentPollCycle++;
-}
-#endif
 
 + (void)recordWebViewSupportMetric:(NSString *)name withToken:(dispatch_once_t *)token {
     dispatch_once(token, ^{

--- a/Agent/Instrumentation/WKWebView/NRWKNavigationDelegateBase.m
+++ b/Agent/Instrumentation/WKWebView/NRWKNavigationDelegateBase.m
@@ -62,6 +62,7 @@ didFinishNavigation:(WKNavigation*)navigation
 {
     // send support metric if this is hit once
     [NRMAWebViewSupportability recordPageFinished];
+    [NRMAWebViewSupportability startBrowserAgentDetection:webView];
     
     //record network details
 

--- a/Agent/Public/NRConstants.h
+++ b/Agent/Public/NRConstants.h
@@ -136,6 +136,8 @@ typedef NSString NRMetricUnit;
 // KMP Detection (Kotlin Multiplatform)
 #define kNRMAKMMDetectionMetric @"Supportability/Mobile/iOS/HybridPlatform/KMP"
 
+#define kNRMAWebViewBrowserAgentDetectedMetric @"Supportability/Mobile/iOS/WebView/BrowserAgentDetected"
+
 #define kNRMABytesOutConnectAPIString     @"/connect/Output/Bytes"
 #define kNRMABytesOutDataAPIString        @"/data/Output/Bytes"
 #define kNRMABytesOutFAPIString           @"/f/Output/Bytes"

--- a/Test Harness/NRTestApp/NRTestApp/Helpers/RandomWalkController.swift
+++ b/Test Harness/NRTestApp/NRTestApp/Helpers/RandomWalkController.swift
@@ -102,6 +102,7 @@ final class RandomWalkController {
             { coordinator.showSwiftUITestView() },
             { coordinator.showSwiftUIViewRepresentableTestView() },
             { coordinator.showMapViewController() },
+            { coordinator.showWebViewController() },
             { coordinator.showCaptureViewer() },
         ]
 

--- a/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Analytics-Tests/NRMASAMTest.mm
@@ -39,8 +39,18 @@
 }
 
 - (void) tearDown {
-    [super tearDown];
     [manager removeAllSessionAttributes];
+
+    // PersistentEventStore debounces disk writes (minimum delay of .025s). Give
+    // the pending writes triggered by -removeAllSessionAttributes time to settle
+    // before the next test's -setUp deletes the backing files, otherwise a
+    // straggling async write can recreate a file the next test also uses.
+    NSDate *settleDeadline = [NSDate dateWithTimeIntervalSinceNow:0.1];
+    while ([NSDate.date compare:settleDeadline] == NSOrderedAscending) {
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    }
+
+    [super tearDown];
 }
 
 - (NRMASAM*) samTest {

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
@@ -399,6 +399,7 @@
 - (void)setUp {
     [super setUp];
     [NRMAWebViewSupportability resetBrowserAgentDetectionForTesting];
+    [NRMATaskQueue clear];
     self.helper = [[NRMAMeasurementConsumerHelper alloc] initWithType:NRMAMT_NamedValue];
     [NRMAMeasurements initializeMeasurements];
     [NRMAMeasurements addMeasurementConsumer:self.helper];

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
@@ -396,6 +396,20 @@
 
 @implementation NRMAWebViewBrowserAgentDetectionTests
 
++ (void)setUp {
+    [super setUp];
+    // The first WKWebView created in a process must launch a separate WebContent
+    // process, which can take longer than an individual test's load timeout on a
+    // busy CI runner. Warm that process up once for the whole test class so the
+    // per-test timeouts below only need to cover normal (already-warm) load time.
+    WKWebView *warmupWebView = [[WKWebView alloc] init];
+    [warmupWebView loadHTMLString:@"<html><body></body></html>" baseURL:nil];
+    NSDate *warmupDeadline = [NSDate dateWithTimeIntervalSinceNow:30.0];
+    while (warmupWebView.isLoading && [NSDate.date compare:warmupDeadline] == NSOrderedAscending) {
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+    }
+}
+
 - (void)setUp {
     [super setUp];
     [NRMAWebViewSupportability resetBrowserAgentDetectionForTesting];

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
@@ -460,7 +460,7 @@
     WKWebView *webView = [[WKWebView alloc] init];
     [webView loadHTMLString:@"<html><body></body></html>" baseURL:nil];
 
-    NSDate *loadDeadline = [NSDate dateWithTimeIntervalSinceNow:3.0];
+    NSDate *loadDeadline = [NSDate dateWithTimeIntervalSinceNow:5.0];
     while (webView.isLoading && [NSDate.date compare:loadDeadline] == NSOrderedAscending) {
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
     }

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
@@ -16,6 +16,9 @@
 #import "NRMeasurementConsumerHelper.h"
 #import "NRMAMeasurements.h"
 #import "NRMAHTTPTransactionMeasurement.h"
+#import "NRMAWebViewSupportability.h"
+#import "NRMANamedValueMeasurement.h"
+#import "NRConstants.h"
 
 @interface NRMATaskQueue (tests)
 + (void) clear;
@@ -375,6 +378,105 @@
 
 - (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView {
     self.didTerminateCalled = YES;
+}
+
+@end
+
+// ---------------------------------------------------------------------------
+#pragma mark - NRMAWebViewBrowserAgentDetectionTests
+
+@interface NRMAWebViewSupportability (Testing)
++ (void)resetBrowserAgentDetectionForTesting;
++ (void)recordBrowserAgentDetected;
+@end
+
+@interface NRMAWebViewBrowserAgentDetectionTests : XCTestCase
+@property (strong) NRMAMeasurementConsumerHelper *helper;
+@end
+
+@implementation NRMAWebViewBrowserAgentDetectionTests
+
+- (void)setUp {
+    [super setUp];
+    [NRMAWebViewSupportability resetBrowserAgentDetectionForTesting];
+    self.helper = [[NRMAMeasurementConsumerHelper alloc] initWithType:NRMAMT_NamedValue];
+    [NRMAMeasurements initializeMeasurements];
+    [NRMAMeasurements addMeasurementConsumer:self.helper];
+}
+
+- (void)tearDown {
+    [NRMAMeasurements removeMeasurementConsumer:self.helper];
+    self.helper = nil;
+    [NRMAMeasurements shutdown];
+    [NRMAWebViewSupportability resetBrowserAgentDetectionForTesting];
+    [super tearDown];
+}
+
+- (void)testBrowserAgentDetectedRecordsCorrectMetricName {
+    [NRMAWebViewSupportability recordBrowserAgentDetected];
+    [NRMATaskQueue synchronousDequeue];
+
+    XCTAssertTrue([self.helper.result isKindOfClass:[NRMANamedValueMeasurement class]]);
+    NRMANamedValueMeasurement *m = (NRMANamedValueMeasurement *)self.helper.result;
+    XCTAssertEqualObjects(m.name, kNRMAWebViewBrowserAgentDetectedMetric);
+}
+
+- (void)testStartBrowserAgentDetectionShortCircuitsWhenAlreadyDetected {
+    [NRMAWebViewSupportability recordBrowserAgentDetected];
+    [NRMATaskQueue synchronousDequeue];
+    NSUInteger countAfterFirstDetection = self.helper.consumedMeasurements.count;
+
+    WKWebView *webView = [[WKWebView alloc] init];
+    [NRMAWebViewSupportability startBrowserAgentDetection:webView];
+    [NRMATaskQueue synchronousDequeue];
+
+    XCTAssertEqual(self.helper.consumedMeasurements.count, countAfterFirstDetection);
+}
+
+- (void)testDetectionRecordsMetricWhenBrowserAgentPresent {
+    WKWebView *webView = [[WKWebView alloc] init];
+    [webView loadHTMLString:@"<script>window.newrelic = {}</script>" baseURL:nil];
+
+    NSDate *loadDeadline = [NSDate dateWithTimeIntervalSinceNow:5.0];
+    while (webView.isLoading && [NSDate.date compare:loadDeadline] == NSOrderedAscending) {
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+    }
+    XCTAssertFalse(webView.isLoading, @"WebView timed out while loading");
+
+    [NRMAWebViewSupportability startBrowserAgentDetection:webView];
+
+    NSDate *detectDeadline = [NSDate dateWithTimeIntervalSinceNow:5.0];
+    while (!self.helper.result && [NSDate.date compare:detectDeadline] == NSOrderedAscending) {
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+        [NRMATaskQueue synchronousDequeue];
+    }
+
+    XCTAssertTrue([self.helper.result isKindOfClass:[NRMANamedValueMeasurement class]]);
+    NRMANamedValueMeasurement *m = (NRMANamedValueMeasurement *)self.helper.result;
+    XCTAssertEqualObjects(m.name, kNRMAWebViewBrowserAgentDetectedMetric);
+}
+
+- (void)testDetectionDoesNotRecordMetricWhenBrowserAgentAbsent {
+    WKWebView *webView = [[WKWebView alloc] init];
+    [webView loadHTMLString:@"<html><body></body></html>" baseURL:nil];
+
+    NSDate *loadDeadline = [NSDate dateWithTimeIntervalSinceNow:3.0];
+    while (webView.isLoading && [NSDate.date compare:loadDeadline] == NSOrderedAscending) {
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+    }
+    XCTAssertFalse(webView.isLoading, @"WebView timed out while loading");
+
+    [NRMAWebViewSupportability startBrowserAgentDetection:webView];
+
+    // Spin the run loop for longer than the full polling window (8 attempts × 250ms = 2s).
+    // We must wait the full duration — there is no early-exit signal for "not detected".
+    NSDate *pollDeadline = [NSDate dateWithTimeIntervalSinceNow:2.5];
+    while ([NSDate.date compare:pollDeadline] == NSOrderedAscending) {
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+        [NRMATaskQueue synchronousDequeue];
+    }
+
+    XCTAssertNil(self.helper.result, @"No metric should be recorded when browser agent is absent");
 }
 
 @end

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
@@ -396,20 +396,6 @@
 
 @implementation NRMAWebViewBrowserAgentDetectionTests
 
-+ (void)setUp {
-    [super setUp];
-    // The first WKWebView created in a process must launch a separate WebContent
-    // process, which can take longer than an individual test's load timeout on a
-    // busy CI runner. Warm that process up once for the whole test class so the
-    // per-test timeouts below only need to cover normal (already-warm) load time.
-    WKWebView *warmupWebView = [[WKWebView alloc] init];
-    [warmupWebView loadHTMLString:@"<html><body></body></html>" baseURL:nil];
-    NSDate *warmupDeadline = [NSDate dateWithTimeIntervalSinceNow:30.0];
-    while (warmupWebView.isLoading && [NSDate.date compare:warmupDeadline] == NSOrderedAscending) {
-        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
-    }
-}
-
 - (void)setUp {
     [super setUp];
     [NRMAWebViewSupportability resetBrowserAgentDetectionForTesting];

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
@@ -385,6 +385,10 @@
 // ---------------------------------------------------------------------------
 #pragma mark - NRMAWebViewBrowserAgentDetectionTests
 
+@interface NRMAWebViewSupportability (Testing)
++ (void)resetPollCycleForTesting;
+@end
+
 @interface NRMAWebViewBrowserAgentDetectionTests : XCTestCase
 @property (strong) NRMAMeasurementConsumerHelper *helper;
 @end
@@ -393,6 +397,11 @@
 
 - (void)setUp {
     [super setUp];
+    // Invalidate any in-flight dispatch_after retries from previous test classes
+    // (e.g. NRMAWKNavigationDelegateBaseTest fires didFinishNavigation: which starts
+    // detection polling; those zombie retries would otherwise fire during our run-loop
+    // spins and record a metric into this test's consumer).
+    [NRMAWebViewSupportability resetPollCycleForTesting];
     [NRMATaskQueue clear];
     self.helper = [[NRMAMeasurementConsumerHelper alloc] initWithType:NRMAMT_NamedValue];
     [NRMAMeasurements initializeMeasurements];

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
@@ -385,10 +385,6 @@
 // ---------------------------------------------------------------------------
 #pragma mark - NRMAWebViewBrowserAgentDetectionTests
 
-@interface NRMAWebViewSupportability (Testing)
-+ (void)resetPollCycleForTesting;
-@end
-
 @interface NRMAWebViewBrowserAgentDetectionTests : XCTestCase
 @property (strong) NRMAMeasurementConsumerHelper *helper;
 @end
@@ -397,11 +393,6 @@
 
 - (void)setUp {
     [super setUp];
-    // Invalidate any in-flight dispatch_after retries from previous test classes
-    // (e.g. NRMAWKNavigationDelegateBaseTest fires didFinishNavigation: which starts
-    // detection polling; those zombie retries would otherwise fire during our run-loop
-    // spins and record a metric into this test's consumer).
-    [NRMAWebViewSupportability resetPollCycleForTesting];
     [NRMATaskQueue clear];
     self.helper = [[NRMAMeasurementConsumerHelper alloc] initWithType:NRMAMT_NamedValue];
     [NRMAMeasurements initializeMeasurements];

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
@@ -385,11 +385,6 @@
 // ---------------------------------------------------------------------------
 #pragma mark - NRMAWebViewBrowserAgentDetectionTests
 
-@interface NRMAWebViewSupportability (Testing)
-+ (void)resetBrowserAgentDetectionForTesting;
-+ (void)recordBrowserAgentDetected;
-@end
-
 @interface NRMAWebViewBrowserAgentDetectionTests : XCTestCase
 @property (strong) NRMAMeasurementConsumerHelper *helper;
 @end
@@ -398,7 +393,6 @@
 
 - (void)setUp {
     [super setUp];
-    [NRMAWebViewSupportability resetBrowserAgentDetectionForTesting];
     [NRMATaskQueue clear];
     self.helper = [[NRMAMeasurementConsumerHelper alloc] initWithType:NRMAMT_NamedValue];
     [NRMAMeasurements initializeMeasurements];
@@ -409,29 +403,7 @@
     [NRMAMeasurements removeMeasurementConsumer:self.helper];
     self.helper = nil;
     [NRMAMeasurements shutdown];
-    [NRMAWebViewSupportability resetBrowserAgentDetectionForTesting];
     [super tearDown];
-}
-
-- (void)testBrowserAgentDetectedRecordsCorrectMetricName {
-    [NRMAWebViewSupportability recordBrowserAgentDetected];
-    [NRMATaskQueue synchronousDequeue];
-
-    XCTAssertTrue([self.helper.result isKindOfClass:[NRMANamedValueMeasurement class]]);
-    NRMANamedValueMeasurement *m = (NRMANamedValueMeasurement *)self.helper.result;
-    XCTAssertEqualObjects(m.name, kNRMAWebViewBrowserAgentDetectedMetric);
-}
-
-- (void)testStartBrowserAgentDetectionShortCircuitsWhenAlreadyDetected {
-    [NRMAWebViewSupportability recordBrowserAgentDetected];
-    [NRMATaskQueue synchronousDequeue];
-    NSUInteger countAfterFirstDetection = self.helper.consumedMeasurements.count;
-
-    WKWebView *webView = [[WKWebView alloc] init];
-    [NRMAWebViewSupportability startBrowserAgentDetection:webView];
-    [NRMATaskQueue synchronousDequeue];
-
-    XCTAssertEqual(self.helper.consumedMeasurements.count, countAfterFirstDetection);
 }
 
 - (void)testDetectionRecordsMetricWhenBrowserAgentPresent {
@@ -478,6 +450,23 @@
     }
 
     XCTAssertNil(self.helper.result, @"No metric should be recorded when browser agent is absent");
+}
+
+- (void)testDetectionDoesNotRetainWebView {
+    __weak WKWebView *weakRef = nil;
+
+    @autoreleasepool {
+        WKWebView *webView = [[WKWebView alloc] init];
+        weakRef = webView;
+        [NRMAWebViewSupportability startBrowserAgentDetection:webView];
+        // webView's only strong owner goes out of scope here
+    }
+
+    // Spin the run loop to let any in-flight dispatch_after blocks fire and release.
+    // The blocks capture weakWebView weakly, so they cannot keep the WKWebView alive.
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.3]];
+
+    XCTAssertNil(weakRef, @"Detection polling must not hold a strong reference to WKWebView");
 }
 
 @end

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
@@ -427,15 +427,23 @@
 
     [NRMAWebViewSupportability startBrowserAgentDetection:webView];
 
+    // Poll until the specific browser agent metric arrives (ignore other NRMANamedValueMeasurements
+    // such as memory/CPU produced by NRMANamedValueProducer while the run loop spins).
     NSDate *detectDeadline = [NSDate dateWithTimeIntervalSinceNow:5.0];
-    while (!self.helper.result && [NSDate.date compare:detectDeadline] == NSOrderedAscending) {
+    NRMANamedValueMeasurement *found = nil;
+    while (!found && [NSDate.date compare:detectDeadline] == NSOrderedAscending) {
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
         [NRMATaskQueue synchronousDequeue];
+        for (NRMANamedValueMeasurement *m in self.helper.consumedMeasurements) {
+            if ([m.name isEqualToString:kNRMAWebViewBrowserAgentDetectedMetric]) {
+                found = m;
+                break;
+            }
+        }
     }
 
-    XCTAssertTrue([self.helper.result isKindOfClass:[NRMANamedValueMeasurement class]]);
-    NRMANamedValueMeasurement *m = (NRMANamedValueMeasurement *)self.helper.result;
-    XCTAssertEqualObjects(m.name, kNRMAWebViewBrowserAgentDetectedMetric);
+    XCTAssertNotNil(found, @"Browser agent detection metric should be recorded");
+    XCTAssertEqualObjects(found.name, kNRMAWebViewBrowserAgentDetectedMetric);
 }
 
 - (void)testDetectionDoesNotRecordMetricWhenBrowserAgentAbsent {
@@ -458,7 +466,18 @@
         [NRMATaskQueue synchronousDequeue];
     }
 
-    XCTAssertNil(self.helper.result, @"No metric should be recorded when browser agent is absent");
+    // Check specifically that the browser agent metric was NOT recorded.
+    // Other NRMANamedValueMeasurements (e.g. memory/CPU from NRMANamedValueProducer)
+    // may have been delivered to the consumer during the wait and must not be confused
+    // with the browser agent detection metric.
+    BOOL browserAgentMetricRecorded = NO;
+    for (NRMANamedValueMeasurement *m in self.helper.consumedMeasurements) {
+        if ([m.name isEqualToString:kNRMAWebViewBrowserAgentDetectedMetric]) {
+            browserAgentMetricRecorded = YES;
+            break;
+        }
+    }
+    XCTAssertFalse(browserAgentMetricRecorded, @"Browser agent detection metric should not be recorded when browser agent is absent");
 }
 
 - (void)testDetectionDoesNotRetainWebView {

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/NRMAWKNavigationDelegateBaseTest.m
@@ -447,29 +447,22 @@
 }
 
 - (void)testDetectionDoesNotRecordMetricWhenBrowserAgentAbsent {
+    // Use an unloaded WKWebView — it has no JavaScript context that could define
+    // window.newrelic, eliminating the unreliable page-load wait and any chance of
+    // picking up injected scripts.  evaluateJavaScript: on an unloaded WebView either
+    // errors immediately (our handler returns early) or evaluates to false; neither
+    // path records the metric.
     WKWebView *webView = [[WKWebView alloc] init];
-    [webView loadHTMLString:@"<html><body></body></html>" baseURL:nil];
-
-    NSDate *loadDeadline = [NSDate dateWithTimeIntervalSinceNow:5.0];
-    while (webView.isLoading && [NSDate.date compare:loadDeadline] == NSOrderedAscending) {
-        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
-    }
-    XCTAssertFalse(webView.isLoading, @"WebView timed out while loading");
 
     [NRMAWebViewSupportability startBrowserAgentDetection:webView];
 
-    // Spin the run loop for longer than the full polling window (8 attempts × 250ms = 2s).
-    // We must wait the full duration — there is no early-exit signal for "not detected".
+    // Spin long enough for all 8 polling attempts to exhaust (8 × 250 ms = 2 s).
     NSDate *pollDeadline = [NSDate dateWithTimeIntervalSinceNow:2.5];
     while ([NSDate.date compare:pollDeadline] == NSOrderedAscending) {
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
         [NRMATaskQueue synchronousDequeue];
     }
 
-    // Check specifically that the browser agent metric was NOT recorded.
-    // Other NRMANamedValueMeasurements (e.g. memory/CPU from NRMANamedValueProducer)
-    // may have been delivered to the consumer during the wait and must not be confused
-    // with the browser agent detection metric.
     BOOL browserAgentMetricRecorded = NO;
     for (NRMANamedValueMeasurement *m in self.helper.consumedMeasurements) {
         if ([m.name isEqualToString:kNRMAWebViewBrowserAgentDetectedMetric]) {

--- a/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/UILabelThingyTests.swift
+++ b/Tests/Unit-Tests/NewRelicAgentTests/Uncategorized/UILabelThingyTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 import UIKit
 
+@MainActor
 struct UILabelThingyTests {
     func makeViewDetails(isMasked: Bool? = nil) -> ViewDetails {
         // Provide a minimal ViewDetails stub for testing


### PR DESCRIPTION
- Adds a Supportability/Mobile/iOS/WebView/BrowserAgentDetected metric that fires when the New Relic browser agent is detected in a WKWebView — mirroring the equivalent metric already shipped in the Android agent (NR-461357-webview-browser-agent-detection).
- After each didFinishNavigation, polls window.newrelic via evaluateJavaScript:completionHandler: up to 8 times at 250 ms intervals (2 s max).
